### PR TITLE
Cross-platform docs & v0.3.0 release sync

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,53 +1,68 @@
-# Filo Quick Start Guide (v0.2.8)
+# Filo Quick Start Guide (v0.3.0)
 
 Welcome to Filo! This guide will get you up and running in 5 minutes.
 
-> ✨ **New in v0.2.8**: CPU architecture detection for executables (ELF, PE, Mach-O)! Instantly identify x86, ARM, RISC-V, Xtensa, and 90+ other architectures.
-> 
-> **Also in v0.2.7**: zsteg-compatible LSB/MSB steganography detection with automatic base64 decoding! Perfect for CTF challenges.
-> 
-> **Also in v0.2.6**: PCAP network analysis for quick flag hunting in packet captures.
+> ✨ **New in v0.3.0**: YARA scanning, Office VBA macro analysis, entropy visualization, strings extraction, CI/CD, Docker, and 22 new format specs!
 
 ## Installation
 
-### Option 1: Easy Install (.deb package) - Recommended
+Filo works on **Linux, macOS, and Windows** (Python 3.10+ required).
+
+### Option 1: pip install (cross-platform) - Recommended
+
+Works on all platforms:
+
+```bash
+pip install filo-forensics
+```
+
+**With optional features:**
+```bash
+pip install filo-forensics[yara]   # YARA scanning support
+pip install filo-forensics[all]    # all optional features
+```
+
+**Benefits:**
+- ✅ Works on Linux, macOS, and Windows
+- ✅ No cloning or building required
+- ✅ Automatic dependency resolution
+- ✅ Works from anywhere (global `filo` command)
+
+### Option 2: Docker (cross-platform)
+
+Works anywhere Docker runs:
+
+```bash
+docker pull ghcr.io/supunhg/filo:latest
+docker run --rm -v $(pwd):/data filo:latest analyze /data/target_file
+```
+
+**Benefits:**
+- ✅ No Python installation needed
+- ✅ Isolated environment
+- ✅ Same experience on all OSes
+
+### Option 3: From Source (development)
+
+```bash
+git clone https://github.com/supunhg/Filo
+cd Filo
+pip install -e .
+```
+
+> **Windows users**: Use `py -m pip install -e .` or `python -m pip install -e .`
+> 
+> **macOS/Linux users**: Use `python3 -m pip install -e .`
+
+### Option 4: .deb package (Linux only)
 
 **For Ubuntu/Debian users:**
 
 ```bash
-# Clone and build
 git clone https://github.com/supunhg/Filo
 cd Filo
 ./build-deb.sh
-
-# Install
-sudo dpkg -i filo-forensics_0.2.8_all.deb
-
-# Verify
-filo --version
-```
-
-**Benefits:**
-- ✅ No manual virtual environment setup
-- ✅ Automatic dependency installation
-- ✅ Works from anywhere (global `filo` command)
-- ✅ Isolated installation (no system conflicts)
-
-### Option 2: From Source
-
-**For development or non-Debian systems:**
-
-```bash
-# Clone the repository
-git clone https://github.com/supunhg/Filo
-cd Filo
-
-# Create virtual environment
-python3 -m venv venv
-source venv/bin/activate
-
-# Install
-pip install -e .
+sudo dpkg -i filo-forensics_0.3.0_all.deb
 ```
 
 ## Basic Usage
@@ -293,8 +308,10 @@ filo analyze challenge
 # Repair it
 filo repair challenge --format=png -o flag.png
 
-# Open it
-xdg-open flag.png  # Shows the flag!
+# Open it (use your OS image viewer)
+open flag.png      # macOS
+xdg-open flag.png  # Linux
+start flag.png     # Windows
 ```
 
 ## Advanced Features

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ Filo transforms unknown binary blobs into classified, repairable, and explainabl
 - 🕵️ **Embedded Detection**: Find files hidden inside files - ZIP in EXE, PNG after EOF (malware hunter candy)
 - 🔧 **Tool Fingerprinting**: Identify how/when/with what tools a file was created (forensic attribution)
 - 🔐 **Crypto Detection** *(NEW v0.3.0)*: Detect encrypted data, identify cipher types (AES-ECB, OpenSSL, PGP), block alignment analysis, entropy interpretation - perfect for CTF challenges
+- 🔍 **YARA Scanning** *(NEW v0.3.0)*: Scan files with custom YARA rules — rule compilation, match parsing, tags and metadata extraction
+- 📄 **Office Macro Analysis** *(NEW v0.3.0)*: Detect VBA macros in OLE2 documents — auto-exec macros, 50+ suspicious keywords
+- 🔤 **Strings Extraction** *(NEW v0.3.0)*: Advanced `filo strings` command with regex, entropy filtering, encoding detection, JSON output
+- 📊 **Entropy Visualization** *(NEW v0.3.0)*: Color-coded entropy map with `--entropy-viz` flag
 - ⚠️ **Polyglot Detection** *(v0.2.5)*: Detect dual-format files (GIFAR, PNG+ZIP, PDF+JS) with risk assessment
 - 🖥️ **CPU Architecture Detection** *(v0.2.8)*: Automatic detection of CPU architecture for executables (90+ architectures: x86, ARM, RISC-V, Xtensa, MIPS, etc.)
 - 🎨 **zsteg-Compatible Steganography** *(v0.2.7)*: 60+ bit plane LSB/MSB extraction (PNG/BMP), auto base64 decoding, file type detection, CTF-optimized
@@ -37,22 +41,36 @@ Filo transforms unknown binary blobs into classified, repairable, and explainabl
 
 ## Quick Start
 
-**Option 1: Easy Install (.deb package)**
+**Option 1: pip install (Linux / macOS / Windows)**
 ```bash
-# Clone and build
-git clone https://github.com/supunhg/Filo
-cd Filo
-./build-deb.sh
+pip install filo-forensics
 
-# Install
-sudo dpkg -i filo-forensics_0.3.0_all.deb
+# With optional YARA support
+pip install filo-forensics[yara]
+
+# All optional features
+pip install filo-forensics[all]
 ```
 
-**Option 2: From Source**
+**Option 2: Docker (any platform)**
+```bash
+docker pull ghcr.io/supunhg/filo:latest
+docker run --rm -v $(pwd):/data filo:latest analyze /data/target_file
+```
+
+**Option 3: From Source (development)**
 ```bash
 git clone https://github.com/supunhg/Filo
 cd Filo
 pip install -e .
+```
+
+**Option 4: .deb package (Linux only)**
+```bash
+git clone https://github.com/supunhg/Filo
+cd Filo
+./build-deb.sh
+sudo dpkg -i filo-forensics_0.3.0_all.deb
 ```
 
 **Usage:**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ warn_unused_configs = true
 [tool.ruff]
 line-length = 100
 target-version = "py312"
+exclude = ["examples/", "demo/"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/test_office.py
+++ b/tests/test_office.py
@@ -1,6 +1,5 @@
-import pytest
 import struct
-from filo.office import analyze_office_file, OfficeAnalysisResult, OLE2_MAGIC, SUSPICIOUS_KEYWORDS, AUTO_EXEC_PATTERNS
+from filo.office import analyze_office_file, OLE2_MAGIC, SUSPICIOUS_KEYWORDS, AUTO_EXEC_PATTERNS
 
 
 def make_ole2_header(sector_shift: int = 9) -> bytes:

--- a/tests/test_polyglot.py
+++ b/tests/test_polyglot.py
@@ -1,7 +1,6 @@
 """
 Tests for polyglot detection - files valid as multiple formats simultaneously.
 """
-import pytest
 import struct
 import zlib
 from filo.polyglot import PolyglotDetector
@@ -132,7 +131,7 @@ class TestPolyglotDetection:
         png_data.extend(b"IEND")
         png_data.extend(struct.pack(">I", iend_crc))
         
-        zip_offset = len(png_data)
+        _zip_offset = len(png_data)
         png_data.extend(b"PK\x03\x04")
         png_data.extend(b'\x00' * 26)
         png_data.extend(b"PK\x05\x06")

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -2,8 +2,6 @@
 
 import time
 
-import pytest
-
 from filo.profiler import Profiler, profile_session, profile_analysis
 
 

--- a/tests/test_strings.py
+++ b/tests/test_strings.py
@@ -1,4 +1,3 @@
-import pytest
 from filo.cli import _extract_strings, _string_entropy, _detect_encoding
 
 


### PR DESCRIPTION
Brings main up to date with dev after v0.3.0 release:

- Cross-platform installation docs (pip-first, Docker, Windows/macOS)
- Lint fixes (ruff config, unused imports/variables)
- Previous v0.3.0 features already merged via PR #6

This is a documentation + cleanup sync — no functional changes beyond what was already tagged as v0.3.0.