### PR TITLE
Fix 3 embedded detector test failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv pip install --system ".[dev]"
+          uv pip install --system ".[dev,yara]"
 
       - name: Lint with ruff
         run: ruff check --output-format=github .
@@ -73,7 +73,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv pip install --system ".[dev]"
+          uv pip install --system ".[dev,yara]"
 
       - name: Run tests with coverage
         run: pytest --cov=filo --cov-report=xml --cov-report=term-missing

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv pip install --system ".[dev]"
+          uv pip install --system ".[dev,yara]"
 
       - name: Lint with ruff
         run: ruff check --output-format=github .

--- a/demo/create_metadata_test_files.py
+++ b/demo/create_metadata_test_files.py
@@ -18,45 +18,45 @@ print(f"Creating test files in {fixtures_dir}")
 def create_minimal_jpeg():
     """Create minimal JPEG with JFIF header"""
     jpeg_data = bytearray()
-    
+
     # SOI marker
-    jpeg_data.extend(b'\xFF\xD8')
-    
+    jpeg_data.extend(b"\xff\xd8")
+
     # APP0 - JFIF
     jfif_data = (
-        b'JFIF\x00'  # Identifier
-        b'\x01\x01'  # Version 1.01
-        b'\x00'  # Density units: none
-        b'\x00\x01'  # X density = 1
-        b'\x00\x01'  # Y density = 1
-        b'\x00\x00'  # Thumbnail size 0x0
+        b"JFIF\x00"  # Identifier
+        b"\x01\x01"  # Version 1.01
+        b"\x00"  # Density units: none
+        b"\x00\x01"  # X density = 1
+        b"\x00\x01"  # Y density = 1
+        b"\x00\x00"  # Thumbnail size 0x0
     )
-    jpeg_data.extend(b'\xFF\xE0')  # APP0 marker
-    jpeg_data.extend(struct.pack('>H', len(jfif_data) + 2))
+    jpeg_data.extend(b"\xff\xe0")  # APP0 marker
+    jpeg_data.extend(struct.pack(">H", len(jfif_data) + 2))
     jpeg_data.extend(jfif_data)
-    
+
     # SOF0 - Start of Frame (Baseline DCT)
     sof_data = bytearray()
     sof_data.append(8)  # Bits per sample
-    sof_data.extend(struct.pack('>H', 100))  # Height
-    sof_data.extend(struct.pack('>H', 100))  # Width
+    sof_data.extend(struct.pack(">H", 100))  # Height
+    sof_data.extend(struct.pack(">H", 100))  # Width
     sof_data.append(3)  # Components
     # Y component
-    sof_data.extend(b'\x01\x22\x00')
+    sof_data.extend(b"\x01\x22\x00")
     # Cb component
-    sof_data.extend(b'\x02\x11\x01')
+    sof_data.extend(b"\x02\x11\x01")
     # Cr component
-    sof_data.extend(b'\x03\x11\x01')
-    
-    jpeg_data.extend(b'\xFF\xC0')  # SOF0 marker
-    jpeg_data.extend(struct.pack('>H', len(sof_data) + 2))
+    sof_data.extend(b"\x03\x11\x01")
+
+    jpeg_data.extend(b"\xff\xc0")  # SOF0 marker
+    jpeg_data.extend(struct.pack(">H", len(sof_data) + 2))
     jpeg_data.extend(sof_data)
-    
+
     # EOI marker
-    jpeg_data.extend(b'\xFF\xD9')
-    
+    jpeg_data.extend(b"\xff\xd9")
+
     output_file = fixtures_dir / "minimal.jpg"
-    with open(output_file, 'wb') as f:
+    with open(output_file, "wb") as f:
         f.write(jpeg_data)
     print(f"  ✓ Created {output_file.name}")
 
@@ -64,33 +64,33 @@ def create_minimal_jpeg():
 def create_jpeg_with_comment():
     """Create JPEG with suspicious base64 comment"""
     jpeg_data = bytearray()
-    
+
     # SOI
-    jpeg_data.extend(b'\xFF\xD8')
-    
+    jpeg_data.extend(b"\xff\xd8")
+
     # APP0 - JFIF
-    jfif_data = b'JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00'
-    jpeg_data.extend(b'\xFF\xE0')
-    jpeg_data.extend(struct.pack('>H', len(jfif_data) + 2))
+    jfif_data = b"JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00"
+    jpeg_data.extend(b"\xff\xe0")
+    jpeg_data.extend(struct.pack(">H", len(jfif_data) + 2))
     jpeg_data.extend(jfif_data)
-    
+
     # COM - Comment with base64
     comment_text = b"steghide:cEF6endvcmQ="  # base64 for "pAzzword"
-    jpeg_data.extend(b'\xFF\xFE')  # COM marker
-    jpeg_data.extend(struct.pack('>H', len(comment_text) + 2))
+    jpeg_data.extend(b"\xff\xfe")  # COM marker
+    jpeg_data.extend(struct.pack(">H", len(comment_text) + 2))
     jpeg_data.extend(comment_text)
-    
+
     # SOF0
-    sof_data = b'\x08\x00\x64\x00\x64\x03\x01\x11\x00\x02\x11\x01\x03\x11\x01'
-    jpeg_data.extend(b'\xFF\xC0')
-    jpeg_data.extend(struct.pack('>H', len(sof_data) + 2))
+    sof_data = b"\x08\x00\x64\x00\x64\x03\x01\x11\x00\x02\x11\x01\x03\x11\x01"
+    jpeg_data.extend(b"\xff\xc0")
+    jpeg_data.extend(struct.pack(">H", len(sof_data) + 2))
     jpeg_data.extend(sof_data)
-    
+
     # EOI
-    jpeg_data.extend(b'\xFF\xD9')
-    
+    jpeg_data.extend(b"\xff\xd9")
+
     output_file = fixtures_dir / "with_comment.jpg"
-    with open(output_file, 'wb') as f:
+    with open(output_file, "wb") as f:
         f.write(jpeg_data)
     print(f"  ✓ Created {output_file.name} (suspicious comment)")
 
@@ -98,54 +98,54 @@ def create_jpeg_with_comment():
 def create_jpeg_with_icc_profile():
     """Create JPEG with ICC profile"""
     jpeg_data = bytearray()
-    
+
     # SOI
-    jpeg_data.extend(b'\xFF\xD8')
-    
+    jpeg_data.extend(b"\xff\xd8")
+
     # APP0 - JFIF
-    jfif_data = b'JFIF\x00\x01\x01\x01\x00\x48\x00\x48\x00\x00'  # 72 DPI
-    jpeg_data.extend(b'\xFF\xE0')
-    jpeg_data.extend(struct.pack('>H', len(jfif_data) + 2))
+    jfif_data = b"JFIF\x00\x01\x01\x01\x00\x48\x00\x48\x00\x00"  # 72 DPI
+    jpeg_data.extend(b"\xff\xe0")
+    jpeg_data.extend(struct.pack(">H", len(jfif_data) + 2))
     jpeg_data.extend(jfif_data)
-    
+
     # APP2 - ICC Profile (minimal)
     icc_data = bytearray()
-    icc_data.extend(b'ICC_PROFILE\x00')  # Identifier
+    icc_data.extend(b"ICC_PROFILE\x00")  # Identifier
     icc_data.append(1)  # Sequence number
     icc_data.append(1)  # Total sequences
-    
+
     # Minimal ICC profile header
     icc_profile = bytearray(128)
     # Profile size (bytes 0-3)
-    struct.pack_into('>I', icc_profile, 0, 128)
+    struct.pack_into(">I", icc_profile, 0, 128)
     # CMM Type (bytes 4-7)
-    icc_profile[4:8] = b'Lino'
+    icc_profile[4:8] = b"Lino"
     # Profile version (bytes 8-11)
-    icc_profile[8:11] = b'\x02\x10\x00'
+    icc_profile[8:11] = b"\x02\x10\x00"
     # Profile class (bytes 12-15)
-    icc_profile[12:16] = b'mntr'
+    icc_profile[12:16] = b"mntr"
     # Color space (bytes 16-19)
-    icc_profile[16:20] = b'RGB '
+    icc_profile[16:20] = b"RGB "
     # PCS (bytes 20-23)
-    icc_profile[20:24] = b'XYZ '
-    
+    icc_profile[20:24] = b"XYZ "
+
     icc_data.extend(icc_profile)
-    
-    jpeg_data.extend(b'\xFF\xE2')  # APP2 marker
-    jpeg_data.extend(struct.pack('>H', len(icc_data) + 2))
+
+    jpeg_data.extend(b"\xff\xe2")  # APP2 marker
+    jpeg_data.extend(struct.pack(">H", len(icc_data) + 2))
     jpeg_data.extend(icc_data)
-    
+
     # SOF0
-    sof_data = b'\x08\x00\xC8\x00\xC8\x03\x01\x22\x00\x02\x11\x01\x03\x11\x01'  # 200x200
-    jpeg_data.extend(b'\xFF\xC0')
-    jpeg_data.extend(struct.pack('>H', len(sof_data) + 2))
+    sof_data = b"\x08\x00\xc8\x00\xc8\x03\x01\x22\x00\x02\x11\x01\x03\x11\x01"  # 200x200
+    jpeg_data.extend(b"\xff\xc0")
+    jpeg_data.extend(struct.pack(">H", len(sof_data) + 2))
     jpeg_data.extend(sof_data)
-    
+
     # EOI
-    jpeg_data.extend(b'\xFF\xD9')
-    
+    jpeg_data.extend(b"\xff\xd9")
+
     output_file = fixtures_dir / "with_icc.jpg"
-    with open(output_file, 'wb') as f:
+    with open(output_file, "wb") as f:
         f.write(jpeg_data)
     print(f"  ✓ Created {output_file.name} (ICC profile)")
 
@@ -153,29 +153,29 @@ def create_jpeg_with_icc_profile():
 def create_png_with_text():
     """Create PNG with tEXt chunk"""
     png_data = bytearray()
-    
+
     # PNG signature
-    png_data.extend(b'\x89PNG\r\n\x1a\n')
-    
+    png_data.extend(b"\x89PNG\r\n\x1a\n")
+
     # IHDR chunk
-    ihdr_data = struct.pack('>IIBBBBB', 150, 150, 8, 6, 0, 0, 0)  # 150x150 RGBA
-    png_data.extend(struct.pack('>I', len(ihdr_data)))
-    png_data.extend(b'IHDR')
+    ihdr_data = struct.pack(">IIBBBBB", 150, 150, 8, 6, 0, 0, 0)  # 150x150 RGBA
+    png_data.extend(struct.pack(">I", len(ihdr_data)))
+    png_data.extend(b"IHDR")
     png_data.extend(ihdr_data)
-    png_data.extend(struct.pack('>I', zlib.crc32(b'IHDR' + ihdr_data)))
-    
+    png_data.extend(struct.pack(">I", zlib.crc32(b"IHDR" + ihdr_data)))
+
     # tEXt chunk with normal comment
-    text_data = b'Comment\x00Created by Filo test suite'
-    png_data.extend(struct.pack('>I', len(text_data)))
-    png_data.extend(b'tEXt')
+    text_data = b"Comment\x00Created by Filo test suite"
+    png_data.extend(struct.pack(">I", len(text_data)))
+    png_data.extend(b"tEXt")
     png_data.extend(text_data)
-    png_data.extend(struct.pack('>I', zlib.crc32(b'tEXt' + text_data)))
-    
+    png_data.extend(struct.pack(">I", zlib.crc32(b"tEXt" + text_data)))
+
     # IEND chunk
-    png_data.extend(b'\x00\x00\x00\x00IEND\xAE\x42\x60\x82')
-    
+    png_data.extend(b"\x00\x00\x00\x00IEND\xae\x42\x60\x82")
+
     output_file = fixtures_dir / "with_text.png"
-    with open(output_file, 'wb') as f:
+    with open(output_file, "wb") as f:
         f.write(png_data)
     print(f"  ✓ Created {output_file.name}")
 
@@ -183,32 +183,32 @@ def create_png_with_text():
 def create_png_with_suspicious_text():
     """Create PNG with suspicious base64 in zTXt"""
     png_data = bytearray()
-    
+
     # PNG signature
-    png_data.extend(b'\x89PNG\r\n\x1a\n')
-    
+    png_data.extend(b"\x89PNG\r\n\x1a\n")
+
     # IHDR chunk
-    ihdr_data = struct.pack('>IIBBBBB', 100, 100, 8, 2, 0, 0, 0)  # 100x100 RGB
-    png_data.extend(struct.pack('>I', len(ihdr_data)))
-    png_data.extend(b'IHDR')
+    ihdr_data = struct.pack(">IIBBBBB", 100, 100, 8, 2, 0, 0, 0)  # 100x100 RGB
+    png_data.extend(struct.pack(">I", len(ihdr_data)))
+    png_data.extend(b"IHDR")
     png_data.extend(ihdr_data)
-    png_data.extend(struct.pack('>I', zlib.crc32(b'IHDR' + ihdr_data)))
-    
+    png_data.extend(struct.pack(">I", zlib.crc32(b"IHDR" + ihdr_data)))
+
     # zTXt chunk with compressed suspicious data
-    keyword = b'Password'
-    compressed_text = zlib.compress(b'c3RlZ2hpZGU6SGlkZGVuUGFzcw==')
-    ztxt_data = keyword + b'\x00\x00' + compressed_text
-    
-    png_data.extend(struct.pack('>I', len(ztxt_data)))
-    png_data.extend(b'zTXt')
+    keyword = b"Password"
+    compressed_text = zlib.compress(b"c3RlZ2hpZGU6SGlkZGVuUGFzcw==")
+    ztxt_data = keyword + b"\x00\x00" + compressed_text
+
+    png_data.extend(struct.pack(">I", len(ztxt_data)))
+    png_data.extend(b"zTXt")
     png_data.extend(ztxt_data)
-    png_data.extend(struct.pack('>I', zlib.crc32(b'zTXt' + ztxt_data)))
-    
+    png_data.extend(struct.pack(">I", zlib.crc32(b"zTXt" + ztxt_data)))
+
     # IEND chunk
-    png_data.extend(b'\x00\x00\x00\x00IEND\xAE\x42\x60\x82')
-    
+    png_data.extend(b"\x00\x00\x00\x00IEND\xae\x42\x60\x82")
+
     output_file = fixtures_dir / "with_suspicious.png"
-    with open(output_file, 'wb') as f:
+    with open(output_file, "wb") as f:
         f.write(png_data)
     print(f"  ✓ Created {output_file.name} (suspicious data)")
 
@@ -216,29 +216,29 @@ def create_png_with_suspicious_text():
 def create_png_with_time():
     """Create PNG with tIME chunk"""
     png_data = bytearray()
-    
+
     # PNG signature
-    png_data.extend(b'\x89PNG\r\n\x1a\n')
-    
+    png_data.extend(b"\x89PNG\r\n\x1a\n")
+
     # IHDR chunk
-    ihdr_data = struct.pack('>IIBBBBB', 80, 80, 8, 0, 0, 0, 0)  # 80x80 grayscale
-    png_data.extend(struct.pack('>I', len(ihdr_data)))
-    png_data.extend(b'IHDR')
+    ihdr_data = struct.pack(">IIBBBBB", 80, 80, 8, 0, 0, 0, 0)  # 80x80 grayscale
+    png_data.extend(struct.pack(">I", len(ihdr_data)))
+    png_data.extend(b"IHDR")
     png_data.extend(ihdr_data)
-    png_data.extend(struct.pack('>I', zlib.crc32(b'IHDR' + ihdr_data)))
-    
+    png_data.extend(struct.pack(">I", zlib.crc32(b"IHDR" + ihdr_data)))
+
     # tIME chunk - 2024-01-15 14:30:45
-    time_data = struct.pack('>H', 2024) + bytes([1, 15, 14, 30, 45])
-    png_data.extend(struct.pack('>I', len(time_data)))
-    png_data.extend(b'tIME')
+    time_data = struct.pack(">H", 2024) + bytes([1, 15, 14, 30, 45])
+    png_data.extend(struct.pack(">I", len(time_data)))
+    png_data.extend(b"tIME")
     png_data.extend(time_data)
-    png_data.extend(struct.pack('>I', zlib.crc32(b'tIME' + time_data)))
-    
+    png_data.extend(struct.pack(">I", zlib.crc32(b"tIME" + time_data)))
+
     # IEND chunk
-    png_data.extend(b'\x00\x00\x00\x00IEND\xAE\x42\x60\x82')
-    
+    png_data.extend(b"\x00\x00\x00\x00IEND\xae\x42\x60\x82")
+
     output_file = fixtures_dir / "with_time.png"
-    with open(output_file, 'wb') as f:
+    with open(output_file, "wb") as f:
         f.write(png_data)
     print(f"  ✓ Created {output_file.name}")
 

--- a/demo/create_polyglot_files.py
+++ b/demo/create_polyglot_files.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Generate polyglot test files for format detection."""
+
 import struct
 import zlib
 from pathlib import Path
@@ -8,18 +9,18 @@ from pathlib import Path
 def create_gifar():
     """Create GIFAR (GIF + JAR) polyglot."""
     output = Path("demo/gifar_malware.gif")
-    
-    gif_data = bytearray(b'GIF89a')
-    gif_data.extend(struct.pack('<HH', 100, 100))
-    gif_data.extend(b'\x00')
-    gif_data.extend(b'\x00' * 50)
-    gif_data.extend(b';')
-    
+
+    gif_data = bytearray(b"GIF89a")
+    gif_data.extend(struct.pack("<HH", 100, 100))
+    gif_data.extend(b"\x00")
+    gif_data.extend(b"\x00" * 50)
+    gif_data.extend(b";")
+
     jar_offset = len(gif_data)
-    
+
     manifest = b"Manifest-Version: 1.0\nMain-Class: Malware\n\n"
     crc = zlib.crc32(manifest)
-    
+
     gif_data.extend(b"PK\x03\x04")
     gif_data.extend(struct.pack("<H", 20))
     gif_data.extend(struct.pack("<H", 0))
@@ -33,7 +34,7 @@ def create_gifar():
     gif_data.extend(struct.pack("<H", 0))
     gif_data.extend(b"META-INF/MANIFEST.MF")
     gif_data.extend(manifest)
-    
+
     cd_offset = len(gif_data) - jar_offset
     gif_data.extend(b"PK\x01\x02")
     gif_data.extend(struct.pack("<H", 20))
@@ -53,7 +54,7 @@ def create_gifar():
     gif_data.extend(struct.pack("<I", 0))
     gif_data.extend(struct.pack("<I", 0))
     gif_data.extend(b"META-INF/MANIFEST.MF")
-    
+
     gif_data.extend(b"PK\x05\x06")
     gif_data.extend(struct.pack("<H", 0))
     gif_data.extend(struct.pack("<H", 0))
@@ -62,7 +63,7 @@ def create_gifar():
     gif_data.extend(struct.pack("<I", len(gif_data) - cd_offset - jar_offset))
     gif_data.extend(struct.pack("<I", cd_offset))
     gif_data.extend(struct.pack("<H", 0))
-    
+
     output.write_bytes(gif_data)
     print(f"✓ Created {output} (GIFAR: valid GIF + JAR, JAR at offset {jar_offset:#x})")
 
@@ -70,36 +71,45 @@ def create_gifar():
 def create_png_zip_polyglot():
     """Create PNG+ZIP polyglot - valid as both formats."""
     output = Path("demo/polyglot_advanced.png")
-    
-    png_data = bytearray([
-        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
-    ])
-    
+
+    png_data = bytearray(
+        [
+            0x89,
+            0x50,
+            0x4E,
+            0x47,
+            0x0D,
+            0x0A,
+            0x1A,
+            0x0A,
+        ]
+    )
+
     ihdr = struct.pack(">IIBBBBB", 1, 1, 8, 2, 0, 0, 0)
     ihdr_crc = zlib.crc32(b"IHDR" + ihdr)
     png_data.extend(struct.pack(">I", len(ihdr)))
     png_data.extend(b"IHDR")
     png_data.extend(ihdr)
     png_data.extend(struct.pack(">I", ihdr_crc))
-    
-    idat_data = b"\x08\x1D\x01\x02\x00\xFD\xFF\x00\x00\x00\x02\x00\x01"
+
+    idat_data = b"\x08\x1d\x01\x02\x00\xfd\xff\x00\x00\x00\x02\x00\x01"
     idat_crc = zlib.crc32(b"IDAT" + idat_data)
     png_data.extend(struct.pack(">I", len(idat_data)))
     png_data.extend(b"IDAT")
     png_data.extend(idat_data)
     png_data.extend(struct.pack(">I", idat_crc))
-    
+
     iend_crc = zlib.crc32(b"IEND")
     png_data.extend(struct.pack(">I", 0))
     png_data.extend(b"IEND")
     png_data.extend(struct.pack(">I", iend_crc))
-    
+
     zip_offset = len(png_data)
-    
+
     filename = b"payload.txt"
     file_data = b"Polyglot payload data"
     crc = zlib.crc32(file_data)
-    
+
     png_data.extend(b"PK\x03\x04")
     png_data.extend(struct.pack("<H", 20))
     png_data.extend(struct.pack("<H", 0))
@@ -113,7 +123,7 @@ def create_png_zip_polyglot():
     png_data.extend(struct.pack("<H", 0))
     png_data.extend(filename)
     png_data.extend(file_data)
-    
+
     cd_offset = len(png_data) - zip_offset
     png_data.extend(b"PK\x01\x02")
     png_data.extend(struct.pack("<H", 20))
@@ -133,7 +143,7 @@ def create_png_zip_polyglot():
     png_data.extend(struct.pack("<I", 0))
     png_data.extend(struct.pack("<I", 0))
     png_data.extend(filename)
-    
+
     png_data.extend(b"PK\x05\x06")
     png_data.extend(struct.pack("<H", 0))
     png_data.extend(struct.pack("<H", 0))
@@ -142,7 +152,7 @@ def create_png_zip_polyglot():
     png_data.extend(struct.pack("<I", len(png_data) - cd_offset - zip_offset))
     png_data.extend(struct.pack("<I", cd_offset))
     png_data.extend(struct.pack("<H", 0))
-    
+
     output.write_bytes(png_data)
     print(f"✓ Created {output} (PNG+ZIP polyglot: valid as both PNG and ZIP)")
 
@@ -150,7 +160,7 @@ def create_png_zip_polyglot():
 def create_pdf_with_javascript():
     """Create PDF with embedded JavaScript payload."""
     output = Path("demo/malicious_document.pdf")
-    
+
     pdf_data = b"""%PDF-1.4
 1 0 obj
 << /Type /Catalog /Pages 2 0 R /OpenAction 3 0 R >>
@@ -185,7 +195,7 @@ startxref
 458
 %%EOF
 """
-    
+
     output.write_bytes(pdf_data)
     print(f"✓ Created {output} (PDF with JavaScript payload - HIGH RISK)")
 
@@ -193,28 +203,71 @@ startxref
 def create_jpeg_zip_polyglot():
     """Create JPEG+ZIP polyglot."""
     output = Path("demo/image_with_archive.jpg")
-    
-    jpeg_data = bytearray([
-        0xFF, 0xD8,              # SOI
-        0xFF, 0xE0, 0x00, 0x10,  # APP0 marker, length 16
-        0x4A, 0x46, 0x49, 0x46, 0x00,  # "JFIF\0"
-        0x01, 0x01, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00,
-        0xFF, 0xDB, 0x00, 0x42,  # DQT marker, length 66 (64 data + 2 for length)
-    ] + [0x10] * 64 + [
-        0xFF, 0xC0, 0x00, 0x0B,  # SOF marker
-        0x08, 0x00, 0x01, 0x00, 0x01, 0x01, 0x01, 0x11, 0x00,
-        0xFF, 0xDA, 0x00, 0x08,  # SOS marker, length 8
-        0x01, 0x01, 0x00, 0x00, 0x3F, 0x00,
-        0x00,                     # minimal scan data
-        0xFF, 0xD9,              # EOI
-    ])
-    
+
+    jpeg_data = bytearray(
+        [
+            0xFF,
+            0xD8,  # SOI
+            0xFF,
+            0xE0,
+            0x00,
+            0x10,  # APP0 marker, length 16
+            0x4A,
+            0x46,
+            0x49,
+            0x46,
+            0x00,  # "JFIF\0"
+            0x01,
+            0x01,
+            0x00,
+            0x00,
+            0x01,
+            0x00,
+            0x01,
+            0x00,
+            0x00,
+            0xFF,
+            0xDB,
+            0x00,
+            0x42,  # DQT marker, length 66 (64 data + 2 for length)
+        ]
+        + [0x10] * 64
+        + [
+            0xFF,
+            0xC0,
+            0x00,
+            0x0B,  # SOF marker
+            0x08,
+            0x00,
+            0x01,
+            0x00,
+            0x01,
+            0x01,
+            0x01,
+            0x11,
+            0x00,
+            0xFF,
+            0xDA,
+            0x00,
+            0x08,  # SOS marker, length 8
+            0x01,
+            0x01,
+            0x00,
+            0x00,
+            0x3F,
+            0x00,
+            0x00,  # minimal scan data
+            0xFF,
+            0xD9,  # EOI
+        ]
+    )
+
     zip_offset = len(jpeg_data)
-    
+
     filename = b"hidden.txt"
     file_data = b"Hidden archive in JPEG"
     crc = zlib.crc32(file_data)
-    
+
     jpeg_data.extend(b"PK\x03\x04")
     jpeg_data.extend(struct.pack("<H", 20))
     jpeg_data.extend(struct.pack("<H", 0))
@@ -228,7 +281,7 @@ def create_jpeg_zip_polyglot():
     jpeg_data.extend(struct.pack("<H", 0))
     jpeg_data.extend(filename)
     jpeg_data.extend(file_data)
-    
+
     cd_offset = len(jpeg_data) - zip_offset
     jpeg_data.extend(b"PK\x01\x02")
     jpeg_data.extend(struct.pack("<H", 20))
@@ -248,7 +301,7 @@ def create_jpeg_zip_polyglot():
     jpeg_data.extend(struct.pack("<I", 0))
     jpeg_data.extend(struct.pack("<I", 0))
     jpeg_data.extend(filename)
-    
+
     jpeg_data.extend(b"PK\x05\x06")
     jpeg_data.extend(struct.pack("<H", 0))
     jpeg_data.extend(struct.pack("<H", 0))
@@ -257,7 +310,7 @@ def create_jpeg_zip_polyglot():
     jpeg_data.extend(struct.pack("<I", len(jpeg_data) - cd_offset - zip_offset))
     jpeg_data.extend(struct.pack("<I", cd_offset))
     jpeg_data.extend(struct.pack("<H", 0))
-    
+
     output.write_bytes(jpeg_data)
     print(f"✓ Created {output} (JPEG+ZIP polyglot at offset {zip_offset:#x})")
 
@@ -265,20 +318,20 @@ def create_jpeg_zip_polyglot():
 def create_pe_zip_polyglot():
     """Create PE+ZIP polyglot."""
     output = Path("demo/executable_archive.exe")
-    
-    pe_data = bytearray(b'MZ')
-    pe_data.extend(b'\x90' + b'\x00' * 57)
-    pe_data.extend(struct.pack('<I', 64))
-    pe_data.extend(b'PE\x00\x00')
-    pe_data.extend(b'\x4C\x01\x01\x00')
-    pe_data.extend(b'\x00' * 200)
-    
+
+    pe_data = bytearray(b"MZ")
+    pe_data.extend(b"\x90" + b"\x00" * 57)
+    pe_data.extend(struct.pack("<I", 64))
+    pe_data.extend(b"PE\x00\x00")
+    pe_data.extend(b"\x4c\x01\x01\x00")
+    pe_data.extend(b"\x00" * 200)
+
     zip_offset = len(pe_data)
-    
+
     filename = b"data.bin"
     file_data = b"Executable with embedded archive"
     crc = zlib.crc32(file_data)
-    
+
     pe_data.extend(b"PK\x03\x04")
     pe_data.extend(struct.pack("<H", 20))
     pe_data.extend(struct.pack("<H", 0))
@@ -292,7 +345,7 @@ def create_pe_zip_polyglot():
     pe_data.extend(struct.pack("<H", 0))
     pe_data.extend(filename)
     pe_data.extend(file_data)
-    
+
     cd_offset = len(pe_data) - zip_offset
     pe_data.extend(b"PK\x01\x02")
     pe_data.extend(struct.pack("<H", 20))
@@ -312,7 +365,7 @@ def create_pe_zip_polyglot():
     pe_data.extend(struct.pack("<I", 0))
     pe_data.extend(struct.pack("<I", 0))
     pe_data.extend(filename)
-    
+
     pe_data.extend(b"PK\x05\x06")
     pe_data.extend(struct.pack("<H", 0))
     pe_data.extend(struct.pack("<H", 0))
@@ -321,22 +374,22 @@ def create_pe_zip_polyglot():
     pe_data.extend(struct.pack("<I", len(pe_data) - cd_offset - zip_offset))
     pe_data.extend(struct.pack("<I", cd_offset))
     pe_data.extend(struct.pack("<H", 0))
-    
+
     output.write_bytes(pe_data)
     print(f"✓ Created {output} (PE+ZIP polyglot - HIGH RISK)")
 
 
 def main():
     Path("demo").mkdir(exist_ok=True)
-    
+
     print("Creating sophisticated polyglot files...\n")
-    
+
     create_gifar()
     create_png_zip_polyglot()
     create_pdf_with_javascript()
     create_jpeg_zip_polyglot()
     create_pe_zip_polyglot()
-    
+
     print(f"\n✓ All polyglot files created in demo/")
     print("\n⚠ WARNING: These files demonstrate advanced evasion techniques")
     print("Test with:")

--- a/demo/create_test_files.py
+++ b/demo/create_test_files.py
@@ -3,6 +3,7 @@
 Generate sophisticated test files for embedded detection testing.
 Creates realistic scenarios: malware droppers, polyglots, stego files.
 """
+
 import struct
 import zlib
 from pathlib import Path
@@ -11,76 +12,115 @@ from pathlib import Path
 def create_zip_in_exe():
     """Malware dropper: ZIP archive embedded in PE executable."""
     output = Path("demo/malware_dropper.exe")
-    
+
     # Minimal PE executable header
-    pe_header = bytes([
-        0x4D, 0x5A,  # MZ signature
-        0x90, 0x00, 0x03, 0x00, 0x00, 0x00, 0x04, 0x00,
-        0x00, 0x00, 0xFF, 0xFF, 0x00, 0x00, 0xB8, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    ] + [0x00] * 32 + [
-        0x50, 0x45, 0x00, 0x00,  # PE signature at offset 64
-        0x4C, 0x01,  # Machine (i386)
-        0x01, 0x00,  # Number of sections
-    ] + [0x00] * 200)
-    
+    pe_header = bytes(
+        [
+            0x4D,
+            0x5A,  # MZ signature
+            0x90,
+            0x00,
+            0x03,
+            0x00,
+            0x00,
+            0x00,
+            0x04,
+            0x00,
+            0x00,
+            0x00,
+            0xFF,
+            0xFF,
+            0x00,
+            0x00,
+            0xB8,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x40,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+        ]
+        + [0x00] * 32
+        + [
+            0x50,
+            0x45,
+            0x00,
+            0x00,  # PE signature at offset 64
+            0x4C,
+            0x01,  # Machine (i386)
+            0x01,
+            0x00,  # Number of sections
+        ]
+        + [0x00] * 200
+    )
+
     # Create a simple ZIP file
     zip_content = bytearray()
-    
+
     # Local file header
     filename = b"payload.txt"
     file_data = b"This is hidden malware payload data"
     crc = zlib.crc32(file_data)
-    
+
     zip_content.extend(b"PK\x03\x04")  # Local file header signature
     zip_content.extend(struct.pack("<H", 20))  # Version needed
-    zip_content.extend(struct.pack("<H", 0))   # Flags
-    zip_content.extend(struct.pack("<H", 0))   # Compression method (stored)
-    zip_content.extend(struct.pack("<H", 0))   # Mod time
-    zip_content.extend(struct.pack("<H", 0))   # Mod date
+    zip_content.extend(struct.pack("<H", 0))  # Flags
+    zip_content.extend(struct.pack("<H", 0))  # Compression method (stored)
+    zip_content.extend(struct.pack("<H", 0))  # Mod time
+    zip_content.extend(struct.pack("<H", 0))  # Mod date
     zip_content.extend(struct.pack("<I", crc))  # CRC-32
     zip_content.extend(struct.pack("<I", len(file_data)))  # Compressed size
     zip_content.extend(struct.pack("<I", len(file_data)))  # Uncompressed size
-    zip_content.extend(struct.pack("<H", len(filename)))   # Filename length
-    zip_content.extend(struct.pack("<H", 0))   # Extra field length
+    zip_content.extend(struct.pack("<H", len(filename)))  # Filename length
+    zip_content.extend(struct.pack("<H", 0))  # Extra field length
     zip_content.extend(filename)
     zip_content.extend(file_data)
-    
+
     # Central directory header
     cd_offset = len(zip_content)
     zip_content.extend(b"PK\x01\x02")  # Central directory signature
     zip_content.extend(struct.pack("<H", 20))  # Version made by
     zip_content.extend(struct.pack("<H", 20))  # Version needed
-    zip_content.extend(struct.pack("<H", 0))   # Flags
-    zip_content.extend(struct.pack("<H", 0))   # Compression
-    zip_content.extend(struct.pack("<H", 0))   # Mod time
-    zip_content.extend(struct.pack("<H", 0))   # Mod date
+    zip_content.extend(struct.pack("<H", 0))  # Flags
+    zip_content.extend(struct.pack("<H", 0))  # Compression
+    zip_content.extend(struct.pack("<H", 0))  # Mod time
+    zip_content.extend(struct.pack("<H", 0))  # Mod date
     zip_content.extend(struct.pack("<I", crc))
     zip_content.extend(struct.pack("<I", len(file_data)))
     zip_content.extend(struct.pack("<I", len(file_data)))
     zip_content.extend(struct.pack("<H", len(filename)))
-    zip_content.extend(struct.pack("<H", 0))   # Extra field length
-    zip_content.extend(struct.pack("<H", 0))   # Comment length
-    zip_content.extend(struct.pack("<H", 0))   # Disk number
-    zip_content.extend(struct.pack("<H", 0))   # Internal attributes
-    zip_content.extend(struct.pack("<I", 0))   # External attributes
-    zip_content.extend(struct.pack("<I", 0))   # Relative offset
+    zip_content.extend(struct.pack("<H", 0))  # Extra field length
+    zip_content.extend(struct.pack("<H", 0))  # Comment length
+    zip_content.extend(struct.pack("<H", 0))  # Disk number
+    zip_content.extend(struct.pack("<H", 0))  # Internal attributes
+    zip_content.extend(struct.pack("<I", 0))  # External attributes
+    zip_content.extend(struct.pack("<I", 0))  # Relative offset
     zip_content.extend(filename)
-    
+
     # End of central directory
     zip_content.extend(b"PK\x05\x06")  # EOCD signature
-    zip_content.extend(struct.pack("<H", 0))   # Disk number
-    zip_content.extend(struct.pack("<H", 0))   # CD start disk
-    zip_content.extend(struct.pack("<H", 1))   # Entries on this disk
-    zip_content.extend(struct.pack("<H", 1))   # Total entries
+    zip_content.extend(struct.pack("<H", 0))  # Disk number
+    zip_content.extend(struct.pack("<H", 0))  # CD start disk
+    zip_content.extend(struct.pack("<H", 1))  # Entries on this disk
+    zip_content.extend(struct.pack("<H", 1))  # Total entries
     zip_content.extend(struct.pack("<I", len(zip_content) - cd_offset))  # CD size
     zip_content.extend(struct.pack("<I", cd_offset))  # CD offset
-    zip_content.extend(struct.pack("<H", 0))   # Comment length
-    
+    zip_content.extend(struct.pack("<H", 0))  # Comment length
+
     # Combine PE header + some padding + ZIP
     combined = pe_header + bytes([0x00] * 100) + bytes(zip_content)
-    
+
     output.write_bytes(combined)
     print(f"✓ Created {output} (ZIP embedded at offset {len(pe_header) + 100:#x})")
 
@@ -88,12 +128,21 @@ def create_zip_in_exe():
 def create_polyglot_png_zip():
     """Polyglot file: valid PNG and valid ZIP simultaneously."""
     output = Path("demo/polyglot_png_zip.png")
-    
+
     # PNG header
-    png_data = bytearray([
-        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,  # PNG signature
-    ])
-    
+    png_data = bytearray(
+        [
+            0x89,
+            0x50,
+            0x4E,
+            0x47,
+            0x0D,
+            0x0A,
+            0x1A,
+            0x0A,  # PNG signature
+        ]
+    )
+
     # IHDR chunk (1x1 red pixel)
     ihdr = struct.pack(">IIBBBBB", 1, 1, 8, 2, 0, 0, 0)
     ihdr_crc = zlib.crc32(b"IHDR" + ihdr)
@@ -101,28 +150,28 @@ def create_polyglot_png_zip():
     png_data.extend(b"IHDR")
     png_data.extend(ihdr)
     png_data.extend(struct.pack(">I", ihdr_crc))
-    
+
     # IDAT chunk with ZIP embedded
-    idat_data = b"\x08\x1D\x01\x02\x00\xFD\xFF\x00\x00\x00\x02\x00\x01"
+    idat_data = b"\x08\x1d\x01\x02\x00\xfd\xff\x00\x00\x00\x02\x00\x01"
     idat_crc = zlib.crc32(b"IDAT" + idat_data)
     png_data.extend(struct.pack(">I", len(idat_data)))
     png_data.extend(b"IDAT")
     png_data.extend(idat_data)
     png_data.extend(struct.pack(">I", idat_crc))
-    
+
     # IEND chunk
     iend_crc = zlib.crc32(b"IEND")
     png_data.extend(struct.pack(">I", 0))
     png_data.extend(b"IEND")
     png_data.extend(struct.pack(">I", iend_crc))
-    
+
     # Append ZIP archive after PNG
     filename = b"secret.txt"
     file_data = b"Hidden data in polyglot file!"
     crc = zlib.crc32(file_data)
-    
+
     zip_offset = len(png_data)
-    
+
     # Local file header
     png_data.extend(b"PK\x03\x04")
     png_data.extend(struct.pack("<H", 20))
@@ -137,7 +186,7 @@ def create_polyglot_png_zip():
     png_data.extend(struct.pack("<H", 0))
     png_data.extend(filename)
     png_data.extend(file_data)
-    
+
     # Central directory
     cd_offset = len(png_data) - zip_offset
     png_data.extend(b"PK\x01\x02")
@@ -158,7 +207,7 @@ def create_polyglot_png_zip():
     png_data.extend(struct.pack("<I", 0))
     png_data.extend(struct.pack("<I", 0))
     png_data.extend(filename)
-    
+
     # EOCD
     png_data.extend(b"PK\x05\x06")
     png_data.extend(struct.pack("<H", 0))
@@ -168,7 +217,7 @@ def create_polyglot_png_zip():
     png_data.extend(struct.pack("<I", len(png_data) - cd_offset - zip_offset))
     png_data.extend(struct.pack("<I", cd_offset))
     png_data.extend(struct.pack("<H", 0))
-    
+
     output.write_bytes(png_data)
     print(f"✓ Created {output} (polyglot: valid PNG + ZIP at offset {zip_offset:#x})")
 
@@ -176,40 +225,73 @@ def create_polyglot_png_zip():
 def create_jpeg_with_trailing_zip():
     """Steganography: JPEG with ZIP appended after EOF marker."""
     output = Path("demo/stego_jpeg_zip.jpg")
-    
+
     # Minimal JPEG
-    jpeg_data = bytearray([
-        0xFF, 0xD8,  # SOI
-        0xFF, 0xE0,  # APP0
-        0x00, 0x10,  # Length
-        0x4A, 0x46, 0x49, 0x46, 0x00,  # "JFIF\0"
-        0x01, 0x01,  # Version 1.1
-        0x00,  # Density units
-        0x00, 0x01, 0x00, 0x01,  # X/Y density
-        0x00, 0x00,  # Thumbnail
-        0xFF, 0xDB,  # DQT
-        0x00, 0x43,  # Length
-    ] + [0x10] * 64 + [  # Quantization table
-        0xFF, 0xC0,  # SOF0
-        0x00, 0x0B,  # Length
-        0x08,  # Precision
-        0x00, 0x01, 0x00, 0x01,  # Dimensions 1x1
-        0x01,  # Components
-        0x01, 0x11, 0x00,  # Component info
-        0xFF, 0xDA,  # SOS
-        0x00, 0x08,  # Length
-        0x01, 0x01, 0x00, 0x00, 0x3F, 0x00,  # Scan header
-        0x00,  # Minimal scan data
-        0xFF, 0xD9,  # EOI (end of JPEG)
-    ])
-    
+    jpeg_data = bytearray(
+        [
+            0xFF,
+            0xD8,  # SOI
+            0xFF,
+            0xE0,  # APP0
+            0x00,
+            0x10,  # Length
+            0x4A,
+            0x46,
+            0x49,
+            0x46,
+            0x00,  # "JFIF\0"
+            0x01,
+            0x01,  # Version 1.1
+            0x00,  # Density units
+            0x00,
+            0x01,
+            0x00,
+            0x01,  # X/Y density
+            0x00,
+            0x00,  # Thumbnail
+            0xFF,
+            0xDB,  # DQT
+            0x00,
+            0x43,  # Length
+        ]
+        + [0x10] * 64
+        + [  # Quantization table
+            0xFF,
+            0xC0,  # SOF0
+            0x00,
+            0x0B,  # Length
+            0x08,  # Precision
+            0x00,
+            0x01,
+            0x00,
+            0x01,  # Dimensions 1x1
+            0x01,  # Components
+            0x01,
+            0x11,
+            0x00,  # Component info
+            0xFF,
+            0xDA,  # SOS
+            0x00,
+            0x08,  # Length
+            0x01,
+            0x01,
+            0x00,
+            0x00,
+            0x3F,
+            0x00,  # Scan header
+            0x00,  # Minimal scan data
+            0xFF,
+            0xD9,  # EOI (end of JPEG)
+        ]
+    )
+
     # Append hidden ZIP
     filename = b"evidence.txt"
     file_data = b"Forensic evidence hidden in JPEG!"
     crc = zlib.crc32(file_data)
-    
+
     zip_offset = len(jpeg_data)
-    
+
     jpeg_data.extend(b"PK\x03\x04")
     jpeg_data.extend(struct.pack("<H", 20))
     jpeg_data.extend(struct.pack("<H", 0))
@@ -223,7 +305,7 @@ def create_jpeg_with_trailing_zip():
     jpeg_data.extend(struct.pack("<H", 0))
     jpeg_data.extend(filename)
     jpeg_data.extend(file_data)
-    
+
     # Central directory
     cd_offset = len(jpeg_data) - zip_offset
     jpeg_data.extend(b"PK\x01\x02")
@@ -244,7 +326,7 @@ def create_jpeg_with_trailing_zip():
     jpeg_data.extend(struct.pack("<I", 0))
     jpeg_data.extend(struct.pack("<I", 0))
     jpeg_data.extend(filename)
-    
+
     # EOCD
     jpeg_data.extend(b"PK\x05\x06")
     jpeg_data.extend(struct.pack("<H", 0))
@@ -254,7 +336,7 @@ def create_jpeg_with_trailing_zip():
     jpeg_data.extend(struct.pack("<I", len(jpeg_data) - cd_offset - zip_offset))
     jpeg_data.extend(struct.pack("<I", cd_offset))
     jpeg_data.extend(struct.pack("<H", 0))
-    
+
     output.write_bytes(jpeg_data)
     print(f"✓ Created {output} (ZIP hidden after JPEG EOF at offset {zip_offset:#x})")
 
@@ -262,7 +344,7 @@ def create_jpeg_with_trailing_zip():
 def create_pdf_with_embedded_exe():
     """Weaponized document: PDF with embedded PE executable."""
     output = Path("demo/weaponized_document.pdf")
-    
+
     # Minimal PDF structure
     pdf_data = b"""%PDF-1.4
 1 0 obj
@@ -286,18 +368,44 @@ startxref
 187
 %%EOF
 """
-    
+
     # Append PE executable
     pe_offset = len(pdf_data)
-    pe_data = bytes([
-        0x4D, 0x5A,  # MZ signature
-        0x90, 0x00, 0x03, 0x00, 0x00, 0x00, 0x04, 0x00,
-        0x00, 0x00, 0xFF, 0xFF, 0x00, 0x00, 0xB8, 0x00,
-    ] + [0x00] * 48 + [
-        0x50, 0x45, 0x00, 0x00,  # PE signature
-        0x4C, 0x01, 0x01, 0x00,  # Machine + sections
-    ] + [0x00] * 100)
-    
+    pe_data = bytes(
+        [
+            0x4D,
+            0x5A,  # MZ signature
+            0x90,
+            0x00,
+            0x03,
+            0x00,
+            0x00,
+            0x00,
+            0x04,
+            0x00,
+            0x00,
+            0x00,
+            0xFF,
+            0xFF,
+            0x00,
+            0x00,
+            0xB8,
+            0x00,
+        ]
+        + [0x00] * 48
+        + [
+            0x50,
+            0x45,
+            0x00,
+            0x00,  # PE signature
+            0x4C,
+            0x01,
+            0x01,
+            0x00,  # Machine + sections
+        ]
+        + [0x00] * 100
+    )
+
     combined = pdf_data + pe_data
     output.write_bytes(combined)
     print(f"✓ Created {output} (PE embedded at offset {pe_offset:#x})")
@@ -306,13 +414,13 @@ startxref
 def create_zip_with_overlay():
     """ZIP archive with overlay data (post-EOCD trailer)."""
     output = Path("demo/zip_with_overlay.zip")
-    
+
     filename = b"readme.txt"
     file_data = b"Normal ZIP file content"
     crc = zlib.crc32(file_data)
-    
+
     zip_data = bytearray()
-    
+
     # Local file header
     zip_data.extend(b"PK\x03\x04")
     zip_data.extend(struct.pack("<H", 20))
@@ -327,7 +435,7 @@ def create_zip_with_overlay():
     zip_data.extend(struct.pack("<H", 0))
     zip_data.extend(filename)
     zip_data.extend(file_data)
-    
+
     # Central directory
     cd_offset = len(zip_data)
     zip_data.extend(b"PK\x01\x02")
@@ -348,7 +456,7 @@ def create_zip_with_overlay():
     zip_data.extend(struct.pack("<I", 0))
     zip_data.extend(struct.pack("<I", 0))
     zip_data.extend(filename)
-    
+
     # EOCD
     zip_data.extend(b"PK\x05\x06")
     zip_data.extend(struct.pack("<H", 0))
@@ -358,27 +466,27 @@ def create_zip_with_overlay():
     zip_data.extend(struct.pack("<I", len(zip_data) - cd_offset))
     zip_data.extend(struct.pack("<I", cd_offset))
     zip_data.extend(struct.pack("<H", 0))
-    
+
     # Add overlay data after EOCD
     overlay_offset = len(zip_data)
     overlay_data = b"OVERLAY_DATA_MALICIOUS_CODE_HERE" * 10
     zip_data.extend(overlay_data)
-    
+
     output.write_bytes(zip_data)
     print(f"✓ Created {output} (overlay at offset {overlay_offset:#x}, {len(overlay_data)} bytes)")
 
 
 def main():
     Path("demo").mkdir(exist_ok=True)
-    
+
     print("Creating sophisticated embedded detection test files...\n")
-    
+
     create_zip_in_exe()
     create_polyglot_png_zip()
     create_jpeg_with_trailing_zip()
     create_pdf_with_embedded_exe()
     create_zip_with_overlay()
-    
+
     print(f"\n✓ All test files created in demo/")
     print("\nTest with:")
     print("  filo analyze demo/malware_dropper.exe")

--- a/demo/test_all_features.py
+++ b/demo/test_all_features.py
@@ -4,6 +4,7 @@ Comprehensive Feature Test - Demonstrate All Filo Capabilities
 
 Tests all major features in sequence with clear output.
 """
+
 import subprocess
 import sys
 from pathlib import Path
@@ -15,21 +16,16 @@ def run_cmd(cmd: str, description: str) -> None:
     print(f"TEST: {description}")
     print(f"{'='*70}")
     print(f"$ {cmd}\n")
-    
-    result = subprocess.run(
-        cmd,
-        shell=True,
-        capture_output=True,
-        text=True
-    )
-    
+
+    result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+
     print(result.stdout)
     if result.stderr and "ResourceWarning" not in result.stderr:
         print(f"[stderr]: {result.stderr}")
-    
+
     if result.returncode != 0:
         print(f"\n⚠ Command failed with exit code {result.returncode}")
-    
+
     return result.returncode == 0
 
 
@@ -40,87 +36,98 @@ def main():
 ║  Testing all major capabilities in realistic scenarios          ║
 ╚══════════════════════════════════════════════════════════════════╝
 """)
-    
+
     results = []
-    
+
     # Test 1: Create demo files
     print("\n📁 Step 1: Creating sophisticated test files...")
-    results.append(run_cmd(
-        "python demo/create_test_files.py",
-        "Generate malware dropper, polyglots, steganography files"
-    ))
-    
+    results.append(
+        run_cmd(
+            "python demo/create_test_files.py",
+            "Generate malware dropper, polyglots, steganography files",
+        )
+    )
+
     # Test 2: Basic analysis
-    results.append(run_cmd(
-        "filo analyze demo/polyglot_png_zip.png",
-        "Basic analysis - polyglot file (valid PNG + ZIP)"
-    ))
-    
+    results.append(
+        run_cmd(
+            "filo analyze demo/polyglot_png_zip.png",
+            "Basic analysis - polyglot file (valid PNG + ZIP)",
+        )
+    )
+
     # Test 3: Embedded detection with -e flag
-    results.append(run_cmd(
-        "filo analyze demo/malware_dropper.exe -e",
-        "Embedded detection - ZIP hidden in PE executable"
-    ))
-    
+    results.append(
+        run_cmd(
+            "filo analyze demo/malware_dropper.exe -e",
+            "Embedded detection - ZIP hidden in PE executable",
+        )
+    )
+
     # Test 4: Tool fingerprinting
-    results.append(run_cmd(
-        "filo analyze demo/zip_with_overlay.zip",
-        "Tool fingerprinting - identify creator tool/OS"
-    ))
-    
+    results.append(
+        run_cmd(
+            "filo analyze demo/zip_with_overlay.zip",
+            "Tool fingerprinting - identify creator tool/OS",
+        )
+    )
+
     # Test 5: Steganography detection
-    results.append(run_cmd(
-        "filo analyze demo/stego_jpeg_zip.jpg -e",
-        "Steganography - ZIP hidden after JPEG EOF marker"
-    ))
-    
+    results.append(
+        run_cmd(
+            "filo analyze demo/stego_jpeg_zip.jpg -e",
+            "Steganography - ZIP hidden after JPEG EOF marker",
+        )
+    )
+
     # Test 6: Weaponized document
-    results.append(run_cmd(
-        "filo analyze demo/weaponized_document.pdf -e",
-        "Weaponized document - PDF with embedded PE"
-    ))
-    
+    results.append(
+        run_cmd(
+            "filo analyze demo/weaponized_document.pdf -e",
+            "Weaponized document - PDF with embedded PE",
+        )
+    )
+
     # Test 7: Full transparency mode
-    results.append(run_cmd(
-        "filo analyze demo/polyglot_png_zip.png --explain -a -e",
-        "Full transparency - explain + all evidence + all embedded"
-    ))
-    
+    results.append(
+        run_cmd(
+            "filo analyze demo/polyglot_png_zip.png --explain -a -e",
+            "Full transparency - explain + all evidence + all embedded",
+        )
+    )
+
     # Test 8: JSON output
-    results.append(run_cmd(
-        "filo analyze demo/malware_dropper.exe --json | head -30",
-        "JSON output for automation/scripting"
-    ))
-    
+    results.append(
+        run_cmd(
+            "filo analyze demo/malware_dropper.exe --json | head -30",
+            "JSON output for automation/scripting",
+        )
+    )
+
     # Test 9: ML teaching
-    results.append(run_cmd(
-        "filo teach demo/zip_with_overlay.zip -f zip",
-        "ML teaching - train on ZIP file"
-    ))
-    
+    results.append(
+        run_cmd("filo teach demo/zip_with_overlay.zip -f zip", "ML teaching - train on ZIP file")
+    )
+
     # Test 10: Lineage stats
-    results.append(run_cmd(
-        "filo lineage-stats",
-        "Lineage statistics - chain-of-custody tracking"
-    ))
-    
+    results.append(run_cmd("filo lineage-stats", "Lineage statistics - chain-of-custody tracking"))
+
     # Test 11: Batch processing
-    results.append(run_cmd(
-        "filo batch demo/ --max-workers 2",
-        "Batch processing - analyze all demo files"
-    ))
-    
+    results.append(
+        run_cmd("filo batch demo/ --max-workers 2", "Batch processing - analyze all demo files")
+    )
+
     # Summary
     print(f"\n{'='*70}")
     print("SUMMARY")
     print(f"{'='*70}")
-    
+
     passed = sum(results)
     total = len(results)
-    
+
     print(f"\n✓ Passed: {passed}/{total}")
     print(f"✗ Failed: {total - passed}/{total}")
-    
+
     if passed == total:
         print("\n🎉 All tests passed! Filo is working perfectly.")
         return 0

--- a/examples/advanced_repair_demo.py
+++ b/examples/advanced_repair_demo.py
@@ -26,37 +26,37 @@ def demo_png_repair():
     """Demonstrate PNG chunk repair with bad CRC."""
     console.print("\n[bold cyan]PNG Chunk Repair Demo[/bold cyan]")
     console.print("=" * 60)
-    
+
     # Create PNG with corrupted CRC
     png = b"\x89PNG\r\n\x1a\n"
-    
+
     # Create IHDR chunk with wrong CRC
     ihdr_data = struct.pack(">II", 200, 150)  # 200x150
     ihdr_data += b"\x08\x06\x00\x00\x00"  # 8-bit RGBA
-    
+
     png += struct.pack(">I", 13)  # Length
     png += b"IHDR" + ihdr_data
     png += struct.pack(">I", 0xDEADBEEF)  # Wrong CRC!
-    
+
     # Add IEND chunk
-    iend_crc = zlib.crc32(b"IEND") & 0xffffffff
+    iend_crc = zlib.crc32(b"IEND") & 0xFFFFFFFF
     png += struct.pack(">I", 0) + b"IEND" + struct.pack(">I", iend_crc)
-    
+
     console.print(f"\n[yellow]Original PNG size:[/yellow] {len(png)} bytes")
     console.print(f"[yellow]Corrupted CRC:[/yellow] 0xDEADBEEF (should be calculated)")
-    
+
     # Repair it
     engine = RepairEngine()
     repaired, report = engine.repair(png, "png")
-    
+
     console.print(f"\n[green]✓ Repair successful![/green]")
     console.print(f"[green]Strategy:[/green] {report.strategy_used}")
     console.print(f"[green]Confidence:[/green] {report.confidence:.1%}")
     console.print(f"[green]Chunks repaired:[/green] {report.chunks_repaired}")
-    
+
     for change in report.changes_made:
         console.print(f"  • {change}")
-    
+
     return repaired
 
 
@@ -64,33 +64,33 @@ def demo_jpeg_repair():
     """Demonstrate JPEG marker reconstruction."""
     console.print("\n[bold cyan]JPEG Marker Repair Demo[/bold cyan]")
     console.print("=" * 60)
-    
+
     # Create truncated JPEG (missing EOI marker)
     jpeg = b"\xff\xd8"  # SOI
     jpeg += b"\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00"  # JFIF
     jpeg += b"\xff\xdb\x00\x43"  # DQT marker
     jpeg += b"\x00" * 67  # Quantization table
     # Missing EOI marker!
-    
+
     console.print(f"\n[yellow]Truncated JPEG size:[/yellow] {len(jpeg)} bytes")
     console.print(f"[yellow]Missing:[/yellow] End of Image (EOI) marker 0xFFD9")
-    
+
     # Repair it
     engine = RepairEngine()
     repaired, report = engine.repair(jpeg, "jpeg")
-    
+
     console.print(f"\n[green]✓ Repair successful![/green]")
     console.print(f"[green]Strategy:[/green] {report.strategy_used}")
     console.print(f"[green]Confidence:[/green] {report.confidence:.1%}")
     console.print(f"[green]Repaired size:[/green] {report.repaired_size} bytes")
-    
+
     for change in report.changes_made:
         console.print(f"  • {change}")
-    
+
     # Verify EOI marker
     if repaired.endswith(b"\xff\xd9"):
         console.print("[green]✓ EOI marker successfully added[/green]")
-    
+
     return repaired
 
 
@@ -98,42 +98,42 @@ def demo_zip_repair():
     """Demonstrate ZIP directory reconstruction."""
     console.print("\n[bold cyan]ZIP Directory Repair Demo[/bold cyan]")
     console.print("=" * 60)
-    
+
     # Create ZIP with missing central directory
     zip_data = b"PK\x03\x04"  # Local file header signature
-    zip_data += b"\x14\x00"    # Version needed
-    zip_data += b"\x00\x00"    # General purpose bit flag
-    zip_data += b"\x00\x00"    # Compression method (stored)
-    zip_data += b"\x00" * 8    # Modification time/date
-    zip_data += b"\x00" * 12   # CRC-32, sizes
-    zip_data += b"\x08\x00"    # File name length (8)
-    zip_data += b"\x00\x00"    # Extra field length
-    zip_data += b"test.txt"    # File name
+    zip_data += b"\x14\x00"  # Version needed
+    zip_data += b"\x00\x00"  # General purpose bit flag
+    zip_data += b"\x00\x00"  # Compression method (stored)
+    zip_data += b"\x00" * 8  # Modification time/date
+    zip_data += b"\x00" * 12  # CRC-32, sizes
+    zip_data += b"\x08\x00"  # File name length (8)
+    zip_data += b"\x00\x00"  # Extra field length
+    zip_data += b"test.txt"  # File name
     zip_data += b"Hello, World!"  # File data
     # Missing central directory and EOCD!
-    
+
     console.print(f"\n[yellow]Broken ZIP size:[/yellow] {len(zip_data)} bytes")
     console.print(f"[yellow]Missing:[/yellow] End of Central Directory (EOCD)")
-    
+
     # Repair it
     engine = RepairEngine()
     repaired, report = engine.repair(zip_data, "zip")
-    
+
     console.print(f"\n[green]✓ Repair successful![/green]")
     console.print(f"[green]Strategy:[/green] {report.strategy_used}")
     console.print(f"[green]Confidence:[/green] {report.confidence:.1%}")
     console.print(f"[green]Repaired size:[/green] {report.repaired_size} bytes")
-    
+
     for change in report.changes_made:
         console.print(f"  • {change}")
-    
+
     for warning in report.warnings:
         console.print(f"  [yellow]⚠[/yellow] {warning}")
-    
+
     # Verify EOCD marker
     if b"PK\x05\x06" in repaired:
         console.print("[green]✓ EOCD signature found[/green]")
-    
+
     return repaired
 
 
@@ -141,99 +141,97 @@ def demo_pdf_repair():
     """Demonstrate PDF cross-reference reconstruction."""
     console.print("\n[bold cyan]PDF Cross-Reference Repair Demo[/bold cyan]")
     console.print("=" * 60)
-    
+
     # Create incomplete PDF (missing xref and EOF)
     pdf = b"%PDF-1.4\n"
     pdf += b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n"
     pdf += b"2 0 obj\n<< /Type /Pages /Count 0 /Kids [] >>\nendobj\n"
     # Missing xref table and %%EOF marker!
-    
+
     console.print(f"\n[yellow]Incomplete PDF size:[/yellow] {len(pdf)} bytes")
     console.print(f"[yellow]Missing:[/yellow] Cross-reference table and %%EOF")
-    
+
     # Repair it
     engine = RepairEngine()
     repaired, report = engine.repair(pdf, "pdf")
-    
+
     console.print(f"\n[green]✓ Repair successful![/green]")
     console.print(f"[green]Strategy:[/green] {report.strategy_used}")
     console.print(f"[green]Confidence:[/green] {report.confidence:.1%}")
     console.print(f"[green]Repaired size:[/green] {report.repaired_size} bytes")
-    
+
     for change in report.changes_made:
         console.print(f"  • {change}")
-    
+
     for warning in report.warnings:
         console.print(f"  [yellow]⚠[/yellow] {warning}")
-    
+
     # Verify repairs
     if b"xref" in repaired:
         console.print("[green]✓ Cross-reference table added[/green]")
     if b"%%EOF" in repaired:
         console.print("[green]✓ EOF marker added[/green]")
-    
+
     return repaired
 
 
 def create_summary_table(results):
     """Create a summary table of all repairs."""
     table = Table(title="Advanced Repair Summary", show_header=True, header_style="bold magenta")
-    
+
     table.add_column("Format", style="cyan")
     table.add_column("Original Size", justify="right")
     table.add_column("Repaired Size", justify="right")
     table.add_column("Strategy", style="yellow")
     table.add_column("Confidence", justify="right")
-    
+
     for name, (original, repaired, strategy, confidence) in results.items():
-        table.add_row(
-            name,
-            f"{original} bytes",
-            f"{repaired} bytes",
-            strategy,
-            f"{confidence:.1%}"
-        )
-    
+        table.add_row(name, f"{original} bytes", f"{repaired} bytes", strategy, f"{confidence:.1%}")
+
     return table
 
 
 def main():
     """Run all advanced repair demos."""
-    console.print(Panel.fit(
-        "[bold cyan]Advanced File Repair Demonstration[/bold cyan]\n"
-        "Showcasing format-specific repair strategies",
-        border_style="cyan"
-    ))
-    
+    console.print(
+        Panel.fit(
+            "[bold cyan]Advanced File Repair Demonstration[/bold cyan]\n"
+            "Showcasing format-specific repair strategies",
+            border_style="cyan",
+        )
+    )
+
     results = {}
-    
+
     # PNG repair
     png_orig_size = 37
     png_repaired = demo_png_repair()
     results["PNG"] = (png_orig_size, len(png_repaired), "repair_png_chunks", 0.9)
-    
+
     # JPEG repair
     jpeg_orig_size = 87
     jpeg_repaired = demo_jpeg_repair()
     results["JPEG"] = (jpeg_orig_size, len(jpeg_repaired), "repair_jpeg_markers", 0.85)
-    
+
     # ZIP repair
     zip_orig_size = 51
     zip_repaired = demo_zip_repair()
     results["ZIP"] = (zip_orig_size, len(zip_repaired), "repair_zip_directory", 0.5)
-    
+
     # PDF repair
     pdf_orig_size = 104
     pdf_repaired = demo_pdf_repair()
     results["PDF"] = (pdf_orig_size, len(pdf_repaired), "repair_pdf_xref", 0.5)
-    
+
     # Show summary
     console.print("\n")
     console.print(create_summary_table(results))
-    
+
     console.print("\n[bold green]All repairs completed successfully![/bold green]")
-    console.print("\n[dim]Note: Repaired files are functional but may have reduced functionality "
-                  "compared to the original uncorrupted files.[/dim]")
+    console.print(
+        "\n[dim]Note: Repaired files are functional but may have reduced functionality "
+        "compared to the original uncorrupted files.[/dim]"
+    )
 
 
 if __name__ == "__main__":

--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -7,9 +7,9 @@ from filo import Analyzer
 
 def benchmark_analysis():
     print("=== Performance Benchmark ===\n")
-    
+
     analyzer = Analyzer(use_ml=False)
-    
+
     test_files = {
         "PNG (small)": bytes.fromhex("89504E470D0A1A0A0000000D49484452") + b"\x00" * 1000,
         "JPEG": bytes.fromhex("FFD8FFE0") + b"\x00" * 5000,
@@ -18,58 +18,58 @@ def benchmark_analysis():
         "ELF": bytes.fromhex("7F454C46") + b"\x00" * 8000,
         "Random": bytes([random.randint(0, 255) for _ in range(50000)]),
     }
-    
+
     print(f"Testing {len(test_files)} different file types...\n")
-    
+
     total_time = 0
     for name, data in test_files.items():
         start = time.perf_counter()
         for _ in range(100):
             result = analyzer.analyze(data)
         end = time.perf_counter()
-        
+
         avg_time = (end - start) / 100 * 1000
-        total_time += (end - start)
-        
+        total_time += end - start
+
         print(f"{name:20s} | {result.primary_format:10s} | {avg_time:6.2f} ms/file")
-    
+
     print(f"\nTotal: {total_time*10:.2f} ms for 600 analyses")
     print(f"Average: {total_time/6*1000:.2f} ms per analysis")
 
 
 def benchmark_ml_learning():
     print("\n\n=== ML Learning Benchmark ===\n")
-    
+
     analyzer = Analyzer(use_ml=True)
-    
+
     png_data = bytes.fromhex("89504E470D0A1A0A0000000D49484452") + b"\x00" * 1000
-    
+
     print("Teaching 10 examples...")
     start = time.perf_counter()
     for i in range(10):
         analyzer.teach(png_data, "png")
     end = time.perf_counter()
-    
+
     print(f"Learning time: {(end-start)*1000:.2f} ms for 10 examples")
     print(f"Average: {(end-start)/10*1000:.2f} ms per example")
-    
+
     print("\nPrediction with ML...")
     start = time.perf_counter()
     for _ in range(100):
         result = analyzer.analyze(png_data)
     end = time.perf_counter()
-    
+
     print(f"Prediction time: {(end-start)/100*1000:.2f} ms per analysis")
     print(f"Confidence: {result.confidence:.1%}")
 
 
 def benchmark_large_file():
     print("\n\n=== Large File Handling ===\n")
-    
+
     import tempfile
-    
+
     analyzer = Analyzer(use_ml=False)
-    
+
     sizes = [
         ("1 KB", 1024),
         ("10 KB", 10 * 1024),
@@ -77,19 +77,19 @@ def benchmark_large_file():
         ("1 MB", 1024 * 1024),
         ("10 MB", 10 * 1024 * 1024),
     ]
-    
+
     for name, size in sizes:
         with tempfile.NamedTemporaryFile(delete=False) as f:
             f.write(bytes.fromhex("89504E470D0A1A0A"))
             f.write(b"\x00" * (size - 8))
             temp_path = f.name
-        
+
         start = time.perf_counter()
         result = analyzer.analyze_file(temp_path)
         end = time.perf_counter()
-        
+
         Path(temp_path).unlink()
-        
+
         print(f"{name:10s} | {result.primary_format:10s} | {(end-start)*1000:6.2f} ms")
 
 

--- a/examples/carving_demo.py
+++ b/examples/carving_demo.py
@@ -10,21 +10,21 @@ from pathlib import Path
 
 def demo_basic_carving():
     print("=== Basic File Carving ===\n")
-    
+
     carver = CarverEngine()
-    
+
     png = bytes.fromhex("89504E470D0A1A0A") + b"\x00" * 1000 + b"IEND\xae\x42\x60\x82"
     jpeg = bytes.fromhex("FFD8FFE000104A4649460001") + b"\x00" * 500 + b"\xff\xd9"
-    
+
     junk_data = b"\xff" * 100
     combined = junk_data + png + junk_data + jpeg + junk_data
-    
+
     print(f"Searching {len(combined)} bytes for embedded files...")
-    
+
     carved = carver.carve_data(combined, min_size=100)
-    
+
     print(f"\nFound {len(carved)} embedded files:\n")
-    
+
     for i, file in enumerate(carved):
         print(f"  File {i+1}:")
         print(f"    Offset:     0x{file.offset:08x}")
@@ -36,60 +36,60 @@ def demo_basic_carving():
 
 def demo_stream_carving():
     print("\n=== Stream Carving (Network Capture) ===\n")
-    
+
     stream = StreamCarver(buffer_size=2048)
-    
+
     png = bytes.fromhex("89504E470D0A1A0A") + b"\x00" * 500 + b"IEND\xae\x42\x60\x82"
-    
+
     chunk1 = b"\x00" * 100 + png[:300]
     chunk2 = png[300:600]
     chunk3 = png[600:] + b"\x00" * 100
-    
+
     print("Processing stream in 3 chunks...")
-    
+
     result1 = stream.feed(chunk1)
     print(f"  Chunk 1 ({len(chunk1)} bytes): {len(result1)} files carved")
-    
+
     result2 = stream.feed(chunk2)
     print(f"  Chunk 2 ({len(chunk2)} bytes): {len(result2)} files carved")
-    
+
     result3 = stream.feed(chunk3)
     print(f"  Chunk 3 ({len(chunk3)} bytes): {len(result3)} files carved")
-    
+
     final = stream.finalize()
     print(f"  Finalize: {len(final)} files carved")
-    
+
     all_files = result1 + result2 + result3 + final
     print(f"\nTotal files carved from stream: {len(all_files)}")
-    
+
     for file in all_files:
         print(f"  - {file.format.upper()} ({file.size:,} bytes, {file.confidence:.0%} confidence)")
 
 
 def demo_file_carving():
     print("\n=== File Carving from Disk ===\n")
-    
+
     import tempfile
-    
+
     png1 = bytes.fromhex("89504E470D0A1A0A") + b"\x00" * 800 + b"IEND\xae\x42\x60\x82"
     png2 = bytes.fromhex("89504E470D0A1A0A") + b"\x00" * 600 + b"IEND\xae\x42\x60\x82"
-    
+
     disk_image = b"\x00" * 512 + png1 + b"\xff" * 200 + png2 + b"\x00" * 512
-    
+
     with tempfile.NamedTemporaryFile(delete=False, suffix=".dd") as f:
         f.write(disk_image)
         temp_path = Path(f.name)
-    
+
     print(f"Created disk image: {temp_path}")
     print(f"Size: {temp_path.stat().st_size:,} bytes\n")
-    
+
     carver = CarverEngine()
     carved = carver.carve_file(temp_path, min_size=500)
-    
+
     print(f"Carved {len(carved)} files:")
     for i, file in enumerate(carved):
         print(f"  {i+1}. {file.format.upper()} at offset 0x{file.offset:08x} ({file.size:,} bytes)")
-    
+
     temp_path.unlink()
     print(f"\nCleaned up {temp_path}")
 

--- a/examples/confidence_breakdown_demo.py
+++ b/examples/confidence_breakdown_demo.py
@@ -17,43 +17,51 @@ def demo_docx_detection():
     print("=" * 70)
     print("Demo 1: DOCX Detection with Container Analysis")
     print("=" * 70)
-    
+
     # Create a minimal DOCX structure
     zip_buffer = io.BytesIO()
-    with zipfile.ZipFile(zip_buffer, 'w', zipfile.ZIP_DEFLATED) as zf:
-        zf.writestr('[Content_Types].xml', 
-                   '<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"></Types>')
-        zf.writestr('word/document.xml', 
-                   '<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"></w:document>')
-        zf.writestr('_rels/.rels', 
-                   '<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"></Relationships>')
-        zf.writestr('docProps/core.xml',
-                   '<?xml version="1.0"?><cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties"></cp:coreProperties>')
-    
+    with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(
+            "[Content_Types].xml",
+            '<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"></Types>',
+        )
+        zf.writestr(
+            "word/document.xml",
+            '<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"></w:document>',
+        )
+        zf.writestr(
+            "_rels/.rels",
+            '<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"></Relationships>',
+        )
+        zf.writestr(
+            "docProps/core.xml",
+            '<?xml version="1.0"?><cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties"></cp:coreProperties>',
+        )
+
     analyzer = Analyzer(use_ml=False)
     result = analyzer.analyze(zip_buffer.getvalue())
-    
+
     print(f"\nDetected Format: {result.primary_format.upper()}")
     print(f"Confidence: {result.confidence:.1%}\n")
-    
+
     print("Confidence Breakdown:")
     print("-" * 70)
-    
+
     # Display contributions for primary format
     for evidence in result.evidence_chain:
         if evidence["format"] == result.primary_format and "contributions" in evidence:
             module = evidence["module"]
             module_weight = evidence.get("weight", 1.0)
-            
+
             module_names = {
                 "signature_analysis": "Signature",
                 "structural_analysis": "Structure",
                 "zip_container_analysis": "ZIP Container",
-                "ml_prediction": "ML"
+                "ml_prediction": "ML",
             }
-            
+
             print(f"\n{module_names.get(module, module)}:")
-            
+
             for contrib in evidence["contributions"]:
                 # Apply module weighting
                 if module == "signature_analysis":
@@ -64,10 +72,10 @@ def demo_docx_detection():
                     weighted = contrib["value"] * module_weight * 0.8
                 else:
                     weighted = contrib["value"]
-                
+
                 sign = "-" if contrib.get("is_penalty", False) else "+"
                 print(f"  {sign}{weighted:>5.1%}  {contrib['description']}")
-    
+
     print("\n")
 
 
@@ -76,34 +84,34 @@ def demo_corrupted_jpeg():
     print("=" * 70)
     print("Demo 2: Corrupted JPEG with Fallback Signature Detection")
     print("=" * 70)
-    
+
     # Create a corrupted JPEG (magic bytes corrupted, but JFIF marker present)
-    corrupted_jpeg = bytes.fromhex('5c78ffd8ffe000104a46494600') + b'\xff\xdb' + b'\x00' * 100
-    
+    corrupted_jpeg = bytes.fromhex("5c78ffd8ffe000104a46494600") + b"\xff\xdb" + b"\x00" * 100
+
     analyzer = Analyzer(use_ml=False)
     result = analyzer.analyze(corrupted_jpeg)
-    
+
     print(f"\nDetected Format: {result.primary_format.upper()}")
     print(f"Confidence: {result.confidence:.1%}\n")
-    
+
     print("Confidence Breakdown:")
     print("-" * 70)
-    
+
     # Display contributions
     for evidence in result.evidence_chain:
         if evidence["format"] == result.primary_format and "contributions" in evidence:
             module = evidence["module"]
             module_weight = evidence.get("weight", 1.0)
-            
+
             module_names = {
                 "signature_analysis": "Signature",
                 "structural_analysis": "Structure",
                 "zip_container_analysis": "ZIP Container",
-                "ml_prediction": "ML"
+                "ml_prediction": "ML",
             }
-            
+
             print(f"\n{module_names.get(module, module)}:")
-            
+
             for contrib in evidence["contributions"]:
                 # Apply module weighting
                 if module == "signature_analysis":
@@ -114,10 +122,10 @@ def demo_corrupted_jpeg():
                     weighted = contrib["value"] * module_weight * 0.8
                 else:
                     weighted = contrib["value"]
-                
+
                 sign = "-" if contrib.get("is_penalty", False) else "+"
                 print(f"  {sign}{weighted:>5.1%}  {contrib['description']}")
-    
+
     print("\n" + "=" * 70)
     print("Note: Fallback signatures allow detection of corrupted files!")
     print("=" * 70 + "\n")
@@ -128,36 +136,36 @@ def demo_with_penalties():
     print("=" * 70)
     print("Demo 3: PNG with Missing Structure (Penalties)")
     print("=" * 70)
-    
+
     # Create PNG with valid signature but incomplete structure
     png_header = bytes.fromhex("89504E470D0A1A0A")  # PNG signature
     png_ihdr_start = bytes.fromhex("0000000D49484452")  # Partial IHDR
     incomplete_png = png_header + png_ihdr_start
-    
+
     analyzer = Analyzer(use_ml=False)
     result = analyzer.analyze(incomplete_png)
-    
+
     print(f"\nDetected Format: {result.primary_format.upper()}")
     print(f"Confidence: {result.confidence:.1%}\n")
-    
+
     print("Confidence Breakdown:")
     print("-" * 70)
-    
+
     # Display contributions including penalties
     for evidence in result.evidence_chain:
         if evidence["format"] == result.primary_format and "contributions" in evidence:
             module = evidence["module"]
             module_weight = evidence.get("weight", 1.0)
-            
+
             module_names = {
                 "signature_analysis": "Signature",
                 "structural_analysis": "Structure",
                 "zip_container_analysis": "ZIP Container",
-                "ml_prediction": "ML"
+                "ml_prediction": "ML",
             }
-            
+
             print(f"\n{module_names.get(module, module)}:")
-            
+
             for contrib in evidence["contributions"]:
                 # Apply module weighting
                 if module == "signature_analysis":
@@ -168,12 +176,12 @@ def demo_with_penalties():
                     weighted = contrib["value"] * module_weight * 0.8
                 else:
                     weighted = contrib["value"]
-                
+
                 sign = "-" if contrib.get("is_penalty", False) else "+"
                 color = "\033[91m" if contrib.get("is_penalty") else "\033[92m"
                 reset = "\033[0m"
                 print(f"  {color}{sign}{weighted:>5.1%}{reset}  {contrib['description']}")
-    
+
     print("\n")
 
 
@@ -182,22 +190,23 @@ def demo_json_output():
     print("=" * 70)
     print("Demo 4: JSON Output with Confidence Breakdown")
     print("=" * 70)
-    
+
     # Create a simple PNG
     png_data = bytes.fromhex("89504E470D0A1A0A0000000D494844520000001000000010080200000090916836")
-    
+
     analyzer = Analyzer(use_ml=False)
     result = analyzer.analyze(png_data)
-    
+
     print("\nSample evidence chain entry (JSON):\n")
-    
+
     # Show first evidence item with contributions
     for evidence in result.evidence_chain:
         if "contributions" in evidence and len(evidence["contributions"]) > 0:
             import json
+
             print(json.dumps(evidence, indent=2))
             break
-    
+
     print("\nThis structure is perfect for:")
     print("  • Automated analysis pipelines")
     print("  • Court documentation")
@@ -211,12 +220,12 @@ if __name__ == "__main__":
     print("║" + " " * 15 + "FILO CONFIDENCE BREAKDOWN DEMO" + " " * 23 + "║")
     print("╚" + "=" * 68 + "╝")
     print("\nMaking detection decisions auditable and transparent\n")
-    
+
     demo_docx_detection()
     demo_corrupted_jpeg()
     demo_with_penalties()
     demo_json_output()
-    
+
     print("=" * 70)
     print("CLI Usage:")
     print("=" * 70)

--- a/examples/contradiction_demo.py
+++ b/examples/contradiction_demo.py
@@ -32,106 +32,116 @@ def create_demo_files():
     """Create demonstration files in /tmp directory"""
     demo_dir = Path("/tmp/filo_contradiction_demos")
     demo_dir.mkdir(exist_ok=True)
-    
+
     # 1. PNG with invalid compression
     png_invalid = demo_dir / "corrupted.png"
     png_data = (
-        b'\x89PNG\r\n\x1a\n'  # PNG signature
-        b'\x00\x00\x00\x0dIHDR'  # IHDR chunk
-        b'\x00\x00\x00\x10\x00\x00\x00\x10\x08\x02\x00\x00\x00'  # IHDR data
-        b'\x90\x91\x68\x36'  # CRC
-        b'\x00\x00\x00\x0cIDAT'  # IDAT chunk
-        b'INVALID_ZLIB'  # Invalid zlib data
-        b'\x00\x00\x00\x00'  # CRC
-        b'\x00\x00\x00\x00IEND'  # IEND chunk
-        b'\xae\x42\x60\x82'  # CRC
+        b"\x89PNG\r\n\x1a\n"  # PNG signature
+        b"\x00\x00\x00\x0dIHDR"  # IHDR chunk
+        b"\x00\x00\x00\x10\x00\x00\x00\x10\x08\x02\x00\x00\x00"  # IHDR data
+        b"\x90\x91\x68\x36"  # CRC
+        b"\x00\x00\x00\x0cIDAT"  # IDAT chunk
+        b"INVALID_ZLIB"  # Invalid zlib data
+        b"\x00\x00\x00\x00"  # CRC
+        b"\x00\x00\x00\x00IEND"  # IEND chunk
+        b"\xae\x42\x60\x82"  # CRC
     )
     png_invalid.write_bytes(png_data)
-    
+
     # 2. DOCX missing _rels/.rels
     docx_malformed = demo_dir / "malformed.docx"
-    with zipfile.ZipFile(docx_malformed, 'w') as zf:
-        zf.writestr('[Content_Types].xml', '<?xml version="1.0"?><Types/>')
-        zf.writestr('word/document.xml', '<?xml version="1.0"?><document/>')
+    with zipfile.ZipFile(docx_malformed, "w") as zf:
+        zf.writestr("[Content_Types].xml", '<?xml version="1.0"?><Types/>')
+        zf.writestr("word/document.xml", '<?xml version="1.0"?><document/>')
         # Missing _rels/.rels - will trigger warning
-    
+
     # 3. DOCX with embedded ELF executable
     docx_malicious = demo_dir / "malicious.docx"
-    elf_payload = b'\x7fELF\x02\x01\x01\x00' + b'\x00' * 56  # ELF header
-    with zipfile.ZipFile(docx_malicious, 'w') as zf:
-        zf.writestr('[Content_Types].xml', '<?xml version="1.0"?><Types/>')
-        zf.writestr('_rels/.rels', '<?xml version="1.0"?><Relationships/>')
-        zf.writestr('word/document.xml', '<?xml version="1.0"?><document/>')
-        zf.writestr('word/media/exploit.dll', elf_payload)  # Embedded ELF
-    
+    elf_payload = b"\x7fELF\x02\x01\x01\x00" + b"\x00" * 56  # ELF header
+    with zipfile.ZipFile(docx_malicious, "w") as zf:
+        zf.writestr("[Content_Types].xml", '<?xml version="1.0"?><Types/>')
+        zf.writestr("_rels/.rels", '<?xml version="1.0"?><Relationships/>')
+        zf.writestr("word/document.xml", '<?xml version="1.0"?><document/>')
+        zf.writestr("word/media/exploit.dll", elf_payload)  # Embedded ELF
+
     # 4. DOCX with embedded PE executable
     docx_pe = demo_dir / "suspicious.docx"
-    pe_payload = b'MZ\x90\x00' + b'\x00' * 60 + b'PE\x00\x00'  # PE header
-    with zipfile.ZipFile(docx_pe, 'w') as zf:
-        zf.writestr('[Content_Types].xml', '<?xml version="1.0"?><Types/>')
-        zf.writestr('_rels/.rels', '<?xml version="1.0"?><Relationships/>')
-        zf.writestr('word/document.xml', '<?xml version="1.0"?><document/>')
-        zf.writestr('word/media/payload.exe', pe_payload)  # Embedded PE
-    
+    pe_payload = b"MZ\x90\x00" + b"\x00" * 60 + b"PE\x00\x00"  # PE header
+    with zipfile.ZipFile(docx_pe, "w") as zf:
+        zf.writestr("[Content_Types].xml", '<?xml version="1.0"?><Types/>')
+        zf.writestr("_rels/.rels", '<?xml version="1.0"?><Relationships/>')
+        zf.writestr("word/document.xml", '<?xml version="1.0"?><document/>')
+        zf.writestr("word/media/payload.exe", pe_payload)  # Embedded PE
+
     # 5. ZIP with shell script
     zip_script = demo_dir / "weaponized.zip"
-    script_payload = b'#!/bin/bash\nrm -rf /'  # Malicious script
-    with zipfile.ZipFile(zip_script, 'w') as zf:
-        zf.writestr('data.txt', 'Normal content')
-        zf.writestr('scripts/install.sh', script_payload)  # Embedded script
-    
+    script_payload = b"#!/bin/bash\nrm -rf /"  # Malicious script
+    with zipfile.ZipFile(zip_script, "w") as zf:
+        zf.writestr("data.txt", "Normal content")
+        zf.writestr("scripts/install.sh", script_payload)  # Embedded script
+
     # 6. PDF missing EOF
     pdf_truncated = demo_dir / "truncated.pdf"
     pdf_data = (
-        b'%PDF-1.4\n'
-        b'1 0 obj\n<< /Type /Catalog >>\nendobj\n'
-        b'xref\n0 1\n'
+        b"%PDF-1.4\n"
+        b"1 0 obj\n<< /Type /Catalog >>\nendobj\n"
+        b"xref\n0 1\n"
         # Missing %%EOF
     )
     pdf_truncated.write_bytes(pdf_data)
-    
+
     # 7. JPEG missing SOS marker
     jpeg_incomplete = demo_dir / "incomplete.jpg"
     jpeg_data = (
-        b'\xff\xd8'  # JPEG SOI
-        b'\xff\xc0\x00\x11\x08\x00\x10\x00\x10\x03\x01\x22\x00\x02\x11\x01\x03\x11\x01'  # SOF
+        b"\xff\xd8"  # JPEG SOI
+        b"\xff\xc0\x00\x11\x08\x00\x10\x00\x10\x03\x01\x22\x00\x02\x11\x01\x03\x11\x01"  # SOF
         # Missing SOS marker
-        b'\xff\xd9'  # JPEG EOI
+        b"\xff\xd9"  # JPEG EOI
     )
     jpeg_incomplete.write_bytes(jpeg_data)
-    
+
     # 8. Valid PNG (no contradictions)
     png_valid = demo_dir / "valid.png"
     import zlib
-    width_height = b'\x00\x00\x00\x10' * 2  # 16x16 pixels
-    ihdr_data = width_height + b'\x08\x02\x00\x00\x00'  # RGB, no interlace
-    ihdr_crc = b'\x90\x91\x68\x36'  # Pre-calculated
-    
+
+    width_height = b"\x00\x00\x00\x10" * 2  # 16x16 pixels
+    ihdr_data = width_height + b"\x08\x02\x00\x00\x00"  # RGB, no interlace
+    ihdr_crc = b"\x90\x91\x68\x36"  # Pre-calculated
+
     # Create valid IDAT with zlib compression
-    raw_image = b'\x00' + (b'\x00' * 16 * 3) * 16  # Blank 16x16 RGB
+    raw_image = b"\x00" + (b"\x00" * 16 * 3) * 16  # Blank 16x16 RGB
     compressed = zlib.compress(raw_image)
-    idat_crc = b'\x00\x00\x00\x00'  # Simplified
-    
+    idat_crc = b"\x00\x00\x00\x00"  # Simplified
+
     png_valid_data = (
-        b'\x89PNG\r\n\x1a\n'
-        b'\x00\x00\x00\x0dIHDR' + ihdr_data + ihdr_crc +
-        bytes([len(compressed) >> 24, len(compressed) >> 16 & 0xff,
-               len(compressed) >> 8 & 0xff, len(compressed) & 0xff]) +
-        b'IDAT' + compressed + idat_crc +
-        b'\x00\x00\x00\x00IEND\xae\x42\x60\x82'
+        b"\x89PNG\r\n\x1a\n"
+        b"\x00\x00\x00\x0dIHDR"
+        + ihdr_data
+        + ihdr_crc
+        + bytes(
+            [
+                len(compressed) >> 24,
+                len(compressed) >> 16 & 0xFF,
+                len(compressed) >> 8 & 0xFF,
+                len(compressed) & 0xFF,
+            ]
+        )
+        + b"IDAT"
+        + compressed
+        + idat_crc
+        + b"\x00\x00\x00\x00IEND\xae\x42\x60\x82"
     )
     png_valid.write_bytes(png_valid_data)
-    
+
     return demo_dir
 
 
 def display_header(title: str, description: str):
     """Display a formatted section header"""
     console.print()
-    console.print(Panel(
-        f"[bold cyan]{title}[/bold cyan]\n[dim]{description}[/dim]",
-        border_style="cyan"
-    ))
+    console.print(
+        Panel(f"[bold cyan]{title}[/bold cyan]\n[dim]{description}[/dim]", border_style="cyan")
+    )
 
 
 def display_contradictions(contradictions: list[Contradiction]):
@@ -139,30 +149,25 @@ def display_contradictions(contradictions: list[Contradiction]):
     if not contradictions:
         console.print("[green]✓ No contradictions detected[/green]\n")
         return
-    
+
     console.print(f"\n[yellow]⚠ {len(contradictions)} Contradiction(s) Detected:[/yellow]\n")
-    
+
     table = Table(show_header=True, header_style="bold magenta", border_style="dim")
     table.add_column("Severity", style="bold", width=10)
     table.add_column("Issue", width=40)
     table.add_column("Details", width=50)
     table.add_column("Category", width=12)
-    
+
     for c in contradictions:
         # Color coding by severity
         severity_style = {
             "warning": "[yellow]⚠ WARNING[/yellow]",
             "error": "[orange3]⚠ ERROR[/orange3]",
-            "critical": "[red]🚨 CRITICAL[/red]"
+            "critical": "[red]🚨 CRITICAL[/red]",
         }.get(c.severity, c.severity.upper())
-        
-        table.add_row(
-            severity_style,
-            c.issue,
-            c.details,
-            c.category
-        )
-    
+
+        table.add_row(severity_style, c.issue, c.details, c.category)
+
     console.print(table)
     console.print()
 
@@ -171,23 +176,29 @@ def demo_1_png_corruption():
     """Demo 1: PNG with invalid compression"""
     display_header(
         "Demo 1: PNG Compression Validation",
-        "Detects PNG files with invalid zlib compression (corruption or steganography)"
+        "Detects PNG files with invalid zlib compression (corruption or steganography)",
     )
-    
+
     demo_dir = Path("/tmp/filo_contradiction_demos")
     file_path = demo_dir / "corrupted.png"
-    
+
     console.print(f"[bold]Analyzing:[/bold] {file_path}")
-    console.print("[dim]File has PNG signature and IHDR chunk, but IDAT contains invalid zlib data[/dim]\n")
-    
+    console.print(
+        "[dim]File has PNG signature and IHDR chunk, but IDAT contains invalid zlib data[/dim]\n"
+    )
+
     analyzer = Analyzer()
     result = analyzer.analyze_file(file_path)
-    
-    console.print(f"[bold]Detected Format:[/bold] {result.primary_format} ({result.confidence:.1f}% confidence)")
-    console.print(f"[bold]Evidence:[/bold] {', '.join(str(e.get('module', '')) for e in result.evidence_chain[:2])}")
-    
+
+    console.print(
+        f"[bold]Detected Format:[/bold] {result.primary_format} ({result.confidence:.1f}% confidence)"
+    )
+    console.print(
+        f"[bold]Evidence:[/bold] {', '.join(str(e.get('module', '')) for e in result.evidence_chain[:2])}"
+    )
+
     display_contradictions(result.contradictions)
-    
+
     console.print("[cyan]💡 Interpretation:[/cyan]")
     console.print("  - PNG structure is valid (signature + IHDR)")
     console.print("  - Compression stream is corrupted or intentionally malformed")
@@ -199,81 +210,97 @@ def demo_2_ooxml_structure():
     """Demo 2: DOCX with missing mandatory files"""
     display_header(
         "Demo 2: OOXML Structure Validation",
-        "Detects Office documents missing mandatory relationship files"
+        "Detects Office documents missing mandatory relationship files",
     )
-    
+
     demo_dir = Path("/tmp/filo_contradiction_demos")
     file_path = demo_dir / "malformed.docx"
-    
+
     console.print(f"[bold]Analyzing:[/bold] {file_path}")
     console.print("[dim]DOCX file missing required '_rels/.rels' file[/dim]\n")
-    
+
     analyzer = Analyzer()
     result = analyzer.analyze_file(file_path)
-    
-    console.print(f"[bold]Detected Format:[/bold] {result.primary_format} ({result.confidence:.1f}% confidence)")
-    console.print(f"[bold]Evidence:[/bold] {', '.join(str(e.get('module', '')) for e in result.evidence_chain[:2])}")
-    
+
+    console.print(
+        f"[bold]Detected Format:[/bold] {result.primary_format} ({result.confidence:.1f}% confidence)"
+    )
+    console.print(
+        f"[bold]Evidence:[/bold] {', '.join(str(e.get('module', '')) for e in result.evidence_chain[:2])}"
+    )
+
     display_contradictions(result.contradictions)
-    
+
     console.print("[cyan]💡 Interpretation:[/cyan]")
     console.print("  - File is valid ZIP and contains OOXML markers")
     console.print("  - Missing '_rels/.rels' - required for all Office Open XML files")
     console.print("  - Could indicate: manual ZIP creation, incomplete extraction, or malware")
-    console.print("  - [yellow]Action: Verify file origin, check if intentionally crafted[/yellow]\n")
+    console.print(
+        "  - [yellow]Action: Verify file origin, check if intentionally crafted[/yellow]\n"
+    )
 
 
 def demo_3_embedded_elf():
     """Demo 3: DOCX with embedded ELF executable"""
     display_header(
         "Demo 3: Embedded Executable Detection (ELF)",
-        "Detects Linux executables hidden in Office documents - CRITICAL malware indicator"
+        "Detects Linux executables hidden in Office documents - CRITICAL malware indicator",
     )
-    
+
     demo_dir = Path("/tmp/filo_contradiction_demos")
     file_path = demo_dir / "malicious.docx"
-    
+
     console.print(f"[bold]Analyzing:[/bold] {file_path}")
     console.print("[dim]DOCX file contains embedded ELF executable in ZIP member[/dim]\n")
-    
+
     analyzer = Analyzer()
     result = analyzer.analyze_file(file_path)
-    
-    console.print(f"[bold]Detected Format:[/bold] {result.primary_format} ({result.confidence:.1f}% confidence)")
-    console.print(f"[bold]Evidence:[/bold] {', '.join(str(e.get('module', '')) for e in result.evidence_chain[:2])}")
-    
+
+    console.print(
+        f"[bold]Detected Format:[/bold] {result.primary_format} ({result.confidence:.1f}% confidence)"
+    )
+    console.print(
+        f"[bold]Evidence:[/bold] {', '.join(str(e.get('module', '')) for e in result.evidence_chain[:2])}"
+    )
+
     display_contradictions(result.contradictions)
-    
+
     console.print("[red][bold]🚨 CRITICAL ALERT[/bold][/red]")
     console.print("[cyan]💡 Interpretation:[/cyan]")
     console.print("  - Legitimate Office documents NEVER contain executable binaries")
     console.print("  - ELF signature detected in ZIP member 'word/media/exploit.dll'")
     console.print("  - [red][bold]HIGH PROBABILITY OF MALWARE[/bold][/red]")
     console.print("  - Could be: payload, dropper, or APT technique")
-    console.print("  - [red][bold]Action: QUARANTINE IMMEDIATELY - Full malware analysis required[/bold][/red]\n")
+    console.print(
+        "  - [red][bold]Action: QUARANTINE IMMEDIATELY - Full malware analysis required[/bold][/red]\n"
+    )
 
 
 def demo_4_embedded_pe():
     """Demo 4: DOCX with embedded PE executable"""
     display_header(
         "Demo 4: Embedded Executable Detection (PE)",
-        "Detects Windows executables hidden in Office documents"
+        "Detects Windows executables hidden in Office documents",
     )
-    
+
     demo_dir = Path("/tmp/filo_contradiction_demos")
     file_path = demo_dir / "suspicious.docx"
-    
+
     console.print(f"[bold]Analyzing:[/bold] {file_path}")
     console.print("[dim]DOCX file contains embedded PE/DOS executable[/dim]\n")
-    
+
     analyzer = Analyzer()
     result = analyzer.analyze_file(file_path)
-    
-    console.print(f"[bold]Detected Format:[/bold] {result.primary_format} ({result.confidence:.1f}% confidence)")
-    console.print(f"[bold]Evidence:[/bold] {', '.join(str(e.get('module', '')) for e in result.evidence_chain[:2])}")
-    
+
+    console.print(
+        f"[bold]Detected Format:[/bold] {result.primary_format} ({result.confidence:.1f}% confidence)"
+    )
+    console.print(
+        f"[bold]Evidence:[/bold] {', '.join(str(e.get('module', '')) for e in result.evidence_chain[:2])}"
+    )
+
     display_contradictions(result.contradictions)
-    
+
     console.print("[red][bold]🚨 CRITICAL ALERT[/bold][/red]")
     console.print("[cyan]💡 Interpretation:[/cyan]")
     console.print("  - PE (Portable Executable) signature detected")
@@ -284,25 +311,26 @@ def demo_4_embedded_pe():
 
 def demo_5_embedded_script():
     """Demo 5: ZIP with embedded shell script"""
-    display_header(
-        "Demo 5: Embedded Script Detection",
-        "Detects shell scripts in archive files"
-    )
-    
+    display_header("Demo 5: Embedded Script Detection", "Detects shell scripts in archive files")
+
     demo_dir = Path("/tmp/filo_contradiction_demos")
     file_path = demo_dir / "weaponized.zip"
-    
+
     console.print(f"[bold]Analyzing:[/bold] {file_path}")
     console.print("[dim]ZIP file contains shell script with suspicious shebang[/dim]\n")
-    
+
     analyzer = Analyzer()
     result = analyzer.analyze_file(file_path)
-    
-    console.print(f"[bold]Detected Format:[/bold] {result.primary_format} ({result.confidence:.1f}% confidence)")
-    console.print(f"[bold]Evidence:[/bold] {', '.join(str(e.get('module', '')) for e in result.evidence_chain[:2])}")
-    
+
+    console.print(
+        f"[bold]Detected Format:[/bold] {result.primary_format} ({result.confidence:.1f}% confidence)"
+    )
+    console.print(
+        f"[bold]Evidence:[/bold] {', '.join(str(e.get('module', '')) for e in result.evidence_chain[:2])}"
+    )
+
     display_contradictions(result.contradictions)
-    
+
     console.print("[cyan]💡 Interpretation:[/cyan]")
     console.print("  - Bash script detected in ZIP archive")
     console.print("  - Shell scripts can be legitimate (installers, automation)")
@@ -314,25 +342,26 @@ def demo_5_embedded_script():
 
 def demo_6_pdf_truncation():
     """Demo 6: PDF missing EOF marker"""
-    display_header(
-        "Demo 6: PDF Structure Validation",
-        "Detects truncated or incomplete PDF files"
-    )
-    
+    display_header("Demo 6: PDF Structure Validation", "Detects truncated or incomplete PDF files")
+
     demo_dir = Path("/tmp/filo_contradiction_demos")
     file_path = demo_dir / "truncated.pdf"
-    
+
     console.print(f"[bold]Analyzing:[/bold] {file_path}")
     console.print("[dim]PDF file missing required '%%EOF' marker[/dim]\n")
-    
+
     analyzer = Analyzer()
     result = analyzer.analyze_file(file_path)
-    
-    console.print(f"[bold]Detected Format:[/bold] {result.primary_format} ({result.confidence:.1f}% confidence)")
-    console.print(f"[bold]Evidence:[/bold] {', '.join(str(e.get('module', '')) for e in result.evidence_chain[:2])}")
-    
+
+    console.print(
+        f"[bold]Detected Format:[/bold] {result.primary_format} ({result.confidence:.1f}% confidence)"
+    )
+    console.print(
+        f"[bold]Evidence:[/bold] {', '.join(str(e.get('module', '')) for e in result.evidence_chain[:2])}"
+    )
+
     display_contradictions(result.contradictions)
-    
+
     console.print("[cyan]💡 Interpretation:[/cyan]")
     console.print("  - PDF signature present but structure incomplete")
     console.print("  - Missing '%%EOF' indicates file truncation")
@@ -343,24 +372,27 @@ def demo_6_pdf_truncation():
 def demo_7_jpeg_incomplete():
     """Demo 7: JPEG missing SOS marker"""
     display_header(
-        "Demo 7: JPEG Structure Validation",
-        "Detects JPEG files with incomplete marker sequence"
+        "Demo 7: JPEG Structure Validation", "Detects JPEG files with incomplete marker sequence"
     )
-    
+
     demo_dir = Path("/tmp/filo_contradiction_demos")
     file_path = demo_dir / "incomplete.jpg"
-    
+
     console.print(f"[bold]Analyzing:[/bold] {file_path}")
     console.print("[dim]JPEG has SOF (Start of Frame) but missing SOS (Start of Scan)[/dim]\n")
-    
+
     analyzer = Analyzer()
     result = analyzer.analyze_file(file_path)
-    
-    console.print(f"[bold]Detected Format:[/bold] {result.primary_format} ({result.confidence:.1f}% confidence)")
-    console.print(f"[bold]Evidence:[/bold] {', '.join(str(e.get('module', '')) for e in result.evidence_chain[:2])}")
-    
+
+    console.print(
+        f"[bold]Detected Format:[/bold] {result.primary_format} ({result.confidence:.1f}% confidence)"
+    )
+    console.print(
+        f"[bold]Evidence:[/bold] {', '.join(str(e.get('module', '')) for e in result.evidence_chain[:2])}"
+    )
+
     display_contradictions(result.contradictions)
-    
+
     console.print("[cyan]💡 Interpretation:[/cyan]")
     console.print("  - JPEG structure started but incomplete")
     console.print("  - SOF marker defines image dimensions")
@@ -372,24 +404,27 @@ def demo_7_jpeg_incomplete():
 def demo_8_valid_file():
     """Demo 8: Valid PNG (no contradictions)"""
     display_header(
-        "Demo 8: Valid File Validation",
-        "Confirms no false positives on correctly formatted files"
+        "Demo 8: Valid File Validation", "Confirms no false positives on correctly formatted files"
     )
-    
+
     demo_dir = Path("/tmp/filo_contradiction_demos")
     file_path = demo_dir / "valid.png"
-    
+
     console.print(f"[bold]Analyzing:[/bold] {file_path}")
     console.print("[dim]Properly formatted PNG with valid zlib compression[/dim]\n")
-    
+
     analyzer = Analyzer()
     result = analyzer.analyze_file(file_path)
-    
-    console.print(f"[bold]Detected Format:[/bold] {result.primary_format} ({result.confidence:.1f}% confidence)")
-    console.print(f"[bold]Evidence:[/bold] {', '.join(str(e.get('module', '')) for e in result.evidence_chain[:2])}")
-    
+
+    console.print(
+        f"[bold]Detected Format:[/bold] {result.primary_format} ({result.confidence:.1f}% confidence)"
+    )
+    console.print(
+        f"[bold]Evidence:[/bold] {', '.join(str(e.get('module', '')) for e in result.evidence_chain[:2])}"
+    )
+
     display_contradictions(result.contradictions)
-    
+
     console.print("[green]✓ File structure is valid and complete[/green]")
     console.print("[cyan]💡 Interpretation:[/cyan]")
     console.print("  - All structural checks passed")
@@ -402,20 +437,21 @@ def demo_9_json_output():
     """Demo 9: JSON output for automation"""
     display_header(
         "Demo 9: JSON Output for Automation",
-        "Shows structured contradiction data for security tools integration"
+        "Shows structured contradiction data for security tools integration",
     )
-    
+
     demo_dir = Path("/tmp/filo_contradiction_demos")
     file_path = demo_dir / "malicious.docx"
-    
+
     console.print(f"[bold]Analyzing:[/bold] {file_path}")
     console.print("[dim]Demonstrating JSON export for automated malware triage[/dim]\n")
-    
+
     analyzer = Analyzer()
     result = analyzer.analyze_file(file_path)
-    
+
     # Convert to JSON-like structure
     import json
+
     json_output = {
         "file": str(file_path),
         "format": result.primary_format,
@@ -424,7 +460,7 @@ def demo_9_json_output():
             {
                 "module": e.get("module", "unknown"),
                 "confidence": e.get("confidence", 0),
-                "evidence": e.get("evidence", [])[:2]  # First 2 evidence items only
+                "evidence": e.get("evidence", [])[:2],  # First 2 evidence items only
             }
             for e in result.evidence_chain[:3]  # First 3 modules only
         ],
@@ -434,20 +470,15 @@ def demo_9_json_output():
                 "claimed_format": c.claimed_format,
                 "issue": c.issue,
                 "details": c.details,
-                "category": c.category
+                "category": c.category,
             }
             for c in result.contradictions
-        ]
+        ],
     }
-    
-    syntax = Syntax(
-        json.dumps(json_output, indent=2),
-        "json",
-        theme="monokai",
-        line_numbers=True
-    )
+
+    syntax = Syntax(json.dumps(json_output, indent=2), "json", theme="monokai", line_numbers=True)
     console.print(syntax)
-    
+
     console.print("\n[cyan]💡 Integration Example:[/cyan]")
     console.print("  [dim]# Filter for critical contradictions[/dim]")
     console.print("  $ filo analyze suspicious.docx --json | \\")
@@ -455,9 +486,9 @@ def demo_9_json_output():
     console.print()
     console.print("  [dim]# Batch scan and quarantine[/dim]")
     console.print("  $ for file in *.docx; do")
-    console.print("      critical=$(filo analyze \"$file\" --json | \\")
+    console.print('      critical=$(filo analyze "$file" --json | \\')
     console.print("                jq '.contradictions[] | select(.severity == \"critical\")')")
-    console.print("      [ -n \"$critical\" ] && mv \"$file\" /quarantine/")
+    console.print('      [ -n "$critical" ] && mv "$file" /quarantine/')
     console.print("    done\n")
 
 
@@ -467,14 +498,16 @@ def main():
     console.print("[bold cyan]  Filo Format Contradiction Detection - Demonstrations [/bold cyan]")
     console.print("[bold cyan]═══════════════════════════════════════════════════════[/bold cyan]")
     console.print()
-    console.print("[dim]This demo shows how Filo detects malware, polyglots, and structural anomalies[/dim]")
+    console.print(
+        "[dim]This demo shows how Filo detects malware, polyglots, and structural anomalies[/dim]"
+    )
     console.print("[dim]for security analysis and malware triage.[/dim]")
-    
+
     # Create demonstration files
     console.print("\n[yellow]Creating demonstration files...[/yellow]")
     demo_dir = create_demo_files()
     console.print(f"[green]✓ Demo files created in: {demo_dir}[/green]")
-    
+
     # Run demonstrations
     demos = [
         demo_1_png_corruption,
@@ -485,60 +518,46 @@ def main():
         demo_6_pdf_truncation,
         demo_7_jpeg_incomplete,
         demo_8_valid_file,
-        demo_9_json_output
+        demo_9_json_output,
     ]
-    
+
     for demo in demos:
         try:
             demo()
         except Exception as e:
             console.print(f"[red]Error in demo: {e}[/red]\n")
-    
+
     # Summary
     console.print("[bold cyan]═══════════════════════════════════════════════════════[/bold cyan]")
     console.print("[bold cyan]  Summary: Contradiction Detection Capabilities        [/bold cyan]")
     console.print("[bold cyan]═══════════════════════════════════════════════════════[/bold cyan]")
     console.print()
-    
+
     summary_table = Table(show_header=True, header_style="bold magenta", border_style="cyan")
     summary_table.add_column("Detection Type", style="bold", width=25)
     summary_table.add_column("Formats", width=30)
     summary_table.add_column("Use Case", width=40)
-    
+
     summary_table.add_row(
-        "Compression Validation",
-        "PNG (zlib streams)",
-        "Detects corruption, steganography"
+        "Compression Validation", "PNG (zlib streams)", "Detects corruption, steganography"
     )
     summary_table.add_row(
         "Structure Validation",
         "OOXML (DOCX/XLSX/PPTX)",
-        "Identifies incomplete/malformed documents"
+        "Identifies incomplete/malformed documents",
     )
     summary_table.add_row(
-        "Embedded Executables",
-        "All ZIP-based formats",
-        "[red]CRITICAL: Malware detection[/red]"
+        "Embedded Executables", "All ZIP-based formats", "[red]CRITICAL: Malware detection[/red]"
     )
     summary_table.add_row(
-        "Embedded Scripts",
-        "ZIP archives",
-        "Security: Identifies executable scripts"
+        "Embedded Scripts", "ZIP archives", "Security: Identifies executable scripts"
     )
-    summary_table.add_row(
-        "PDF Structure",
-        "PDF files",
-        "Detects truncation, corruption"
-    )
-    summary_table.add_row(
-        "JPEG Structure",
-        "JPEG files",
-        "Validates marker sequence"
-    )
-    
+    summary_table.add_row("PDF Structure", "PDF files", "Detects truncation, corruption")
+    summary_table.add_row("JPEG Structure", "JPEG files", "Validates marker sequence")
+
     console.print(summary_table)
     console.print()
-    
+
     console.print("[bold green]✓ All demonstrations complete![/bold green]")
     console.print()
     console.print("[cyan]Next Steps:[/cyan]")

--- a/examples/corrupted_file_demo.py
+++ b/examples/corrupted_file_demo.py
@@ -13,59 +13,56 @@ def demo_corrupted_jpeg_detection():
     print("=" * 70)
     print("Corrupted JPEG Detection Demo")
     print("=" * 70)
-    
+
     analyzer = Analyzer(use_ml=False)  # Disable ML for clearer demonstration
-    
+
     # Case 1: Normal JPEG with proper magic bytes
     print("\n1. Normal JPEG (proper magic bytes):")
     print("   Bytes: FF D8 FF E0 00 10 J F I F ...")
-    
+
     normal_jpeg = bytes.fromhex(
-        "FFD8FFE000104A4649460001010000010001000000"
-        "FFDB004300080606070605080707070909080A0C"
+        "FFD8FFE000104A4649460001010000010001000000" "FFDB004300080606070605080707070909080A0C"
     )
-    
+
     result = analyzer.analyze(normal_jpeg)
     print(f"   → Detected: {result.primary_format}")
     print(f"   → Confidence: {result.confidence:.1%}")
     print(f"   → Evidence: Exact magic byte match at offset 0")
-    
+
     # Case 2: Corrupted JPEG - missing SOI (FF D8) but has JFIF marker
     print("\n2. Corrupted JPEG (missing SOI marker, but JFIF present):")
     print("   Bytes: 5C 78 FF E0 00 10 J F I F ...")
-    
+
     corrupted_jpeg = bytes.fromhex(
-        "5C78FFE000104A4649460001010000010001000000"
-        "FFDB004300080606070605080707070909080A0C"
+        "5C78FFE000104A4649460001010000010001000000" "FFDB004300080606070605080707070909080A0C"
     )
-    
+
     result = analyzer.analyze(corrupted_jpeg)
     print(f"   → Detected: {result.primary_format}")
     print(f"   → Confidence: {result.confidence:.1%}")
-    
+
     if result.evidence_chain:
         print("   → Evidence:")
         for evidence in result.evidence_chain:
             if evidence.get("module") == "signature_analysis":
                 for detail in evidence.get("evidence", []):
                     print(f"      • {detail}")
-    
+
     # Case 3: Heavily corrupted - only quantization table visible
     print("\n3. Heavily corrupted JPEG (only internal markers visible):")
     print("   Bytes: 00 00 00 00 FF DB 00 43 ...")
-    
+
     heavily_corrupted = bytes.fromhex(
-        "00000000FFDB004300080606070605080707070909"
-        "080A0C140D0C0B0B0C1912130F141D1A1F1E1D1A"
+        "00000000FFDB004300080606070605080707070909" "080A0C140D0C0B0B0C1912130F141D1A1F1E1D1A"
     )
-    
+
     result = analyzer.analyze(heavily_corrupted)
     print(f"   → Detected: {result.primary_format}")
     print(f"   → Confidence: {result.confidence:.1%}")
-    
+
     if result.primary_format == "unknown":
         print("   → Note: Too corrupted for reliable detection")
-    
+
     print("\n" + "=" * 70)
     print("Key Takeaways:")
     print("=" * 70)

--- a/examples/embedded_demo.py
+++ b/examples/embedded_demo.py
@@ -16,32 +16,33 @@ Author: Filo Forensics Team
 from filo import Analyzer
 from filo.embedded import EmbeddedDetector
 
+
 def demo_zip_in_exe():
     """Demo: ZIP archive embedded in EXE (malware dropper pattern)."""
-    print("\n" + "="*70)
+    print("\n" + "=" * 70)
     print("DEMO 1: ZIP Inside EXE (Malware Dropper)")
-    print("="*70)
-    
+    print("=" * 70)
+
     # Create fake EXE with embedded ZIP
     exe_header = b"MZ" + b"\x00" * 58
     exe_header += b"\x80\x00\x00\x00"  # PE offset
     exe_padding = b"\x00" * (0x80 - len(exe_header))
     exe_sig = b"PE\x00\x00"
     exe_body = b"\x00" * 1000
-    
+
     # Embedded ZIP at offset 0x500
     zip_data = b"PK\x03\x04\x14\x00\x00\x00\x08\x00" + b"\x00" * 500
-    
+
     malware = exe_header + exe_padding + exe_sig + exe_body + zip_data
-    
+
     # Analyze
     detector = EmbeddedDetector()
     embedded = detector.detect_embedded(malware, skip_primary=True)
-    
+
     print(f"\nFile size: {len(malware):,} bytes")
     print(f"Primary format: PE")
     print(f"\n🔍 Embedded Artifacts Found: {len(embedded)}")
-    
+
     for obj in embedded:
         print(f"\n  • {obj.format.upper()} at offset {obj.offset:#x}")
         print(f"    Confidence: {obj.confidence:.0%}")
@@ -53,40 +54,40 @@ def demo_zip_in_exe():
 
 def demo_polyglot():
     """Demo: File valid as multiple formats (polyglot)."""
-    print("\n" + "="*70)
+    print("\n" + "=" * 70)
     print("DEMO 2: Polyglot Detection (Valid as Multiple Formats)")
-    print("="*70)
-    
+    print("=" * 70)
+
     # Create polyglot: ZIP with embedded PE
     data = b"PK\x03\x04\x14\x00\x00\x00\x08\x00" + b"\x00" * 200
-    
+
     # Add PE signature at offset 256
     pe_header = b"MZ" + b"\x00" * 58
     pe_header += b"\x80\x00\x00\x00"
-    
+
     polyglot = data + b"\x00" * (256 - len(data)) + pe_header
-    
+
     # Analyze
     detector = EmbeddedDetector()
     embedded = detector.detect_embedded(polyglot, skip_primary=True, min_confidence=0.60)
-    
+
     formats_found = {obj.format for obj in embedded}
-    
+
     print(f"\nFile size: {len(polyglot):,} bytes")
     print(f"Primary format: ZIP")
     print(f"\n⚠ Polyglot Detected!")
     print(f"Valid as: {', '.join(formats_found)}")
-    
+
     for obj in embedded:
         print(f"\n  • {obj.format.upper()} at {obj.offset:#x} ({obj.confidence:.0%})")
 
 
 def demo_overlay():
     """Demo: Overlay detection (data after EOF)."""
-    print("\n" + "="*70)
+    print("\n" + "=" * 70)
     print("DEMO 3: Overlay Detection (Data After EOF)")
-    print("="*70)
-    
+    print("=" * 70)
+
     # Create ZIP with overlay
     zip_header = b"PK\x03\x04"
     zip_header += b"\x14\x00"  # Version
@@ -100,24 +101,24 @@ def demo_overlay():
     zip_header += b"\x04\x00"  # Filename length
     zip_header += b"\x00\x00"  # Extra field length
     zip_header += b"test"  # Filename
-    
+
     # EOCD
     eocd = b"PK\x05\x06" + b"\x00" * 18
-    
+
     zip_data = zip_header + eocd
-    
+
     # Add overlay (hidden data after ZIP EOF)
     overlay_data = b"\x00" * 512 + b"SECRET PAYLOAD" + b"\x00" * 512
-    
+
     full_file = zip_data + overlay_data
-    
+
     # Detect overlay
     detector = EmbeddedDetector()
     overlay = detector.detect_overlay(full_file, "zip")
-    
+
     print(f"\nFile size: {len(full_file):,} bytes")
     print(f"ZIP logical EOF: {len(zip_data)} bytes")
-    
+
     if overlay:
         print(f"\n⚠ Overlay Detected!")
         print(f"  Starts at: {overlay.offset:#x}")
@@ -129,33 +130,33 @@ def demo_overlay():
 
 def demo_full_analysis():
     """Demo: Full analysis with Analyzer class."""
-    print("\n" + "="*70)
+    print("\n" + "=" * 70)
     print("DEMO 4: Full Analysis with Embedded Detection")
-    print("="*70)
-    
+    print("=" * 70)
+
     # Create suspicious file with multiple embedded objects
     data = b"\x00" * 100
-    
+
     # Add PNG
     data += bytes.fromhex("89504E470D0A1A0A") + b"\x00" * 100
-    
+
     # Add ZIP
     data += b"PK\x03\x04\x14\x00\x00\x00\x08\x00" + b"\x00" * 100
-    
+
     # Add JPEG
     data += bytes.fromhex("FFD8FFE0") + b"\x00" * 100
-    
+
     # Analyze
     analyzer = Analyzer()
     result = analyzer.analyze(data)
-    
+
     print(f"\nPrimary Format: {result.primary_format.upper()}")
     print(f"Confidence: {result.confidence:.0%}")
     print(f"File Size: {result.file_size:,} bytes")
-    
+
     if result.embedded_objects:
         print(f"\n🔍 Embedded Artifacts: {len(result.embedded_objects)}")
-        
+
         for obj in result.embedded_objects:
             print(f"\n  • {obj.format.upper()} at offset {obj.offset:#x}")
             print(f"    Confidence: {obj.confidence:.0%}")
@@ -165,19 +166,19 @@ def demo_full_analysis():
 
 def main():
     """Run all demos."""
-    print("\n" + "="*70)
+    print("\n" + "=" * 70)
     print(" EMBEDDED OBJECT DETECTION DEMO")
     print(" Malware Hunter Candy 🍬")
-    print("="*70)
-    
+    print("=" * 70)
+
     demo_zip_in_exe()
     demo_polyglot()
     demo_overlay()
     demo_full_analysis()
-    
-    print("\n" + "="*70)
+
+    print("\n" + "=" * 70)
     print(" All demos completed!")
-    print("="*70)
+    print("=" * 70)
     print("\nFor real-world usage:")
     print("  filo analyze suspicious.exe")
     print("  filo analyze --json malware.bin | jq '.embedded_objects'")

--- a/examples/features_demo.py
+++ b/examples/features_demo.py
@@ -29,87 +29,91 @@ console = Console()
 def create_sample_files():
     """Create sample files for testing."""
     tmpdir = Path(tempfile.mkdtemp())
-    
+
     # Create various file types
     (tmpdir / "image.png").write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
     (tmpdir / "photo.jpg").write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 100)
     (tmpdir / "document.pdf").write_bytes(b"%PDF-1.7\n" + b"\x00" * 100)
-    
+
     # Create subdirectory
     subdir = tmpdir / "archives"
     subdir.mkdir()
-    
+
     # Create a ZIP archive
     zip_buffer = io.BytesIO()
-    with zipfile.ZipFile(zip_buffer, 'w') as zf:
+    with zipfile.ZipFile(zip_buffer, "w") as zf:
         zf.writestr("README.txt", b"Hello, World!")
         zf.writestr("data.bin", b"\x00" * 50)
-    
+
     (subdir / "archive.zip").write_bytes(zip_buffer.getvalue())
-    
+
     return tmpdir
 
 
 def demo_batch_processing():
     """Demonstrate batch directory analysis."""
-    console.print(Panel.fit(
-        "[bold cyan]Feature 1: Batch Processing[/bold cyan]\n"
-        "Efficiently analyze entire directories with parallel processing",
-        border_style="cyan"
-    ))
-    
+    console.print(
+        Panel.fit(
+            "[bold cyan]Feature 1: Batch Processing[/bold cyan]\n"
+            "Efficiently analyze entire directories with parallel processing",
+            border_style="cyan",
+        )
+    )
+
     # Create sample files
     tmpdir = create_sample_files()
-    
+
     console.print(f"\n[bold]Analyzing directory:[/bold] {tmpdir}")
-    
+
     # Batch process
     result = analyze_directory(tmpdir, max_workers=4, recursive=True)
-    
+
     # Show results
     table = Table(title="Batch Processing Results", show_header=True)
     table.add_column("Metric", style="cyan")
     table.add_column("Value", justify="right", style="green")
-    
+
     table.add_row("Total Files", str(result.total_files))
     table.add_row("Analyzed", str(result.analyzed_files))
     table.add_row("Failed", str(result.failed_files))
     table.add_row("Duration", f"{result.duration:.2f}s")
     table.add_row("Speed", f"{result.files_per_second:.1f} files/sec")
-    
+
     console.print(table)
-    
+
     # Show format distribution
     if result.results:
         formats = {}
         for path, res in result.results:
             fmt = res.primary_format
             formats[fmt] = formats.get(fmt, 0) + 1
-        
+
         console.print("\n[bold]Format Distribution:[/bold]")
         for fmt, count in formats.items():
             console.print(f"  • {fmt}: {count}")
-    
+
     return tmpdir, result
 
 
 def demo_export(batch_result):
     """Demonstrate JSON and SARIF export."""
     console.print("\n")
-    console.print(Panel.fit(
-        "[bold cyan]Feature 2: Export Reports[/bold cyan]\n"
-        "Export analysis results to JSON and SARIF formats",
-        border_style="cyan"
-    ))
-    
+    console.print(
+        Panel.fit(
+            "[bold cyan]Feature 2: Export Reports[/bold cyan]\n"
+            "Export analysis results to JSON and SARIF formats",
+            border_style="cyan",
+        )
+    )
+
     tmpdir, result = batch_result
-    
+
     # JSON Export
     console.print("\n[bold]JSON Export:[/bold]")
     json_output = JSONExporter.export_batch(result.results, pretty=True)
     console.print(f"  Size: {len(json_output):,} bytes")
     console.print(f"  Preview: {json_output[:200]}...")
-    
+
     # SARIF Export
     console.print("\n[bold]SARIF Export:[/bold]")
     sarif_output = SARIFExporter.export_batch(result.results, pretty=True)
@@ -121,32 +125,34 @@ def demo_export(batch_result):
 def demo_container_detection(tmpdir):
     """Demonstrate container file detection and analysis."""
     console.print("\n")
-    console.print(Panel.fit(
-        "[bold cyan]Feature 3: Container Detection[/bold cyan]\n"
-        "Detect and recursively analyze ZIP/TAR/ISO archives",
-        border_style="cyan"
-    ))
-    
+    console.print(
+        Panel.fit(
+            "[bold cyan]Feature 3: Container Detection[/bold cyan]\n"
+            "Detect and recursively analyze ZIP/TAR/ISO archives",
+            border_style="cyan",
+        )
+    )
+
     # Analyze the ZIP file
     zip_path = tmpdir / "archives" / "archive.zip"
     console.print(f"\n[bold]Analyzing container:[/bold] {zip_path.name}")
-    
-    with open(zip_path, 'rb') as f:
+
+    with open(zip_path, "rb") as f:
         data = f.read()
-    
+
     result = analyze_archive(data, recursive=True)
-    
+
     if result:
         table = Table(show_header=True)
         table.add_column("Property", style="cyan")
         table.add_column("Value", style="green")
-        
+
         table.add_row("Container Type", result.container_format.upper())
         table.add_row("Total Entries", str(result.total_entries))
         table.add_row("Analyzed", str(result.analyzed_entries))
-        
+
         console.print(table)
-        
+
         # Show entries
         if result.entries:
             console.print("\n[bold]Container Contents:[/bold]")
@@ -154,145 +160,150 @@ def demo_container_detection(tmpdir):
             entries_table.add_column("Path")
             entries_table.add_column("Size", justify="right")
             entries_table.add_column("Type")
-            
+
             for entry in result.entries:
                 if not entry.is_dir:
                     entries_table.add_row(
-                        entry.path,
-                        f"{entry.size:,} bytes",
-                        "dir" if entry.is_dir else "file"
+                        entry.path, f"{entry.size:,} bytes", "dir" if entry.is_dir else "file"
                     )
-            
+
             console.print(entries_table)
 
 
 def demo_performance_profiling(tmpdir):
     """Demonstrate performance profiling."""
     console.print("\n")
-    console.print(Panel.fit(
-        "[bold cyan]Feature 4: Performance Profiling[/bold cyan]\n"
-        "Identify bottlenecks in large file analysis",
-        border_style="cyan"
-    ))
-    
+    console.print(
+        Panel.fit(
+            "[bold cyan]Feature 4: Performance Profiling[/bold cyan]\n"
+            "Identify bottlenecks in large file analysis",
+            border_style="cyan",
+        )
+    )
+
     console.print("\n[bold]Profiling file analysis...[/bold]")
-    
+
     # Profile analysis of multiple files
     with profile_session() as profiler:
         analyzer = Analyzer(use_ml=False)
-        
+
         for file_path in tmpdir.glob("**/*"):
             if file_path.is_file():
                 with profiler.time_operation(f"analyze_{file_path.suffix}"):
-                    with open(file_path, 'rb') as f:
+                    with open(file_path, "rb") as f:
                         data = f.read()
                     analyzer.analyze(data)
-    
+
     report = profiler.report
-    
+
     # Show results
     console.print(f"\n[bold]Profiling Results:[/bold]")
     console.print(f"Total Duration: [cyan]{report.total_duration:.4f}s[/cyan]")
-    
+
     table = Table(show_header=True)
     table.add_column("Operation", style="cyan")
     table.add_column("Time (s)", justify="right", style="green")
     table.add_column("Calls", justify="right")
     table.add_column("Avg (s)", justify="right", style="yellow")
-    
+
     for timing in report.get_sorted_timings()[:5]:
         table.add_row(
-            timing.name,
-            f"{timing.duration:.4f}",
-            str(timing.calls),
-            f"{timing.avg_duration:.6f}"
+            timing.name, f"{timing.duration:.4f}", str(timing.calls), f"{timing.avg_duration:.6f}"
         )
-    
+
     console.print(table)
 
 
 def demo_better_output():
     """Demonstrate enhanced CLI output."""
     console.print("\n")
-    console.print(Panel.fit(
-        "[bold cyan]Feature 5: Better CLI Output[/bold cyan]\n"
-        "Color-coded confidence, hex dumps, repair suggestions",
-        border_style="cyan"
-    ))
-    
+    console.print(
+        Panel.fit(
+            "[bold cyan]Feature 5: Better CLI Output[/bold cyan]\n"
+            "Color-coded confidence, hex dumps, repair suggestions",
+            border_style="cyan",
+        )
+    )
+
     # Create sample file
     data = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
-    
+
     analyzer = Analyzer(use_ml=False)
     result = analyzer.analyze(data)
-    
+
     console.print("\n[bold]Enhanced Analysis Output:[/bold]")
-    
+
     table = Table(show_header=True)
     table.add_column("Property", style="cyan")
     table.add_column("Value")
-    
+
     table.add_row("Format", f"[cyan]{result.primary_format}[/cyan]")
-    
+
     # Color-coded confidence
-    conf_color = "green" if result.confidence >= 0.8 else "yellow" if result.confidence >= 0.5 else "red"
+    conf_color = (
+        "green" if result.confidence >= 0.8 else "yellow" if result.confidence >= 0.5 else "red"
+    )
     table.add_row("Confidence", f"[{conf_color}]{result.confidence:.1%}[/{conf_color}]")
-    
+
     table.add_row("File Size", f"{result.file_size:,} bytes")
     table.add_row("Entropy", f"{result.entropy:.4f}" if result.entropy else "—")
     table.add_row("Checksum", result.checksum_sha256)
-    
+
     console.print(table)
-    
+
     # Hex dump
     console.print("\n[bold]Hex Dump (first 64 bytes):[/bold]")
     for i in range(0, min(64, len(data)), 16):
         offset = f"{i:08x}"
-        hex_part = " ".join(f"{b:02x}" for b in data[i:i+16])
+        hex_part = " ".join(f"{b:02x}" for b in data[i : i + 16])
         hex_part = hex_part.ljust(48)
-        ascii_part = "".join(
-            chr(b) if 32 <= b < 127 else "."
-            for b in data[i:i+16]
-        )
+        ascii_part = "".join(chr(b) if 32 <= b < 127 else "." for b in data[i : i + 16])
         console.print(f"  {offset}  {hex_part}  {ascii_part}")
-    
+
     # Repair suggestion
     if result.confidence < 0.8:
         console.print("\n[bold cyan]💡 Repair Suggestions:[/bold cyan]")
-        console.print(f"  Try: [green]filo repair --format={result.primary_format} file.bin[/green]")
+        console.print(
+            f"  Try: [green]filo repair --format={result.primary_format} file.bin[/green]"
+        )
 
 
 def main():
     """Run all demonstrations."""
-    console.print(Panel.fit(
-        "[bold white]Filo Features Demonstration[/bold white]\n"
-        "Showcasing 5 powerful new features",
-        border_style="bold white",
-        title="[bold]🔍 FILO[/bold]"
-    ))
-    
+    console.print(
+        Panel.fit(
+            "[bold white]Filo Features Demonstration[/bold white]\n"
+            "Showcasing 5 powerful new features",
+            border_style="bold white",
+            title="[bold]🔍 FILO[/bold]",
+        )
+    )
+
     # Run demos
     tmpdir, batch_result = demo_batch_processing()
     demo_export((tmpdir, batch_result))
     demo_container_detection(tmpdir)
     demo_performance_profiling(tmpdir)
     demo_better_output()
-    
+
     console.print("\n")
-    console.print(Panel.fit(
-        "[bold green]✓ All demonstrations completed successfully![/bold green]\n\n"
-        "Ready to use in production:\n"
-        "  • filo batch ./directory\n"
-        "  • filo analyze --export=json --output=report.json file.bin\n"
-        "  • filo analyze --container archive.zip\n"
-        "  • filo profile large_file.dat\n"
-        "  • filo analyze --hex-dump suspicious.bin",
-        border_style="green",
-        title="[bold]Summary[/bold]"
-    ))
-    
+    console.print(
+        Panel.fit(
+            "[bold green]✓ All demonstrations completed successfully![/bold green]\n\n"
+            "Ready to use in production:\n"
+            "  • filo batch ./directory\n"
+            "  • filo analyze --export=json --output=report.json file.bin\n"
+            "  • filo analyze --container archive.zip\n"
+            "  • filo profile large_file.dat\n"
+            "  • filo analyze --hex-dump suspicious.bin",
+            border_style="green",
+            title="[bold]Summary[/bold]",
+        )
+    )
+
     # Cleanup
     import shutil
+
     shutil.rmtree(tmpdir)
 
 

--- a/examples/polyglot_examples.py
+++ b/examples/polyglot_examples.py
@@ -12,26 +12,26 @@ def example_1_basic_polyglot_detection():
     print("=" * 70)
     print("Example 1: Basic Polyglot Detection")
     print("=" * 70)
-    
+
     # Create a simple polyglot detector
     detector = PolyglotDetector()
-    
+
     # Read a suspicious file
     demo_file = Path("demo/gifar_malware.gif")
     if not demo_file.exists():
         print("⚠ Demo file not found. Run: python demo/create_polyglot_files.py")
         return
-    
-    with open(demo_file, 'rb') as f:
+
+    with open(demo_file, "rb") as f:
         data = f.read()
-    
+
     # Detect polyglots
-    polyglots = detector.detect_polyglots(data, primary_format='gif')
-    
+    polyglots = detector.detect_polyglots(data, primary_format="gif")
+
     print(f"\n📁 File: {demo_file}")
     print(f"📊 Size: {len(data)} bytes")
     print(f"\n⚠ Polyglots detected: {len(polyglots)}")
-    
+
     for i, p in enumerate(polyglots, 1):
         print(f"\n{i}. {' + '.join(p.formats).upper()}")
         print(f"   Pattern: {p.pattern}")
@@ -46,25 +46,25 @@ def example_2_analyzer_integration():
     print("\n" + "=" * 70)
     print("Example 2: Analyzer Integration")
     print("=" * 70)
-    
+
     demo_file = Path("demo/malicious_document.pdf")
     if not demo_file.exists():
         print("⚠ Demo file not found. Run: python demo/create_polyglot_files.py")
         return
-    
+
     # Create analyzer with polyglot detection enabled (default)
     analyzer = Analyzer(detect_polyglots=True)
-    
+
     # Analyze file - read data first
-    with open(demo_file, 'rb') as f:
+    with open(demo_file, "rb") as f:
         data = f.read()
-    
+
     result = analyzer.analyze(data, file_path=str(demo_file))
-    
+
     print(f"\n📁 File: {demo_file}")
     print(f"🎯 Primary Format: {result.primary_format}")
     print(f"📊 Confidence: {result.confidence:.1%}")
-    
+
     if result.polyglots:
         print(f"\n⚠ Polyglots detected: {len(result.polyglots)}")
         for p in result.polyglots:
@@ -80,36 +80,36 @@ def example_3_format_validation():
     print("\n" + "=" * 70)
     print("Example 3: Individual Format Validation")
     print("=" * 70)
-    
+
     demo_file = Path("demo/polyglot_advanced.png")
     if not demo_file.exists():
         print("⚠ Demo file not found. Run: python demo/create_polyglot_files.py")
         return
-    
-    with open(demo_file, 'rb') as f:
+
+    with open(demo_file, "rb") as f:
         data = f.read()
-    
+
     detector = PolyglotDetector()
-    
+
     print(f"\n📁 File: {demo_file}")
     print(f"📊 Size: {len(data)} bytes")
     print("\n🔍 Format Validation Results:")
-    
+
     # Test multiple formats
     formats_to_test = {
-        'PNG': detector._validate_png,
-        'GIF': detector._validate_gif,
-        'JPEG': detector._validate_jpeg,
-        'ZIP': detector._validate_zip,
-        'PDF': detector._validate_pdf,
-        'PE': detector._validate_pe,
+        "PNG": detector._validate_png,
+        "GIF": detector._validate_gif,
+        "JPEG": detector._validate_jpeg,
+        "ZIP": detector._validate_zip,
+        "PDF": detector._validate_pdf,
+        "PE": detector._validate_pe,
     }
-    
+
     for format_name, validator in formats_to_test.items():
         is_valid = validator(data)
         status = "✓ VALID" if is_valid else "✗ Invalid"
         print(f"  {format_name:8} {status}")
-    
+
     # Get all valid formats
     valid_formats = detector._get_valid_formats(data)
     print(f"\n✓ File is valid as: {', '.join(valid_formats).upper()}")
@@ -120,40 +120,40 @@ def example_4_javascript_detection():
     print("\n" + "=" * 70)
     print("Example 4: JavaScript Payload Detection")
     print("=" * 70)
-    
+
     demo_file = Path("demo/malicious_document.pdf")
     if not demo_file.exists():
         print("⚠ Demo file not found. Run: python demo/create_polyglot_files.py")
         return
-    
-    with open(demo_file, 'rb') as f:
+
+    with open(demo_file, "rb") as f:
         data = f.read()
-    
+
     detector = PolyglotDetector()
-    
+
     print(f"\n📁 File: {demo_file}")
-    
+
     # Check if it's a valid PDF
     is_pdf = detector._validate_pdf(data)
     print(f"📄 Valid PDF: {is_pdf}")
-    
+
     if is_pdf:
         # Check for JavaScript payload
         has_js = detector._has_js_payload(data)
         print(f"⚠ JavaScript Detected: {has_js}")
-        
+
         if has_js:
             # Look for specific indicators
             js_indicators = [
-                b'/JavaScript',
-                b'/JS',
-                b'/AA',
-                b'/OpenAction',
-                b'eval(',
-                b'unescape(',
-                b'String.fromCharCode',
+                b"/JavaScript",
+                b"/JS",
+                b"/AA",
+                b"/OpenAction",
+                b"eval(",
+                b"unescape(",
+                b"String.fromCharCode",
             ]
-            
+
             print("\n🔍 JavaScript Indicators Found:")
             for indicator in js_indicators:
                 if indicator in data:
@@ -165,35 +165,35 @@ def example_5_security_filtering():
     print("\n" + "=" * 70)
     print("Example 5: Security Filtering")
     print("=" * 70)
-    
+
     print("\n🛡️ Security Policy: Block HIGH risk polyglots\n")
-    
+
     test_files = [
         ("demo/gifar_malware.gif", "GIFAR Attack"),
         ("demo/polyglot_advanced.png", "PNG+ZIP Steganography"),
         ("demo/malicious_document.pdf", "PDF with JavaScript"),
         ("demo/executable_archive.exe", "PE+ZIP Hybrid"),
     ]
-    
+
     analyzer = Analyzer(detect_polyglots=True)
-    
+
     for file_path, description in test_files:
         demo_file = Path(file_path)
         if not demo_file.exists():
             continue
-        
-        with open(demo_file, 'rb') as f:
+
+        with open(demo_file, "rb") as f:
             data = f.read()
-        
+
         result = analyzer.analyze(data, file_path=str(demo_file))
-        
+
         print(f"\n📁 {demo_file.name} - {description}")
-        
+
         # Check for high-risk polyglots
-        high_risk = [p for p in result.polyglots if p.risk_level == 'high']
-        medium_risk = [p for p in result.polyglots if p.risk_level == 'medium']
-        low_risk = [p for p in result.polyglots if p.risk_level == 'low']
-        
+        high_risk = [p for p in result.polyglots if p.risk_level == "high"]
+        medium_risk = [p for p in result.polyglots if p.risk_level == "medium"]
+        low_risk = [p for p in result.polyglots if p.risk_level == "low"]
+
         if high_risk:
             print(f"  🚫 BLOCKED - High risk polyglot detected!")
             for p in high_risk:
@@ -213,14 +213,14 @@ def example_6_batch_analysis():
     print("\n" + "=" * 70)
     print("Example 6: Batch Polyglot Analysis")
     print("=" * 70)
-    
+
     demo_dir = Path("demo")
     if not demo_dir.exists():
         print("⚠ Demo directory not found")
         return
-    
+
     analyzer = Analyzer(detect_polyglots=True)
-    
+
     # Find all demo polyglot files
     polyglot_files = [
         "gifar_malware.gif",
@@ -229,33 +229,30 @@ def example_6_batch_analysis():
         "image_with_archive.jpg",
         "executable_archive.exe",
     ]
-    
+
     print("\n📊 Analyzing demo polyglot files...\n")
-    
+
     results = []
     for filename in polyglot_files:
         file_path = demo_dir / filename
         if not file_path.exists():
             continue
-        
-        with open(file_path, 'rb') as f:
+
+        with open(file_path, "rb") as f:
             data = f.read()
-        
+
         result = analyzer.analyze(data, file_path=str(file_path))
         results.append((filename, result))
-    
+
     # Summary statistics
     total_files = len(results)
     files_with_polyglots = sum(1 for _, r in results if r.polyglots)
-    high_risk_count = sum(
-        1 for _, r in results 
-        for p in r.polyglots if p.risk_level == 'high'
-    )
-    
+    high_risk_count = sum(1 for _, r in results for p in r.polyglots if p.risk_level == "high")
+
     print(f"📁 Total files analyzed: {total_files}")
     print(f"⚠️  Files with polyglots: {files_with_polyglots}")
     print(f"🚨 High-risk detections: {high_risk_count}")
-    
+
     print("\n📋 Detailed Results:\n")
     for filename, result in results:
         print(f"  {filename}")
@@ -274,14 +271,14 @@ def main():
     print("\n" + "=" * 70)
     print(" " * 10 + "Filo v0.2.5 - Polyglot Detection Examples")
     print("=" * 70)
-    
+
     # Check if demo files exist
     demo_dir = Path("demo")
     if not demo_dir.exists() or not (demo_dir / "gifar_malware.gif").exists():
         print("\n⚠️  Demo files not found!")
         print("Please run first: python demo/create_polyglot_files.py\n")
         return 1
-    
+
     try:
         example_1_basic_polyglot_detection()
         example_2_analyzer_integration()
@@ -289,7 +286,7 @@ def main():
         example_4_javascript_detection()
         example_5_security_filtering()
         example_6_batch_analysis()
-        
+
         print("\n" + "=" * 70)
         print("✅ All examples completed successfully!")
         print("=" * 70)
@@ -297,12 +294,13 @@ def main():
         print("  - docs/POLYGLOT_DETECTION.md")
         print("  - RELEASE_v0.2.5.md")
         print("=" * 70 + "\n")
-        
+
         return 0
-    
+
     except Exception as e:
         print(f"\n❌ Error running examples: {e}")
         import traceback
+
         traceback.print_exc()
         return 1
 

--- a/examples/test_new_formats.py
+++ b/examples/test_new_formats.py
@@ -6,38 +6,40 @@ from filo import Analyzer
 analyzer = Analyzer()
 
 # Test Office formats
-docx = bytes.fromhex('504B0304') + b'\x00' * 26 + b'word' + b'\x00' * 100
-xlsx = bytes.fromhex('504B0304') + b'\x00' * 26 + b'xl' + b'\x00' * 100
-rtf = bytes.fromhex('7B5C727466') + b'1 test' + b'\x00' * 50
+docx = bytes.fromhex("504B0304") + b"\x00" * 26 + b"word" + b"\x00" * 100
+xlsx = bytes.fromhex("504B0304") + b"\x00" * 26 + b"xl" + b"\x00" * 100
+rtf = bytes.fromhex("7B5C727466") + b"1 test" + b"\x00" * 50
 
 # Test media formats
-mkv = bytes.fromhex('1A45DFA3') + b'\x00' * 100
-avi = bytes.fromhex('52494646') + b'\x00' * 4 + b'AVI ' + b'\x00' * 100
-midi = bytes.fromhex('4D546864') + b'\x00' * 100
+mkv = bytes.fromhex("1A45DFA3") + b"\x00" * 100
+avi = bytes.fromhex("52494646") + b"\x00" * 4 + b"AVI " + b"\x00" * 100
+midi = bytes.fromhex("4D546864") + b"\x00" * 100
 
 # Test executables
-java_class = bytes.fromhex('CAFEBABE') + b'\x00' * 100
-macho = bytes.fromhex('FEEDFACE') + b'\x00' * 100
+java_class = bytes.fromhex("CAFEBABE") + b"\x00" * 100
+macho = bytes.fromhex("FEEDFACE") + b"\x00" * 100
 
 # Test archives
-tar = b'\x00' * 257 + bytes.fromhex('7573746172') + b'\x00' * 100
-cab = bytes.fromhex('4D534346') + b'\x00' * 100
+tar = b"\x00" * 257 + bytes.fromhex("7573746172") + b"\x00" * 100
+cab = bytes.fromhex("4D534346") + b"\x00" * 100
 
 tests = [
-    ('DOCX', docx),
-    ('XLSX', xlsx),
-    ('RTF', rtf),
-    ('MKV', mkv),
-    ('AVI', avi),
-    ('MIDI', midi),
-    ('Java Class', java_class),
-    ('Mach-O', macho),
-    ('TAR', tar),
-    ('CAB', cab),
+    ("DOCX", docx),
+    ("XLSX", xlsx),
+    ("RTF", rtf),
+    ("MKV", mkv),
+    ("AVI", avi),
+    ("MIDI", midi),
+    ("Java Class", java_class),
+    ("Mach-O", macho),
+    ("TAR", tar),
+    ("CAB", cab),
 ]
 
-print('=== Testing New File Formats ===\n')
+print("=== Testing New File Formats ===\n")
 for name, data in tests:
     result = analyzer.analyze(data)
-    status = '✓' if result.primary_format else '✗'
-    print(f'{status} {name:12s} → {result.primary_format.upper() if result.primary_format else "UNKNOWN":10s} ({result.confidence:.1%})')
+    status = "✓" if result.primary_format else "✗"
+    print(
+        f'{status} {name:12s} → {result.primary_format.upper() if result.primary_format else "UNKNOWN":10s} ({result.confidence:.1%})'
+    )

--- a/examples/usage_examples.py
+++ b/examples/usage_examples.py
@@ -8,68 +8,68 @@ from filo import Analyzer, RepairEngine, FormatDatabase
 def example_basic_analysis():
     """Basic file analysis example."""
     print("=== Basic File Analysis ===\n")
-    
+
     # Create analyzer
     analyzer = Analyzer()
-    
+
     # Create sample PNG data
     png_data = bytes.fromhex("89504E470D0A1A0A0000000D49484452")
     png_data += b"\x00" * 100
-    
+
     # Analyze
     result = analyzer.analyze(png_data)
-    
+
     print(f"Detected Format: {result.primary_format}")
     print(f"Confidence: {result.confidence:.1%}")
     print(f"File Size: {result.file_size} bytes")
     print(f"Entropy: {result.entropy:.2f} bits/byte")
     print(f"SHA256: {result.checksum_sha256}")
-    
+
     if result.alternative_formats:
         print("\nAlternative Possibilities:")
         for fmt, conf in result.alternative_formats:
             print(f"  - {fmt}: {conf:.1%}")
-    
+
     print("\nEvidence Chain:")
     for evidence in result.evidence_chain:
         print(f"  Module: {evidence['module']}")
         print(f"  Confidence: {evidence['confidence']:.1%}")
-        for e in evidence.get('evidence', []):
+        for e in evidence.get("evidence", []):
             print(f"    • {e}")
 
 
 def example_repair():
     """File repair example."""
     print("\n\n=== File Repair ===\n")
-    
+
     # Create repair engine
     engine = RepairEngine()
-    
+
     # Corrupted PDF (missing header)
     corrupted_pdf = b"1 0 obj\n<< /Type /Catalog >>\nendobj\n%%EOF\n"
-    
+
     print(f"Original data: {corrupted_pdf[:50]}...")
-    
+
     # Repair
     repaired, report = engine.repair(corrupted_pdf, "pdf", strategy="auto")
-    
+
     print(f"\nRepair Status: {'SUCCESS' if report.success else 'FAILED'}")
     print(f"Strategy Used: {report.strategy_used}")
     print(f"Changes Made:")
     for change in report.changes_made:
         print(f"  • {change}")
-    
+
     print(f"\nRepaired data: {repaired[:50]}...")
 
 
 def example_format_database():
     """Format database query example."""
     print("\n\n=== Format Database ===\n")
-    
+
     db = FormatDatabase()
-    
+
     print(f"Total formats loaded: {db.count()}")
-    
+
     # Get specific format
     png_spec = db.get_format("png")
     if png_spec:
@@ -80,13 +80,13 @@ def example_format_database():
         print(f"  Extensions: {', '.join(png_spec.extensions)}")
         print(f"  Signatures: {len(png_spec.signatures)}")
         print(f"  Repair Strategies: {len(png_spec.repair_strategies)}")
-    
+
     # List by category
     print("\nImage Formats:")
     image_formats = db.get_formats_by_category("raster_image")
     for spec in image_formats:
         print(f"  • {spec.format} ({', '.join(spec.extensions)})")
-    
+
     # List by extension
     print("\nFormats using .pdf extension:")
     pdf_formats = db.get_formats_by_extension("pdf")
@@ -97,9 +97,9 @@ def example_format_database():
 def example_multi_format_detection():
     """Detect multiple file formats."""
     print("\n\n=== Multi-Format Detection ===\n")
-    
+
     analyzer = Analyzer()
-    
+
     test_files = {
         "PNG": bytes.fromhex("89504E470D0A1A0A"),
         "JPEG": bytes.fromhex("FFD8FFE0"),
@@ -107,12 +107,12 @@ def example_multi_format_detection():
         "ZIP": bytes.fromhex("504B0304"),
         "ELF": bytes.fromhex("7F454C46"),
     }
-    
+
     for name, data in test_files.items():
         # Pad with some data
         padded_data = data + b"\x00" * 100
         result = analyzer.analyze(padded_data)
-        
+
         status = "✓" if result.confidence > 0.7 else "?"
         print(f"{status} {name:8s} -> {result.primary_format:10s} ({result.confidence:.1%})")
 

--- a/filo/__init__.py
+++ b/filo/__init__.py
@@ -37,6 +37,8 @@ __all__ = [
     "BMPStegoDetector",
     "PDFMetadataDetector",
     "TrailingDataDetector",
+    "CryptoDetector",
+    "CryptoAnalysis",
     "YARAScanner",
     "YARAScanResult",
     "YARAMatch",

--- a/filo/__init__.py
+++ b/filo/__init__.py
@@ -7,7 +7,13 @@ from filo.batch import BatchProcessor, BatchConfig, analyze_directory
 from filo.export import JSONExporter, SARIFExporter, export_to_file
 from filo.container import ContainerDetector, analyze_archive
 from filo.profiler import Profiler, profile_session
-from filo.stego import detect_steganography, PNGStegoDetector, BMPStegoDetector, PDFMetadataDetector, TrailingDataDetector
+from filo.stego import (
+    detect_steganography,
+    PNGStegoDetector,
+    BMPStegoDetector,
+    PDFMetadataDetector,
+    TrailingDataDetector,
+)
 from filo.crypto import CryptoDetector, CryptoAnalysis
 from filo.yarascanner import YARAScanner, YARAScanResult, YARAMatch
 from filo.office import analyze_office_file, OfficeAnalysisResult
@@ -15,12 +21,12 @@ from filo.office import analyze_office_file, OfficeAnalysisResult
 __version__ = "0.3.0"
 __author__ = "Supun Hewagamage"
 __all__ = [
-    "Analyzer", 
-    "RepairEngine", 
-    "FormatDatabase", 
-    "MLDetector", 
-    "CarverEngine", 
-    "CarvedFile", 
+    "Analyzer",
+    "RepairEngine",
+    "FormatDatabase",
+    "MLDetector",
+    "CarverEngine",
+    "CarvedFile",
     "StreamCarver",
     "BatchProcessor",
     "BatchConfig",

--- a/filo/analyzer.py
+++ b/filo/analyzer.py
@@ -1,7 +1,7 @@
 import hashlib
 import logging
 from pathlib import Path
-from typing import Optional, Union
+from typing import Any, Optional, Union
 import mmap
 
 from filo.formats import FormatDatabase
@@ -49,7 +49,7 @@ class SignatureAnalyzer:
 
     def __init__(self, database: FormatDatabase) -> None:
         self.database = database
-        self._signature_cache = {}
+        self._signature_cache: dict[str, Any] = {}
 
     def analyze(self, data: bytes, max_bytes: int = 8192) -> list[DetectionResult]:
         """
@@ -748,7 +748,7 @@ class Analyzer:
             ml_results = self.ml_detector.predict(data, entropy, len(data))
 
         format_scores: dict[str, float] = {}
-        evidence_chain: list[dict] = []
+        evidence_chain: list[dict[str, Any]] = []
 
         for result in sig_results:
             format_scores[result.format] = format_scores.get(result.format, 0.0) + (
@@ -955,7 +955,7 @@ class Analyzer:
             logger.debug(f"Crypto analysis failed: {e}")
 
         # Run YARA scanning
-        yara_matches_list: list[YARAMatchInfo] = []
+        yara_matches_list = []
         if self.yara_scanner and self.yara_scanner.available:
             try:
                 yara_result = self.yara_scanner.scan_data(data)

--- a/filo/analyzer.py
+++ b/filo/analyzer.py
@@ -5,7 +5,14 @@ from typing import Optional, Union
 import mmap
 
 from filo.formats import FormatDatabase
-from filo.models import AnalysisResult, DetectionResult, ConfidenceContribution, ArchitectureInfo, YARAMatchInfo, OfficeMacroInfo
+from filo.models import (
+    AnalysisResult,
+    DetectionResult,
+    ConfidenceContribution,
+    ArchitectureInfo,
+    YARAMatchInfo,
+    OfficeMacroInfo,
+)
 from filo.contradictions import ContradictionDetector
 from filo.embedded import EmbeddedDetector
 from filo.fingerprint import ToolFingerprinter
@@ -15,12 +22,14 @@ from filo.crypto import CryptoDetector
 
 try:
     from filo.yarascanner import YARAScanner
+
     YARA_AVAILABLE = True
 except ImportError:
     YARA_AVAILABLE = False
 
 try:
     from filo.office import analyze_office_file
+
     OFFICE_AVAILABLE = True
 except ImportError:
     OFFICE_AVAILABLE = False
@@ -29,6 +38,7 @@ logger = logging.getLogger(__name__)
 
 try:
     from filo.ml import MLDetector, LearningExample, PatternMatch
+
     ML_AVAILABLE = True
 except ImportError:
     ML_AVAILABLE = False
@@ -36,78 +46,82 @@ except ImportError:
 
 class SignatureAnalyzer:
     """Signature-based file format detection."""
-    
+
     def __init__(self, database: FormatDatabase) -> None:
         self.database = database
         self._signature_cache = {}
-    
+
     def analyze(self, data: bytes, max_bytes: int = 8192) -> list[DetectionResult]:
         """
         Analyze file signatures.
-        
+
         Args:
             data: File data to analyze
             max_bytes: Maximum bytes to scan for signatures
-        
+
         Returns:
             List of detection results with confidence scores
         """
         results: list[DetectionResult] = []
         scan_data = data[:max_bytes]
-        
+
         for format_spec in self.database._formats.values():
             evidence = []
             contributions = []
             total_weight = 0.0
             matched_weight = 0.0
-            
+
             # Check signatures
             for sig in format_spec.signatures:
                 total_weight += sig.weight
-                
+
                 if sig.offset >= len(data):
                     continue
-                
+
                 # Convert hex string to bytes
                 sig_bytes = bytes.fromhex(sig.hex)
-                
+
                 # If offset_max is set, scan within the range
                 if sig.offset_max is not None:
                     search_end = min(sig.offset_max, len(scan_data) - len(sig_bytes) + 1)
                     for search_offset in range(sig.offset, search_end):
-                        if scan_data[search_offset:search_offset + len(sig_bytes)] == sig_bytes:
+                        if scan_data[search_offset : search_offset + len(sig_bytes)] == sig_bytes:
                             match_contribution = sig.weight * format_spec.confidence_weight
                             matched_weight += sig.weight
                             evidence.append(
                                 f"Signature match at offset {search_offset}: {sig.description}"
                             )
-                            contributions.append(ConfidenceContribution(
-                                source="signature",
-                                value=match_contribution,
-                                description=f"{sig.description} at offset {search_offset}"
-                            ))
+                            contributions.append(
+                                ConfidenceContribution(
+                                    source="signature",
+                                    value=match_contribution,
+                                    description=f"{sig.description} at offset {search_offset}",
+                                )
+                            )
                             break
                 else:
                     # Exact offset match
                     end_offset = sig.offset + len(sig_bytes)
-                    
+
                     if end_offset <= len(scan_data):
-                        if scan_data[sig.offset:end_offset] == sig_bytes:
+                        if scan_data[sig.offset : end_offset] == sig_bytes:
                             match_contribution = sig.weight * format_spec.confidence_weight
                             matched_weight += sig.weight
                             evidence.append(
                                 f"Signature match at offset {sig.offset}: {sig.description}"
                             )
-                            contributions.append(ConfidenceContribution(
-                                source="signature",
-                                value=match_contribution,
-                                description=f"{sig.description} at offset {sig.offset}"
-                            ))
-            
+                            contributions.append(
+                                ConfidenceContribution(
+                                    source="signature",
+                                    value=match_contribution,
+                                    description=f"{sig.description} at offset {sig.offset}",
+                                )
+                            )
+
             # Calculate confidence
             if total_weight > 0:
                 confidence = (matched_weight / total_weight) * format_spec.confidence_weight
-                
+
                 if confidence > 0.25:  # Minimum threshold (lowered to detect corrupted files)
                     results.append(
                         DetectionResult(
@@ -118,9 +132,9 @@ class SignatureAnalyzer:
                             contributions=contributions,
                         )
                     )
-        
+
         return sorted(results, key=lambda r: r.confidence, reverse=True)
-    
+
     def fuzzy_match(self, data: bytes, max_bytes: int = 8192) -> list[DetectionResult]:
         """
         Detect corrupted file signatures by fuzzy matching.
@@ -128,48 +142,50 @@ class SignatureAnalyzer:
         """
         results: list[DetectionResult] = []
         scan_data = data[:max_bytes]
-        
+
         # Focus on formats commonly corrupted in CTF challenges
-        priority_formats = ['png', 'jpeg', 'gif', 'pdf', 'bmp', 'zip']
-        
+        priority_formats = ["png", "jpeg", "gif", "pdf", "bmp", "zip"]
+
         for format_name in priority_formats:
             if format_name not in self.database._formats:
                 continue
-                
+
             format_spec = self.database._formats[format_name]
-            
+
             for sig in format_spec.signatures:
                 if sig.offset >= len(data):
                     continue
-                
+
                 sig_bytes = bytes.fromhex(sig.hex)
                 sig_len = len(sig_bytes)
-                
+
                 # Check if we have enough data
                 if sig.offset + sig_len > len(scan_data):
                     continue
-                
-                actual_bytes = scan_data[sig.offset:sig.offset + sig_len]
-                
+
+                actual_bytes = scan_data[sig.offset : sig.offset + sig_len]
+
                 # Count matching bytes
                 matches = sum(1 for a, b in zip(actual_bytes, sig_bytes) if a == b)
                 match_ratio = matches / sig_len if sig_len > 0 else 0
-                
+
                 # If 40-90% of bytes match, it's likely corrupted
                 if 0.4 <= match_ratio < 0.95:
                     # Build corruption details
                     corruptions = []
                     for i, (actual, expected) in enumerate(zip(actual_bytes, sig_bytes)):
                         if actual != expected:
-                            corruptions.append(f"byte {i}: 0x{actual:02X} (expected 0x{expected:02X})")
-                    
+                            corruptions.append(
+                                f"byte {i}: 0x{actual:02X} (expected 0x{expected:02X})"
+                            )
+
                     # Limit to first 5 corruptions
-                    corruption_desc = '; '.join(corruptions[:5])
+                    corruption_desc = "; ".join(corruptions[:5])
                     if len(corruptions) > 5:
                         corruption_desc += f" ... and {len(corruptions) - 5} more"
-                    
+
                     confidence = match_ratio * 0.6  # Lower confidence for fuzzy matches
-                    
+
                     results.append(
                         DetectionResult(
                             format=f"{format_spec.format} (corrupted)",
@@ -177,30 +193,30 @@ class SignatureAnalyzer:
                             evidence=[
                                 f"Partially corrupted signature at offset {sig.offset}",
                                 f"{matches}/{sig_len} bytes match ({match_ratio*100:.1f}%)",
-                                f"Corruptions: {corruption_desc}"
+                                f"Corruptions: {corruption_desc}",
                             ],
                             weight=0.7,
                             contributions=[
                                 ConfidenceContribution(
                                     source="fuzzy_signature",
                                     value=confidence,
-                                    description=f"Fuzzy match: {match_ratio*100:.1f}% similarity"
+                                    description=f"Fuzzy match: {match_ratio*100:.1f}% similarity",
                                 )
                             ],
                         )
                     )
                     break  # One fuzzy match per format is enough
-        
+
         return sorted(results, key=lambda r: r.confidence, reverse=True)
 
 
 class StructuralAnalyzer:
     def __init__(self, database: FormatDatabase) -> None:
         self.database = database
-    
+
     def analyze(self, data: bytes, suspected_format: Optional[str] = None) -> list[DetectionResult]:
         results: list[DetectionResult] = []
-        
+
         # If we have a suspected format, validate its structure
         if suspected_format and suspected_format in self.database:
             spec = self.database.get_format(suspected_format)
@@ -208,27 +224,31 @@ class StructuralAnalyzer:
                 evidence = []
                 contributions = []
                 confidence = 0.8  # Base confidence for structural match
-                
+
                 # Check header size
                 if spec.structure.header_size:
                     if len(data) >= spec.structure.header_size:
                         evidence.append(f"Valid header size: {spec.structure.header_size} bytes")
-                        contributions.append(ConfidenceContribution(
-                            source="structure",
-                            value=0.3,
-                            description=f"Valid header size ({spec.structure.header_size} bytes)"
-                        ))
+                        contributions.append(
+                            ConfidenceContribution(
+                                source="structure",
+                                value=0.3,
+                                description=f"Valid header size ({spec.structure.header_size} bytes)",
+                            )
+                        )
                     else:
                         penalty = 0.4
                         confidence *= 0.5
                         evidence.append("File too small for expected header")
-                        contributions.append(ConfidenceContribution(
-                            source="structure",
-                            value=-penalty,
-                            description="File too small for expected header",
-                            is_penalty=True
-                        ))
-                
+                        contributions.append(
+                            ConfidenceContribution(
+                                source="structure",
+                                value=-penalty,
+                                description="File too small for expected header",
+                                is_penalty=True,
+                            )
+                        )
+
                 # Check footer signatures
                 for footer in spec.footers:
                     footer_bytes = bytes.fromhex(footer.hex)
@@ -236,12 +256,14 @@ class StructuralAnalyzer:
                         footer_contribution = 0.15
                         confidence = min(1.0, confidence + footer_contribution)
                         evidence.append(f"Footer match: {footer.description}")
-                        contributions.append(ConfidenceContribution(
-                            source="structure",
-                            value=footer_contribution,
-                            description=f"Footer: {footer.description}"
-                        ))
-                
+                        contributions.append(
+                            ConfidenceContribution(
+                                source="structure",
+                                value=footer_contribution,
+                                description=f"Footer: {footer.description}",
+                            )
+                        )
+
                 if evidence:
                     results.append(
                         DetectionResult(
@@ -252,264 +274,284 @@ class StructuralAnalyzer:
                             contributions=contributions,
                         )
                     )
-        
+
         return results
 
 
 class ZipBasedFormatAnalyzer:
     """Analyzer for ZIP-based formats like DOCX, XLSX, PPTX, ODT, ODP, ODS, etc."""
-    
+
     def __init__(self, database: FormatDatabase) -> None:
         self.database = database
-    
-    def analyze(self, data: bytes, file_path: Optional[Union[str, Path]] = None) -> list[DetectionResult]:
+
+    def analyze(
+        self, data: bytes, file_path: Optional[Union[str, Path]] = None
+    ) -> list[DetectionResult]:
         """
         Analyze ZIP-based formats by inspecting container contents.
-        
+
         Args:
             data: File data (may be partial for large files)
             file_path: Optional path to file (used for large ZIPs to read central directory)
         """
         results: list[DetectionResult] = []
-        
+
         # Check if it's a ZIP file
         if not data.startswith(b"PK\x03\x04"):
             return results
-        
+
         try:
             import zipfile
             import io
-            
+
             # For large files, try to use file path directly
             if file_path and Path(file_path).stat().st_size > 10 * 1024 * 1024:
                 try:
-                    zf = zipfile.ZipFile(file_path, 'r')
+                    zf = zipfile.ZipFile(file_path, "r")
                     namelist = zf.namelist()
                 except Exception:
                     # Fall back to data buffer if file access fails
                     zip_buffer = io.BytesIO(data)
-                    zf = zipfile.ZipFile(zip_buffer, 'r')
+                    zf = zipfile.ZipFile(zip_buffer, "r")
                     namelist = zf.namelist()
             else:
                 zip_buffer = io.BytesIO(data)
-                zf = zipfile.ZipFile(zip_buffer, 'r')
+                zf = zipfile.ZipFile(zip_buffer, "r")
                 namelist = zf.namelist()
             # Check for Office Open XML formats (DOCX, PPTX, XLSX)
             # Support both standard and non-standard structures (with subdirectories)
-            has_content_types = any('[content_types].xml' in name.lower() for name in namelist)
-            
+            has_content_types = any("[content_types].xml" in name.lower() for name in namelist)
+
             if has_content_types:
                 # DOCX: Contains word/document.xml (anywhere in structure)
-                if any('word/document.xml' in name.lower() for name in namelist):
-                    word_doc = next((n for n in namelist if 'word/document.xml' in n.lower()), None)
+                if any("word/document.xml" in name.lower() for name in namelist):
+                    word_doc = next((n for n in namelist if "word/document.xml" in n.lower()), None)
                     contributions = [
                         ConfidenceContribution(
-                            source="container",
-                            value=0.50,
-                            description=f"Contains {word_doc}"
+                            source="container", value=0.50, description=f"Contains {word_doc}"
                         ),
                         ConfidenceContribution(
                             source="container",
                             value=0.45,
-                            description="Contains [Content_Types].xml"
-                        )
+                            description="Contains [Content_Types].xml",
+                        ),
                     ]
-                    results.append(DetectionResult(
-                        format="docx",
-                        confidence=0.95,
-                        evidence=[f"Contains {word_doc}", "Contains [Content_Types].xml"],
-                        weight=2.0,
-                        contributions=contributions
-                    ))
-                
+                    results.append(
+                        DetectionResult(
+                            format="docx",
+                            confidence=0.95,
+                            evidence=[f"Contains {word_doc}", "Contains [Content_Types].xml"],
+                            weight=2.0,
+                            contributions=contributions,
+                        )
+                    )
+
                 # PPTX: Contains ppt/presentation.xml
-                elif any('ppt/presentation.xml' in name.lower() for name in namelist):
-                    ppt_file = next((n for n in namelist if 'ppt/presentation.xml' in n.lower()), None)
+                elif any("ppt/presentation.xml" in name.lower() for name in namelist):
+                    ppt_file = next(
+                        (n for n in namelist if "ppt/presentation.xml" in n.lower()), None
+                    )
                     contributions = [
                         ConfidenceContribution(
-                            source="container",
-                            value=0.50,
-                            description=f"Contains {ppt_file}"
+                            source="container", value=0.50, description=f"Contains {ppt_file}"
                         ),
                         ConfidenceContribution(
                             source="container",
                             value=0.45,
-                            description="Contains [Content_Types].xml"
-                        )
+                            description="Contains [Content_Types].xml",
+                        ),
                     ]
-                    results.append(DetectionResult(
-                        format="pptx",
-                        confidence=0.95,
-                        evidence=[f"Contains {ppt_file}", "Contains [Content_Types].xml"],
-                        weight=2.0,
-                        contributions=contributions
-                    ))
-                
+                    results.append(
+                        DetectionResult(
+                            format="pptx",
+                            confidence=0.95,
+                            evidence=[f"Contains {ppt_file}", "Contains [Content_Types].xml"],
+                            weight=2.0,
+                            contributions=contributions,
+                        )
+                    )
+
                 # XLSX: Contains xl/workbook.xml
-                elif any('xl/workbook.xml' in name.lower() for name in namelist):
-                    xl_file = next((n for n in namelist if 'xl/workbook.xml' in n.lower()), None)
+                elif any("xl/workbook.xml" in name.lower() for name in namelist):
+                    xl_file = next((n for n in namelist if "xl/workbook.xml" in n.lower()), None)
                     contributions = [
                         ConfidenceContribution(
-                            source="container",
-                            value=0.50,
-                            description=f"Contains {xl_file}"
+                            source="container", value=0.50, description=f"Contains {xl_file}"
                         ),
                         ConfidenceContribution(
                             source="container",
                             value=0.45,
-                            description="Contains [Content_Types].xml"
-                        )
+                            description="Contains [Content_Types].xml",
+                        ),
                     ]
-                    results.append(DetectionResult(
-                        format="xlsx",
-                        confidence=0.95,
-                        evidence=[f"Contains {xl_file}", "Contains [Content_Types].xml"],
-                        weight=2.0,
-                        contributions=contributions
-                    ))
-            
+                    results.append(
+                        DetectionResult(
+                            format="xlsx",
+                            confidence=0.95,
+                            evidence=[f"Contains {xl_file}", "Contains [Content_Types].xml"],
+                            weight=2.0,
+                            contributions=contributions,
+                        )
+                    )
+
             # Check for OpenDocument formats (ODT, ODP, ODS)
-            if 'mimetype' in namelist:
+            if "mimetype" in namelist:
                 try:
-                    mimetype_content = zf.read('mimetype').decode('utf-8', errors='ignore').strip()
-                    
+                    mimetype_content = zf.read("mimetype").decode("utf-8", errors="ignore").strip()
+
                     # ODT: OpenDocument Text
-                    if 'application/vnd.oasis.opendocument.text' in mimetype_content:
-                        results.append(DetectionResult(
-                            format="odt",
-                            confidence=0.98,
-                            evidence=[f"Mimetype: {mimetype_content}"],
-                            weight=2.0,
-                            contributions=[
-                                ConfidenceContribution(
-                                    source="container",
-                                    value=0.98,
-                                    description=f"Mimetype: {mimetype_content}"
-                                )
-                            ]
-                        ))
-                    
+                    if "application/vnd.oasis.opendocument.text" in mimetype_content:
+                        results.append(
+                            DetectionResult(
+                                format="odt",
+                                confidence=0.98,
+                                evidence=[f"Mimetype: {mimetype_content}"],
+                                weight=2.0,
+                                contributions=[
+                                    ConfidenceContribution(
+                                        source="container",
+                                        value=0.98,
+                                        description=f"Mimetype: {mimetype_content}",
+                                    )
+                                ],
+                            )
+                        )
+
                     # ODP: OpenDocument Presentation
-                    elif 'application/vnd.oasis.opendocument.presentation' in mimetype_content:
-                        results.append(DetectionResult(
-                            format="odp",
-                            confidence=0.98,
-                            evidence=[f"Mimetype: {mimetype_content}"],
-                            weight=2.0,
-                            contributions=[
-                                ConfidenceContribution(
-                                    source="container",
-                                    value=0.98,
-                                    description=f"Mimetype: {mimetype_content}"
-                                )
-                            ]
-                        ))
-                    
+                    elif "application/vnd.oasis.opendocument.presentation" in mimetype_content:
+                        results.append(
+                            DetectionResult(
+                                format="odp",
+                                confidence=0.98,
+                                evidence=[f"Mimetype: {mimetype_content}"],
+                                weight=2.0,
+                                contributions=[
+                                    ConfidenceContribution(
+                                        source="container",
+                                        value=0.98,
+                                        description=f"Mimetype: {mimetype_content}",
+                                    )
+                                ],
+                            )
+                        )
+
                     # ODS: OpenDocument Spreadsheet
-                    elif 'application/vnd.oasis.opendocument.spreadsheet' in mimetype_content:
-                        results.append(DetectionResult(
-                            format="ods",
-                            confidence=0.98,
-                            evidence=[f"Mimetype: {mimetype_content}"],
-                            weight=2.0,
-                            contributions=[
-                                ConfidenceContribution(
-                                    source="container",
-                                    value=0.98,
-                                    description=f"Mimetype: {mimetype_content}"
-                                )
-                            ]
-                        ))
+                    elif "application/vnd.oasis.opendocument.spreadsheet" in mimetype_content:
+                        results.append(
+                            DetectionResult(
+                                format="ods",
+                                confidence=0.98,
+                                evidence=[f"Mimetype: {mimetype_content}"],
+                                weight=2.0,
+                                contributions=[
+                                    ConfidenceContribution(
+                                        source="container",
+                                        value=0.98,
+                                        description=f"Mimetype: {mimetype_content}",
+                                    )
+                                ],
+                            )
+                        )
                 except Exception:
                     pass
-            
+
             # Check for EPUB (electronic publication)
-            if 'META-INF/container.xml' in namelist and 'mimetype' in namelist:
+            if "META-INF/container.xml" in namelist and "mimetype" in namelist:
                 try:
-                    mimetype_content = zf.read('mimetype').decode('utf-8', errors='ignore').strip()
-                    if 'application/epub+zip' in mimetype_content:
-                        results.append(DetectionResult(
-                            format="epub",
-                            confidence=0.98,
-                            evidence=[f"Mimetype: {mimetype_content}", "Contains META-INF/container.xml"],
-                            weight=2.0,
-                            contributions=[
-                                ConfidenceContribution(
-                                    source="container",
-                                    value=0.60,
-                                    description=f"Mimetype: {mimetype_content}"
-                                ),
-                                ConfidenceContribution(
-                                    source="container",
-                                    value=0.38,
-                                    description="Contains META-INF/container.xml"
-                                )
-                            ]
-                        ))
+                    mimetype_content = zf.read("mimetype").decode("utf-8", errors="ignore").strip()
+                    if "application/epub+zip" in mimetype_content:
+                        results.append(
+                            DetectionResult(
+                                format="epub",
+                                confidence=0.98,
+                                evidence=[
+                                    f"Mimetype: {mimetype_content}",
+                                    "Contains META-INF/container.xml",
+                                ],
+                                weight=2.0,
+                                contributions=[
+                                    ConfidenceContribution(
+                                        source="container",
+                                        value=0.60,
+                                        description=f"Mimetype: {mimetype_content}",
+                                    ),
+                                    ConfidenceContribution(
+                                        source="container",
+                                        value=0.38,
+                                        description="Contains META-INF/container.xml",
+                                    ),
+                                ],
+                            )
+                        )
                 except Exception:
                     pass
-            
+
             # Check for JAR (Java Archive)
-            if 'META-INF/MANIFEST.MF' in namelist:
-                results.append(DetectionResult(
-                    format="jar",
-                    confidence=0.90,
-                    evidence=["Contains META-INF/MANIFEST.MF"],
-                    weight=2.0,
-                    contributions=[
-                        ConfidenceContribution(
-                            source="container",
-                            value=0.90,
-                            description="Contains META-INF/MANIFEST.MF"
-                        )
-                    ]
-                ))
-            
+            if "META-INF/MANIFEST.MF" in namelist:
+                results.append(
+                    DetectionResult(
+                        format="jar",
+                        confidence=0.90,
+                        evidence=["Contains META-INF/MANIFEST.MF"],
+                        weight=2.0,
+                        contributions=[
+                            ConfidenceContribution(
+                                source="container",
+                                value=0.90,
+                                description="Contains META-INF/MANIFEST.MF",
+                            )
+                        ],
+                    )
+                )
+
             # Check for APK (Android Package)
-            if 'AndroidManifest.xml' in namelist and 'classes.dex' in namelist:
-                results.append(DetectionResult(
-                    format="apk",
-                    confidence=0.95,
-                    evidence=["Contains AndroidManifest.xml", "Contains classes.dex"],
-                    weight=2.0,
-                    contributions=[
-                        ConfidenceContribution(
-                            source="container",
-                            value=0.50,
-                            description="Contains AndroidManifest.xml"
-                        ),
-                        ConfidenceContribution(
-                            source="container",
-                            value=0.45,
-                            description="Contains classes.dex"
-                        )
-                    ]
-                ))
-            
+            if "AndroidManifest.xml" in namelist and "classes.dex" in namelist:
+                results.append(
+                    DetectionResult(
+                        format="apk",
+                        confidence=0.95,
+                        evidence=["Contains AndroidManifest.xml", "Contains classes.dex"],
+                        weight=2.0,
+                        contributions=[
+                            ConfidenceContribution(
+                                source="container",
+                                value=0.50,
+                                description="Contains AndroidManifest.xml",
+                            ),
+                            ConfidenceContribution(
+                                source="container", value=0.45, description="Contains classes.dex"
+                            ),
+                        ],
+                    )
+                )
+
             # Close ZIP file
             zf.close()
-            
+
             # If no specific ZIP-based format was detected, it's a plain ZIP archive
             if not results:
-                results.append(DetectionResult(
-                    format="zip",
-                    confidence=0.95,
-                    evidence=[f"Standard ZIP archive with {len(namelist)} files"],
-                    weight=2.5,
-                    contributions=[
-                        ConfidenceContribution(
-                            source="container",
-                            value=0.95,
-                            description=f"Standard ZIP archive with {len(namelist)} files"
-                        )
-                    ]
-                ))
-        
+                results.append(
+                    DetectionResult(
+                        format="zip",
+                        confidence=0.95,
+                        evidence=[f"Standard ZIP archive with {len(namelist)} files"],
+                        weight=2.5,
+                        contributions=[
+                            ConfidenceContribution(
+                                source="container",
+                                value=0.95,
+                                description=f"Standard ZIP archive with {len(namelist)} files",
+                            )
+                        ],
+                    )
+                )
+
         except Exception as e:
             import traceback
+
             logger.debug(f"ZIP analysis failed: {e}")
             logger.debug(traceback.format_exc())
-        
+
         return results
 
 
@@ -518,34 +560,35 @@ class StatisticalAnalyzer:
     def calculate_entropy(data: bytes, sample_size: int = 2048) -> float:
         if not data:
             return 0.0
-        
-        sample = data[:min(sample_size, len(data))]
-        
+
+        sample = data[: min(sample_size, len(data))]
+
         frequencies = [0] * 256
         for byte in sample:
             frequencies[byte] += 1
-        
+
         import math
+
         entropy = 0.0
         data_len = len(sample)
-        
+
         for freq in frequencies:
             if freq > 0:
                 probability = freq / data_len
                 entropy -= probability * math.log2(probability)
-        
+
         return entropy
-    
+
     @staticmethod
     def chunk_entropy(data: bytes, chunk_size: int = 256) -> list[float]:
         if not data:
             return []
         entropies = []
         for i in range(0, len(data), chunk_size):
-            chunk = data[i:i + chunk_size]
+            chunk = data[i : i + chunk_size]
             entropies.append(StatisticalAnalyzer.calculate_entropy(chunk, sample_size=chunk_size))
         return entropies
-    
+
     @staticmethod
     def format_entropy_bar(entropies: list[float], width: int = 60) -> str:
         if not entropies:
@@ -570,14 +613,14 @@ class StatisticalAnalyzer:
         result = []
         per_segment = max(1, len(blocks) // width)
         for i in range(0, len(blocks), per_segment):
-            segment = blocks[i:i + per_segment]
+            segment = blocks[i : i + per_segment]
             result.append("".join(segment))
         return "".join(result[:width])
 
 
 class Analyzer:
     def __init__(
-        self, 
+        self,
         database: Optional[FormatDatabase] = None,
         use_ml: bool = True,
         detect_embedded: bool = True,
@@ -593,17 +636,17 @@ class Analyzer:
         self.embedded_detector = EmbeddedDetector(self.database) if detect_embedded else None
         self.fingerprinter = ToolFingerprinter() if fingerprint else None
         self.polyglot_detector = PolyglotDetector() if detect_polyglots else None
-        
-        self.ml_detector: Optional['MLDetector'] = None
+
+        self.ml_detector: Optional["MLDetector"] = None
         if use_ml and ML_AVAILABLE:
             try:
                 self.ml_detector = MLDetector()
                 logger.info("ML detector enabled")
             except Exception as e:
                 logger.warning(f"ML detector failed to initialize: {e}")
-        
+
         # Initialize YARA scanner
-        self.yara_scanner: Optional['YARAScanner'] = None
+        self.yara_scanner: Optional["YARAScanner"] = None
         if YARA_AVAILABLE:
             self.yara_scanner = YARAScanner()
             if yara_rules:
@@ -615,30 +658,41 @@ class Analyzer:
                     logger.info(f"YARA scanner loaded {len(rule_paths)} rule file(s)")
                 except Exception as e:
                     logger.warning(f"YARA rule loading failed: {e}")
-        
+
         logger.info(f"Analyzer initialized with {self.database.count()} formats")
-    
+
     def analyze(self, data: bytes, file_path: Optional[Union[str, Path]] = None) -> AnalysisResult:
         checksum = hashlib.sha256(data).hexdigest()[:16]
-        
+
         sig_results = self.signature_analyzer.analyze(data)
-        
+
         # Early return for high-confidence matches, BUT NOT for ZIP-based formats
         # (they need container analysis to distinguish between DOCX/XLSX/ODP/etc)
-        zip_based_formats = {'zip', 'docx', 'pptx', 'xlsx', 'odt', 'odp', 'ods', 'epub', 'jar', 'apk'}
-        
+        zip_based_formats = {
+            "zip",
+            "docx",
+            "pptx",
+            "xlsx",
+            "odt",
+            "odp",
+            "ods",
+            "epub",
+            "jar",
+            "apk",
+        }
+
         if sig_results and sig_results[0].confidence > 0.95:
             # Skip early return if this is a ZIP-based format (needs container inspection)
             if sig_results[0].format not in zip_based_formats:
                 entropy = self.statistical_analyzer.calculate_entropy(data[:2048])
-                
+
                 # Check for contradictions even in early return
                 contradictions = []
                 try:
                     contradictions = ContradictionDetector.detect_all(data, sig_results[0].format)
                 except Exception as e:
                     logger.debug(f"Contradiction detection failed: {e}")
-                
+
                 # Run YARA scanning in early return too
                 yara_matches_list = []
                 if self.yara_scanner and self.yara_scanner.available:
@@ -646,103 +700,131 @@ class Analyzer:
                         yara_result = self.yara_scanner.scan_data(data)
                         if yara_result.matches:
                             yara_matches_list = [
-                                YARAMatchInfo(rule=m.rule, namespace=m.namespace, tags=m.tags, meta=m.meta, matched_strings=m.strings)
+                                YARAMatchInfo(
+                                    rule=m.rule,
+                                    namespace=m.namespace,
+                                    tags=m.tags,
+                                    meta=m.meta,
+                                    matched_strings=m.strings,
+                                )
                                 for m in yara_result.matches
                             ]
                     except Exception:
                         pass
-                
+
                 return AnalysisResult(
                     primary_format=sig_results[0].format,
                     confidence=sig_results[0].confidence,
                     alternative_formats=[(r.format, r.confidence) for r in sig_results[1:3]],
-                    evidence_chain=[{
-                        "module": "signature_analysis",
-                        "format": sig_results[0].format,
-                        "confidence": sig_results[0].confidence,
-                        "evidence": sig_results[0].evidence,
-                        "weight": 1.0,
-                    }],
+                    evidence_chain=[
+                        {
+                            "module": "signature_analysis",
+                            "format": sig_results[0].format,
+                            "confidence": sig_results[0].confidence,
+                            "evidence": sig_results[0].evidence,
+                            "weight": 1.0,
+                        }
+                    ],
                     contradictions=contradictions,
                     yara_matches=yara_matches_list,
                     file_size=len(data),
                     entropy=entropy,
                     checksum_sha256=checksum,
                 )
-        
+
         struct_results = []
         if sig_results:
             struct_results = self.structural_analyzer.analyze(
                 data, suspected_format=sig_results[0].format
             )
-        
+
         # Check for ZIP-based formats (DOCX, XLSX, PPTX, ODT, ODP, ODS, etc.)
         zip_results = self.zip_analyzer.analyze(data, file_path=file_path)
-        
+
         entropy = self.statistical_analyzer.calculate_entropy(data[:2048])
-        
+
         ml_results = []
         if self.ml_detector:
             ml_results = self.ml_detector.predict(data, entropy, len(data))
-        
+
         format_scores: dict[str, float] = {}
         evidence_chain: list[dict] = []
-        
+
         for result in sig_results:
             format_scores[result.format] = format_scores.get(result.format, 0.0) + (
                 result.confidence * result.weight * 0.6
             )
-            evidence_chain.append({
-                "module": "signature_analysis",
-                "format": result.format,
-                "confidence": result.confidence,
-                "evidence": result.evidence,
-                "weight": result.weight,
-                "contributions": [c.model_dump() for c in result.contributions] if result.contributions else [],
-            })
-        
+            evidence_chain.append(
+                {
+                    "module": "signature_analysis",
+                    "format": result.format,
+                    "confidence": result.confidence,
+                    "evidence": result.evidence,
+                    "weight": result.weight,
+                    "contributions": (
+                        [c.model_dump() for c in result.contributions]
+                        if result.contributions
+                        else []
+                    ),
+                }
+            )
+
         for result in struct_results:
             format_scores[result.format] = format_scores.get(result.format, 0.0) + (
                 result.confidence * result.weight * 0.4
             )
-            evidence_chain.append({
-                "module": "structural_analysis",
-                "format": result.format,
-                "confidence": result.confidence,
-                "evidence": result.evidence,
-                "weight": result.weight,
-                "contributions": [c.model_dump() for c in result.contributions] if result.contributions else [],
-            })
-        
+            evidence_chain.append(
+                {
+                    "module": "structural_analysis",
+                    "format": result.format,
+                    "confidence": result.confidence,
+                    "evidence": result.evidence,
+                    "weight": result.weight,
+                    "contributions": (
+                        [c.model_dump() for c in result.contributions]
+                        if result.contributions
+                        else []
+                    ),
+                }
+            )
+
         # ZIP-based format detection has highest weight for accurate container detection
         for result in zip_results:
             format_scores[result.format] = format_scores.get(result.format, 0.0) + (
                 result.confidence * result.weight * 0.8
             )
-            evidence_chain.append({
-                "module": "zip_container_analysis",
-                "format": result.format,
-                "confidence": result.confidence,
-                "evidence": result.evidence,
-                "weight": result.weight,
-                "contributions": [c.model_dump() for c in result.contributions] if result.contributions else [],
-            })
-        
+            evidence_chain.append(
+                {
+                    "module": "zip_container_analysis",
+                    "format": result.format,
+                    "confidence": result.confidence,
+                    "evidence": result.evidence,
+                    "weight": result.weight,
+                    "contributions": (
+                        [c.model_dump() for c in result.contributions]
+                        if result.contributions
+                        else []
+                    ),
+                }
+            )
+
         for fmt, ml_confidence in ml_results:
             format_scores[fmt] = format_scores.get(fmt, 0.0) + (ml_confidence * 0.2)
-            evidence_chain.append({
-                "module": "ml_prediction",
-                "format": fmt,
-                "confidence": ml_confidence,
-                "evidence": ["Learned pattern match"],
-                "weight": 0.2,
-            })
-        
+            evidence_chain.append(
+                {
+                    "module": "ml_prediction",
+                    "format": fmt,
+                    "confidence": ml_confidence,
+                    "evidence": ["Learned pattern match"],
+                    "weight": 0.2,
+                }
+            )
+
         # Determine primary format
         if format_scores:
             primary_format = max(format_scores, key=format_scores.get)  # type: ignore
             confidence = min(1.0, format_scores[primary_format])
-            
+
             alternatives = [
                 (fmt, score) for fmt, score in format_scores.items() if fmt != primary_format
             ]
@@ -750,77 +832,82 @@ class Analyzer:
         else:
             # No format detected - try fuzzy matching for corrupted files
             fuzzy_results = self.signature_analyzer.fuzzy_match(data)
-            
+
             if fuzzy_results:
                 # Report the best fuzzy match
                 best_match = fuzzy_results[0]
                 primary_format = best_match.format
                 confidence = best_match.confidence
-                
-                evidence_chain.append({
-                    "module": "fuzzy_signature_analysis",
-                    "format": best_match.format,
-                    "confidence": best_match.confidence,
-                    "evidence": best_match.evidence,
-                    "weight": best_match.weight,
-                    "contributions": [c.model_dump() for c in best_match.contributions] if best_match.contributions else [],
-                })
-                
-                alternatives = [
-                    (r.format, r.confidence) for r in fuzzy_results[1:3]
-                ]
+
+                evidence_chain.append(
+                    {
+                        "module": "fuzzy_signature_analysis",
+                        "format": best_match.format,
+                        "confidence": best_match.confidence,
+                        "evidence": best_match.evidence,
+                        "weight": best_match.weight,
+                        "contributions": (
+                            [c.model_dump() for c in best_match.contributions]
+                            if best_match.contributions
+                            else []
+                        ),
+                    }
+                )
+
+                alternatives = [(r.format, r.confidence) for r in fuzzy_results[1:3]]
             else:
                 primary_format = "unknown"
                 confidence = 0.0
                 alternatives = []
-        
+
         # Detect contradictions
         contradictions = []
         try:
             # Strip " (corrupted)" suffix for format comparison (fuzzy matches append this)
             clean_format = primary_format.replace(" (corrupted)", "")
-            
+
             # Gather context for contradiction checks
             context = {}
-            if clean_format in ['docx', 'xlsx', 'pptx', 'zip', 'odt', 'odp', 'ods']:
+            if clean_format in ["docx", "xlsx", "pptx", "zip", "odt", "odp", "ods"]:
                 # Get ZIP namelist if available
                 for evidence in evidence_chain:
                     if evidence.get("module") == "zip_container_analysis":
                         try:
                             import zipfile
                             import io
-                            with zipfile.ZipFile(io.BytesIO(data), 'r') as zf:
-                                context['namelist'] = zf.namelist()
+
+                            with zipfile.ZipFile(io.BytesIO(data), "r") as zf:
+                                context["namelist"] = zf.namelist()
                         except Exception:
                             pass
                         break
-            
+
             # Run contradiction detection with clean format name
             contradictions = ContradictionDetector.detect_all(data, clean_format, **context)
         except Exception as e:
             logger.debug(f"Contradiction detection failed: {e}")
-        
+
         # Detect embedded objects
         embedded_objects = []
         if self.embedded_detector:
             try:
                 # Use higher confidence threshold and pass parent format for exclusion rules
                 embedded_objects = self.embedded_detector.detect_embedded(
-                    data, 
+                    data,
                     min_confidence=0.80,  # Raised from 0.70 to reduce false positives
-                    parent_format=primary_format
+                    parent_format=primary_format,
                 )
-                
-                if primary_format in ['pe', 'elf', 'zip']:
+
+                if primary_format in ["pe", "elf", "zip"]:
                     overlay = self.embedded_detector.detect_overlay(data, primary_format)
                     if overlay:
                         embedded_objects.append(overlay)
-                
+
                 if embedded_objects:
                     logger.info(f"Detected {len(embedded_objects)} embedded object(s)")
             except Exception as e:
                 logger.debug(f"Embedded detection failed: {e}")
-        
+
         # Extract tool/creator fingerprints
         fingerprints = []
         if self.fingerprinter:
@@ -830,7 +917,7 @@ class Analyzer:
                     logger.info(f"Extracted {len(fingerprints)} fingerprint(s)")
             except Exception as e:
                 logger.debug(f"Fingerprinting failed: {e}")
-        
+
         # Detect polyglot files
         polyglots = []
         if self.polyglot_detector:
@@ -840,19 +927,21 @@ class Analyzer:
                     logger.info(f"Detected {len(polyglots)} polyglot combination(s)")
             except Exception as e:
                 logger.debug(f"Polyglot detection failed: {e}")
-        
+
         # Detect CPU architecture for executable formats
         architecture = None
-        if primary_format in ['elf', 'exe', 'dll', 'macho']:
+        if primary_format in ["elf", "exe", "dll", "macho"]:
             try:
                 arch_detector = ArchitectureDetector()
                 arch_info = arch_detector.detect(data)
                 if arch_info:
                     architecture = ArchitectureInfo(**arch_info)
-                    logger.info(f"Detected architecture: {arch_info['architecture']} ({arch_info['bits']})")
+                    logger.info(
+                        f"Detected architecture: {arch_info['architecture']} ({arch_info['bits']})"
+                    )
             except Exception as e:
                 logger.debug(f"Architecture detection failed: {e}")
-        
+
         # Perform cryptographic analysis
         crypto_analysis = None
         try:
@@ -864,7 +953,7 @@ class Analyzer:
                     logger.info(f"Likely encrypted (confidence: {crypto_result.confidence:.0%})")
         except Exception as e:
             logger.debug(f"Crypto analysis failed: {e}")
-        
+
         # Run YARA scanning
         yara_matches_list: list[YARAMatchInfo] = []
         if self.yara_scanner and self.yara_scanner.available:
@@ -873,25 +962,29 @@ class Analyzer:
                 if yara_result.matches:
                     for m in yara_result.matches:
                         desc = m.meta.get("description", "") if m.meta else ""
-                        yara_matches_list.append(YARAMatchInfo(
-                            rule=m.rule,
-                            namespace=m.namespace,
-                            tags=m.tags,
-                            meta=m.meta,
-                            matched_strings=m.strings,
-                            description=desc,
-                        ))
+                        yara_matches_list.append(
+                            YARAMatchInfo(
+                                rule=m.rule,
+                                namespace=m.namespace,
+                                tags=m.tags,
+                                meta=m.meta,
+                                matched_strings=m.strings,
+                                description=desc,
+                            )
+                        )
                     logger.info(f"YARA: {len(yara_matches_list)} rule(s) matched")
             except Exception as e:
                 logger.debug(f"YARA scanning failed: {e}")
-        
+
         # Run Office macro analysis for OLE2-based files
         office_macros_info: Optional[OfficeMacroInfo] = None
         clean_fmt = primary_format.replace(" (corrupted)", "")
-        if OFFICE_AVAILABLE and clean_fmt in ('ole2', 'msi', 'msg', 'doc', 'xls', 'ppt'):
+        if OFFICE_AVAILABLE and clean_fmt in ("ole2", "msi", "msg", "doc", "xls", "ppt"):
             try:
                 office_result = analyze_office_file(data)
-                if office_result and (office_result.has_macros or office_result.suspicious_keywords):
+                if office_result and (
+                    office_result.has_macros or office_result.suspicious_keywords
+                ):
                     office_macros_info = OfficeMacroInfo(
                         has_macros=office_result.has_macros,
                         macro_count=office_result.macro_count,
@@ -903,10 +996,12 @@ class Analyzer:
                         is_protected=office_result.is_protected,
                     )
                     if office_result.has_macros:
-                        logger.info(f"Office macros detected: {office_result.macro_count} module(s)")
+                        logger.info(
+                            f"Office macros detected: {office_result.macro_count} module(s)"
+                        )
             except Exception as e:
                 logger.debug(f"Office analysis failed: {e}")
-        
+
         return AnalysisResult(
             primary_format=primary_format,
             confidence=confidence,
@@ -924,47 +1019,51 @@ class Analyzer:
             entropy=entropy,
             checksum_sha256=checksum,
         )
-    
-    def teach(self, data: bytes, correct_format: str, incorrect_guess: Optional[str] = None) -> None:
+
+    def teach(
+        self, data: bytes, correct_format: str, incorrect_guess: Optional[str] = None
+    ) -> None:
         if not self.ml_detector:
             logger.warning("ML detector not available for teaching")
             return
-        
+
         entropy = self.statistical_analyzer.calculate_entropy(data[:8192])
         file_hash = hashlib.sha256(data).hexdigest()
-        
+
         patterns = []
-        
+
         # First, try to extract known signatures for this format
         spec = self.database.get_format(correct_format)
         if spec:
             for sig in spec.signatures:
                 sig_bytes = bytes.fromhex(sig.hex)
                 if len(data) > sig.offset + len(sig_bytes):
-                    if data[sig.offset:sig.offset + len(sig_bytes)] == sig_bytes:
-                        patterns.append(PatternMatch(
-                            offset=sig.offset,
-                            pattern=sig_bytes,
-                            format=correct_format,
-                            weight=sig.weight
-                        ))
-        
+                    if data[sig.offset : sig.offset + len(sig_bytes)] == sig_bytes:
+                        patterns.append(
+                            PatternMatch(
+                                offset=sig.offset,
+                                pattern=sig_bytes,
+                                format=correct_format,
+                                weight=sig.weight,
+                            )
+                        )
+
         # Also extract discriminative patterns automatically from the file
         auto_patterns = self.ml_detector.extract_discriminative_patterns(data, max_patterns=15)
         for pattern in auto_patterns:
             pattern.format = correct_format
             patterns.append(pattern)
-        
+
         # Extract rich statistical features
         features = self.ml_detector.extract_features(data)
-        
+
         # Build n-gram profile
         ngram_profile = self.ml_detector.build_ngram_profile(data, n=3)
-        
+
         incorrect_formats = []
         if incorrect_guess:
             incorrect_formats.append(incorrect_guess)
-        
+
         example = LearningExample(
             file_hash=file_hash,
             patterns=patterns,
@@ -973,25 +1072,26 @@ class Analyzer:
             entropy=entropy,
             incorrect_formats=incorrect_formats,
             features=features,
-            ngram_profile=ngram_profile
+            ngram_profile=ngram_profile,
         )
-        
-        self.ml_detector.learn(example)
-        logger.info(f"Learned from example: {correct_format} ({len(patterns)} patterns, {len(features)} features, {len(ngram_profile)} n-grams)")
 
-    
+        self.ml_detector.learn(example)
+        logger.info(
+            f"Learned from example: {correct_format} ({len(patterns)} patterns, {len(features)} features, {len(ngram_profile)} n-grams)"
+        )
+
     def analyze_file(self, file_path: Union[str, Path]) -> AnalysisResult:
         path = Path(file_path)
         file_size = path.stat().st_size
-        
+
         # Read file data (limited for large files to save memory)
         if file_size > 10 * 1024 * 1024:
             with open(path, "rb") as f:
                 with mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ) as mmapped:
-                    data = bytes(mmapped[:min(1024 * 1024, file_size)])
+                    data = bytes(mmapped[: min(1024 * 1024, file_size)])
         else:
             with open(path, "rb") as f:
                 data = f.read()
-        
+
         # Pass file path so ZIP analyzer can open the full file if needed
         return self.analyze(data, file_path=path)

--- a/filo/analyzer.py
+++ b/filo/analyzer.py
@@ -5,7 +5,7 @@ from typing import Optional, Union
 import mmap
 
 from filo.formats import FormatDatabase
-from filo.models import AnalysisResult, DetectionResult, ConfidenceContribution, Fingerprint, ArchitectureInfo, YARAMatchInfo, OfficeMacroInfo
+from filo.models import AnalysisResult, DetectionResult, ConfidenceContribution, ArchitectureInfo, YARAMatchInfo, OfficeMacroInfo
 from filo.contradictions import ContradictionDetector
 from filo.embedded import EmbeddedDetector
 from filo.fingerprint import ToolFingerprinter
@@ -20,7 +20,7 @@ except ImportError:
     YARA_AVAILABLE = False
 
 try:
-    from filo.office import analyze_office_file, OfficeAnalysisResult
+    from filo.office import analyze_office_file
     OFFICE_AVAILABLE = True
 except ImportError:
     OFFICE_AVAILABLE = False
@@ -73,7 +73,6 @@ class SignatureAnalyzer:
                 
                 # If offset_max is set, scan within the range
                 if sig.offset_max is not None:
-                    found = False
                     search_end = min(sig.offset_max, len(scan_data) - len(sig_bytes) + 1)
                     for search_offset in range(sig.offset, search_end):
                         if scan_data[search_offset:search_offset + len(sig_bytes)] == sig_bytes:
@@ -87,7 +86,6 @@ class SignatureAnalyzer:
                                 value=match_contribution,
                                 description=f"{sig.description} at offset {search_offset}"
                             ))
-                            found = True
                             break
                 else:
                     # Exact offset match
@@ -287,7 +285,7 @@ class ZipBasedFormatAnalyzer:
                 try:
                     zf = zipfile.ZipFile(file_path, 'r')
                     namelist = zf.namelist()
-                except Exception as ex:
+                except Exception:
                     # Fall back to data buffer if file access fails
                     zip_buffer = io.BytesIO(data)
                     zf = zipfile.ZipFile(zip_buffer, 'r')
@@ -296,8 +294,6 @@ class ZipBasedFormatAnalyzer:
                 zip_buffer = io.BytesIO(data)
                 zf = zipfile.ZipFile(zip_buffer, 'r')
                 namelist = zf.namelist()
-            namelist_lower = [name.lower() for name in namelist]
-            
             # Check for Office Open XML formats (DOCX, PPTX, XLSX)
             # Support both standard and non-standard structures (with subdirectories)
             has_content_types = any('[content_types].xml' in name.lower() for name in namelist)

--- a/filo/architecture.py
+++ b/filo/architecture.py
@@ -5,7 +5,7 @@ This module provides architecture detection for ELF, PE, and Mach-O executables.
 
 import logging
 import struct
-from typing import Optional
+from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -169,11 +169,11 @@ class ArchitectureDetector:
         0x01000012: "PowerPC 64",
     }
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize the architecture detector."""
         pass
 
-    def detect_elf_architecture(self, data: bytes) -> Optional[dict]:
+    def detect_elf_architecture(self, data: bytes) -> Optional[dict[str, Any]]:
         """
         Detect CPU architecture from ELF header.
 
@@ -218,7 +218,7 @@ class ArchitectureDetector:
             "format": "ELF",
         }
 
-    def detect_pe_architecture(self, data: bytes) -> Optional[dict]:
+    def detect_pe_architecture(self, data: bytes) -> Optional[dict[str, Any]]:
         """
         Detect CPU architecture from PE header.
 
@@ -264,7 +264,7 @@ class ArchitectureDetector:
             "format": "PE",
         }
 
-    def detect_macho_architecture(self, data: bytes) -> Optional[dict]:
+    def detect_macho_architecture(self, data: bytes) -> Optional[dict[str, Any]]:
         """
         Detect CPU architecture from Mach-O header.
 
@@ -317,7 +317,7 @@ class ArchitectureDetector:
             "format": "Mach-O",
         }
 
-    def detect(self, data: bytes) -> Optional[dict]:
+    def detect(self, data: bytes) -> Optional[dict[str, Any]]:
         """
         Auto-detect architecture from any executable format.
 

--- a/filo/architecture.py
+++ b/filo/architecture.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 class ArchitectureDetector:
     """Detect CPU architecture from executable file headers."""
-    
+
     # ELF e_machine values (from ELF specification)
     # Reference: https://refspecs.linuxfoundation.org/elf/gabi4+/ch4.eheader.html
     ELF_MACHINES = {
@@ -110,7 +110,7 @@ class ArchitectureDetector:
         0xF7: "Berkeley Packet Filter",
         0x101: "WDC 65C816",
     }
-    
+
     # PE Machine types (from PE/COFF specification)
     # Reference: https://learn.microsoft.com/en-us/windows/win32/debug/pe-format
     PE_MACHINES = {
@@ -149,7 +149,7 @@ class ArchitectureDetector:
         0xAA64: "ARM64 little endian (Aarch64)",
         0xC0EE: "clr pure MSIL",
     }
-    
+
     # Mach-O CPU types (from mach-o/loader.h)
     # Reference: https://github.com/apple-oss-distributions/xnu/blob/main/EXTERNAL_HEADERS/mach-o/machine.h
     MACHO_CPUTYPES = {
@@ -168,119 +168,121 @@ class ArchitectureDetector:
         18: "PowerPC",
         0x01000012: "PowerPC 64",
     }
-    
+
     def __init__(self):
         """Initialize the architecture detector."""
         pass
-    
+
     def detect_elf_architecture(self, data: bytes) -> Optional[dict]:
         """
         Detect CPU architecture from ELF header.
-        
+
         Args:
             data: First 20+ bytes of ELF file
-            
+
         Returns:
             Dict with architecture info or None if not ELF
         """
         if len(data) < 20:
             return None
-            
+
         # Check ELF magic
-        if data[0:4] != b'\x7fELF':
+        if data[0:4] != b"\x7fELF":
             return None
-        
+
         # Extract ELF class (32-bit or 64-bit)
         ei_class = data[4]
         class_name = "32-bit" if ei_class == 1 else "64-bit" if ei_class == 2 else "Unknown"
-        
+
         # Extract endianness
         ei_data = data[5]
-        is_little_endian = (ei_data == 1)
-        endian_name = "Little-endian" if is_little_endian else "Big-endian" if ei_data == 2 else "Unknown"
-        
+        is_little_endian = ei_data == 1
+        endian_name = (
+            "Little-endian" if is_little_endian else "Big-endian" if ei_data == 2 else "Unknown"
+        )
+
         # Extract e_machine (at offset 0x12 for both 32/64-bit, 2 bytes)
         if is_little_endian:
-            e_machine = struct.unpack('<H', data[0x12:0x14])[0]
+            e_machine = struct.unpack("<H", data[0x12:0x14])[0]
         else:
-            e_machine = struct.unpack('>H', data[0x12:0x14])[0]
-        
+            e_machine = struct.unpack(">H", data[0x12:0x14])[0]
+
         # Get architecture name
         arch_name = self.ELF_MACHINES.get(e_machine, f"Unknown (0x{e_machine:04X})")
-        
+
         return {
             "architecture": arch_name,
             "bits": class_name,
             "endian": endian_name,
             "machine_code": e_machine,
-            "format": "ELF"
+            "format": "ELF",
         }
-    
+
     def detect_pe_architecture(self, data: bytes) -> Optional[dict]:
         """
         Detect CPU architecture from PE header.
-        
+
         Args:
             data: First 128+ bytes of PE file
-            
+
         Returns:
             Dict with architecture info or None if not PE
         """
         if len(data) < 128:
             return None
-            
+
         # Check DOS header
-        if data[0:2] != b'MZ':
+        if data[0:2] != b"MZ":
             return None
-        
+
         # Get PE header offset (at 0x3C)
-        pe_offset = struct.unpack('<I', data[0x3C:0x40])[0]
-        
+        pe_offset = struct.unpack("<I", data[0x3C:0x40])[0]
+
         if pe_offset + 6 > len(data):
             return None
-            
+
         # Check PE signature
-        if data[pe_offset:pe_offset+4] != b'PE\x00\x00':
+        if data[pe_offset : pe_offset + 4] != b"PE\x00\x00":
             return None
-        
+
         # Extract Machine type (2 bytes after PE signature)
-        machine = struct.unpack('<H', data[pe_offset+4:pe_offset+6])[0]
-        
+        machine = struct.unpack("<H", data[pe_offset + 4 : pe_offset + 6])[0]
+
         # Get architecture name
         arch_name = self.PE_MACHINES.get(machine, f"Unknown (0x{machine:04X})")
-        
+
         # Determine bits
         bits = "32-bit"
         if machine in [0x8664, 0xAA64, 0x0200, 0x5064, 0x5128]:
             bits = "64-bit"
-        
+
         return {
             "architecture": arch_name,
             "bits": bits,
             "endian": "Little-endian",  # PE is always little-endian
             "machine_code": machine,
-            "format": "PE"
+            "format": "PE",
         }
-    
+
     def detect_macho_architecture(self, data: bytes) -> Optional[dict]:
         """
         Detect CPU architecture from Mach-O header.
-        
+
         Args:
             data: First 32+ bytes of Mach-O file
-            
+
         Returns:
             Dict with architecture info or None if not Mach-O
         """
         if len(data) < 32:
             return None
-        
+
         # Check magic numbers
-        magic = struct.unpack('<I', data[0:4])[0]
-        
+        magic = struct.unpack("<I", data[0:4])[0]
+
         is_little_endian = None
         bits = None
-        
+
         if magic == 0xFEEDFACE:  # 32-bit little-endian
             is_little_endian = True
             bits = "32-bit"
@@ -295,33 +297,33 @@ class ArchitectureDetector:
             bits = "64-bit"
         else:
             return None
-        
+
         # Extract CPU type (4 bytes at offset 4)
         if is_little_endian:
-            cputype = struct.unpack('<i', data[4:8])[0]
+            cputype = struct.unpack("<i", data[4:8])[0]
         else:
-            cputype = struct.unpack('>i', data[4:8])[0]
-        
+            cputype = struct.unpack(">i", data[4:8])[0]
+
         # Get architecture name
         arch_name = self.MACHO_CPUTYPES.get(cputype, f"Unknown (0x{cputype:08X})")
-        
+
         endian_name = "Little-endian" if is_little_endian else "Big-endian"
-        
+
         return {
             "architecture": arch_name,
             "bits": bits,
             "endian": endian_name,
             "machine_code": cputype,
-            "format": "Mach-O"
+            "format": "Mach-O",
         }
-    
+
     def detect(self, data: bytes) -> Optional[dict]:
         """
         Auto-detect architecture from any executable format.
-        
+
         Args:
             data: First 128+ bytes of file
-            
+
         Returns:
             Dict with architecture info or None if not recognized
         """
@@ -329,15 +331,15 @@ class ArchitectureDetector:
         result = self.detect_elf_architecture(data)
         if result:
             return result
-        
+
         # Try PE
         result = self.detect_pe_architecture(data)
         if result:
             return result
-        
+
         # Try Mach-O
         result = self.detect_macho_architecture(data)
         if result:
             return result
-        
+
         return None

--- a/filo/batch.py
+++ b/filo/batch.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 @dataclass
 class BatchResult:
     """Result from batch analysis."""
+
     total_files: int
     analyzed_files: int
     failed_files: int
@@ -31,6 +32,7 @@ class BatchResult:
 @dataclass
 class BatchConfig:
     """Configuration for batch processing."""
+
     max_workers: int = 4
     max_file_size: int = 100 * 1024 * 1024  # 100MB default
     recursive: bool = True
@@ -43,7 +45,7 @@ class BatchConfig:
 class BatchProcessor:
     """
     Efficient batch processing for directory analysis.
-    
+
     Features:
     - Parallel processing with thread pool
     - File size filtering
@@ -51,48 +53,48 @@ class BatchProcessor:
     - Progress tracking
     - Error handling and reporting
     """
-    
+
     def __init__(self, config: Optional[BatchConfig] = None) -> None:
         """
         Initialize batch processor.
-        
+
         Args:
             config: Batch processing configuration
         """
         self.config = config or BatchConfig()
         self.analyzer = Analyzer(use_ml=False)
         logger.info(f"BatchProcessor initialized with {self.config.max_workers} workers")
-    
+
     def process_directory(self, directory: Path) -> BatchResult:
         """
         Process all files in a directory.
-        
+
         Args:
             directory: Directory to analyze
-            
+
         Returns:
             BatchResult with analysis results and statistics
         """
         directory = Path(directory)
         if not directory.is_dir():
             raise ValueError(f"Not a directory: {directory}")
-        
+
         # Collect files
         files = self._collect_files(directory)
-        
+
         logger.info(f"Processing {len(files)} files from {directory}")
-        
+
         # Process files
         start_time = time.time()
         results, errors = self._process_files(files)
         duration = time.time() - start_time
-        
+
         # Calculate statistics
         analyzed = len(results)
         failed = len(errors)
         skipped = len(files) - analyzed - failed
         fps = analyzed / duration if duration > 0 else 0
-        
+
         return BatchResult(
             total_files=len(files),
             analyzed_files=analyzed,
@@ -101,27 +103,27 @@ class BatchProcessor:
             results=results,
             errors=errors,
             duration=duration,
-            files_per_second=fps
+            files_per_second=fps,
         )
-    
+
     def _collect_files(self, directory: Path) -> List[Path]:
         """Collect files matching criteria."""
         files = []
-        
+
         if self.config.recursive:
             pattern = "**/*"
         else:
             pattern = "*"
-        
+
         for path in directory.glob(pattern):
             # Skip directories
             if path.is_dir():
                 continue
-            
+
             # Check symlinks
             if path.is_symlink() and not self.config.follow_symlinks:
                 continue
-            
+
             # Check size
             try:
                 if path.stat().st_size > self.config.max_file_size:
@@ -129,53 +131,52 @@ class BatchProcessor:
                     continue
             except OSError:
                 continue
-            
+
             # Check exclude patterns
             if self._matches_patterns(path, self.config.exclude_patterns):
                 logger.debug(f"Skipping {path}: matches exclude pattern")
                 continue
-            
+
             # Check include patterns (if specified)
             if self.config.include_patterns:
                 if not self._matches_patterns(path, self.config.include_patterns):
                     continue
-            
+
             files.append(path)
-        
+
         return sorted(files)
-    
+
     def _matches_patterns(self, path: Path, patterns: List[str]) -> bool:
         """Check if path matches any pattern."""
         from fnmatch import fnmatch
-        
+
         path_str = str(path)
         for pattern in patterns:
             if fnmatch(path_str, pattern) or fnmatch(path.name, pattern):
                 return True
         return False
-    
-    def _process_files(self, files: List[Path]) -> tuple[List[tuple[Path, AnalysisResult]], List[tuple[Path, Exception]]]:
+
+    def _process_files(
+        self, files: List[Path]
+    ) -> tuple[List[tuple[Path, AnalysisResult]], List[tuple[Path, Exception]]]:
         """Process files in parallel."""
         results = []
         errors = []
         completed = 0
-        
+
         with ThreadPoolExecutor(max_workers=self.config.max_workers) as executor:
             # Submit all tasks
-            future_to_path = {
-                executor.submit(self._analyze_file, path): path
-                for path in files
-            }
-            
+            future_to_path = {executor.submit(self._analyze_file, path): path for path in files}
+
             # Process completed tasks
             for future in as_completed(future_to_path):
                 path = future_to_path[future]
                 completed += 1
-                
+
                 # Progress callback
                 if self.config.progress_callback:
                     self.config.progress_callback(completed, len(files))
-                
+
                 try:
                     result = future.result()
                     if result:
@@ -183,15 +184,15 @@ class BatchProcessor:
                 except Exception as e:
                     logger.error(f"Error analyzing {path}: {e}")
                     errors.append((path, e))
-        
+
         return results, errors
-    
+
     def _analyze_file(self, path: Path) -> Optional[AnalysisResult]:
         """Analyze a single file."""
         try:
-            with open(path, 'rb') as f:
+            with open(path, "rb") as f:
                 data = f.read()
-            
+
             result = self.analyzer.analyze(data)
             return result
         except Exception as e:
@@ -204,18 +205,18 @@ def analyze_directory(
     recursive: bool = True,
     max_workers: int = 4,
     max_file_size: int = 100 * 1024 * 1024,
-    progress_callback: Optional[Callable[[int, int], None]] = None
+    progress_callback: Optional[Callable[[int, int], None]] = None,
 ) -> BatchResult:
     """
     Convenience function for batch directory analysis.
-    
+
     Args:
         directory: Directory to analyze
         recursive: Recursively process subdirectories
         max_workers: Number of parallel workers
         max_file_size: Maximum file size to process
         progress_callback: Optional progress callback(completed, total)
-        
+
     Returns:
         BatchResult with analysis results
     """
@@ -223,8 +224,8 @@ def analyze_directory(
         max_workers=max_workers,
         max_file_size=max_file_size,
         recursive=recursive,
-        progress_callback=progress_callback
+        progress_callback=progress_callback,
     )
-    
+
     processor = BatchProcessor(config)
     return processor.process_directory(directory)

--- a/filo/carver.py
+++ b/filo/carver.py
@@ -1,8 +1,7 @@
 import logging
 from pathlib import Path
-from typing import List, Dict, Optional, BinaryIO
+from typing import List, Dict, Optional
 from dataclasses import dataclass
-import mmap
 
 from .formats import FormatDatabase
 from .analyzer import Analyzer

--- a/filo/carver.py
+++ b/filo/carver.py
@@ -19,79 +19,87 @@ class CarvedFile:
     confidence: float
     data: bytes
     metadata: Dict[str, any] = None
-    
+
     def save(self, output_path: Path) -> None:
         output_path.parent.mkdir(parents=True, exist_ok=True)
         output_path.write_bytes(self.data)
 
 
 class CarverEngine:
-    def __init__(self, format_db: Optional[FormatDatabase] = None, lineage_tracker: Optional[LineageTracker] = None):
+    def __init__(
+        self,
+        format_db: Optional[FormatDatabase] = None,
+        lineage_tracker: Optional[LineageTracker] = None,
+    ):
         self.format_db = format_db or FormatDatabase()
         self.analyzer = Analyzer(database=self.format_db, use_ml=False)
         self.lineage_tracker = lineage_tracker
-        
+
         self.signatures = self._build_signature_index()
-    
+
     def _build_signature_index(self) -> Dict[bytes, List[str]]:
         """Build index of signatures to format names for fast scanning."""
         sig_index = {}
-        
+
         for format_name in self.format_db.list_formats():
             spec = self.format_db.get_format(format_name)
             if not spec:
                 continue
-                
+
             for sig in spec.signatures:
                 if sig.offset == 0:
                     sig_bytes = bytes.fromhex(sig.hex.replace(" ", ""))
                     if sig_bytes not in sig_index:
                         sig_index[sig_bytes] = []
                     sig_index[sig_bytes].append(format_name)
-        
+
         return sig_index
-    
-    def carve_file(self, file_path: Path, min_size: int = 512, max_size: Optional[int] = None) -> List[CarvedFile]:
+
+    def carve_file(
+        self, file_path: Path, min_size: int = 512, max_size: Optional[int] = None
+    ) -> List[CarvedFile]:
         """Carve embedded files from a file."""
         with open(file_path, "rb") as f:
             data = f.read()
-        
+
         return self.carve_data(data, min_size=min_size, max_size=max_size)
-    
-    def carve_data(self, data: bytes, min_size: int = 512, max_size: Optional[int] = None) -> List[CarvedFile]:
+
+    def carve_data(
+        self, data: bytes, min_size: int = 512, max_size: Optional[int] = None
+    ) -> List[CarvedFile]:
         """Carve embedded files from binary data."""
         carved_files = []
         data_len = len(data)
-        
+
         if max_size is None:
             max_size = data_len
-        
+
         logger.info(f"Carving {data_len} bytes, min_size={min_size}, max_size={max_size}")
-        
+
         for signature, format_names in self.signatures.items():
             sig_len = len(signature)
             offset = 0
-            
+
             while offset < data_len - sig_len:
                 idx = data.find(signature, offset)
                 if idx == -1:
                     break
-                
+
                 logger.debug(f"Found signature for {format_names} at offset {idx}")
-                
-                chunk = data[idx:min(idx + max_size, data_len)]
+
+                chunk = data[idx : min(idx + max_size, data_len)]
                 if len(chunk) < min_size:
                     offset = idx + 1
                     continue
-                
+
                 result = self.analyzer.analyze(chunk)
-                
+
                 if result.primary_format and result.confidence > 0.5:
                     file_size = self._estimate_file_size(chunk, result)
-                    
+
                     if file_size >= min_size:
-                        carved_data = data[idx:idx + file_size]
-                        
+                        carved_data = data[idx : idx + file_size]
+
                         carved = CarvedFile(
                             offset=idx,
                             size=file_size,
@@ -100,10 +108,10 @@ class CarverEngine:
                             data=carved_data,
                             metadata={
                                 "alternative_formats": result.alternative_formats,
-                                "evidence": result.evidence_chain
-                            }
+                                "evidence": result.evidence_chain,
+                            },
                         )
-                        
+
                         # Record lineage if tracker available
                         if self.lineage_tracker:
                             self.lineage_tracker.record(
@@ -113,44 +121,46 @@ class CarverEngine:
                                 offset=idx,
                                 size=file_size,
                                 format=result.primary_format,
-                                confidence=result.confidence
+                                confidence=result.confidence,
                             )
-                        
+
                         carved_files.append(carved)
-                        logger.info(f"Carved {result.primary_format} at offset {idx}, size {file_size}")
-                        
+                        logger.info(
+                            f"Carved {result.primary_format} at offset {idx}, size {file_size}"
+                        )
+
                         offset = idx + file_size
                     else:
                         offset = idx + 1
                 else:
                     offset = idx + 1
-        
+
         carved_files.sort(key=lambda x: x.offset)
         return carved_files
-    
+
     def _estimate_file_size(self, data: bytes, result: AnalysisResult) -> int:
         """Estimate actual file size based on format and structure."""
         format_name = result.primary_format
         spec = self.format_db.get_format(format_name)
-        
+
         if not spec or not spec.structure:
             return self._estimate_by_footer(data, format_name)
-        
+
         # Use footer detection as the primary size estimation method
         return self._estimate_by_footer(data, format_name)
-    
+
     def _read_size_field(self, data: bytes, offset: int, size: int, endian: str) -> int:
         """Read size value from specific offset."""
         if offset + size > len(data):
             return 0
-        
-        size_bytes = data[offset:offset + size]
-        
+
+        size_bytes = data[offset : offset + size]
+
         if endian == "little":
             return int.from_bytes(size_bytes, byteorder="little")
         else:
             return int.from_bytes(size_bytes, byteorder="big")
-    
+
     def _estimate_by_footer(self, data: bytes, format_name: str) -> int:
         """Estimate size by looking for known footer/EOF markers."""
         footers = {
@@ -161,67 +171,71 @@ class CarverEngine:
             "rar": b"Rar!\x1a\x07\x01\x00",
             "pdf": b"%%EOF",
         }
-        
+
         footer = footers.get(format_name.lower())
         if footer:
             idx = data.find(footer)
             if idx != -1:
                 return idx + len(footer)
-        
+
         return min(len(data), 10 * 1024 * 1024)
-    
-    def carve_directory(self, dir_path: Path, output_dir: Path, 
-                       recursive: bool = False, 
-                       min_size: int = 512,
-                       max_size: Optional[int] = None) -> Dict[str, List[CarvedFile]]:
+
+    def carve_directory(
+        self,
+        dir_path: Path,
+        output_dir: Path,
+        recursive: bool = False,
+        min_size: int = 512,
+        max_size: Optional[int] = None,
+    ) -> Dict[str, List[CarvedFile]]:
         """Carve files from all files in a directory."""
         results = {}
-        
+
         pattern = "**/*" if recursive else "*"
-        
+
         for file_path in dir_path.glob(pattern):
             if file_path.is_file():
                 try:
                     carved = self.carve_file(file_path, min_size=min_size, max_size=max_size)
-                    
+
                     if carved:
                         results[str(file_path)] = carved
-                        
+
                         for i, carved_file in enumerate(carved):
                             out_name = f"{file_path.stem}_carved_{i:04d}_{carved_file.format}.bin"
                             out_path = output_dir / out_name
                             carved_file.save(out_path)
                             logger.info(f"Saved carved file to {out_path}")
-                
+
                 except Exception as e:
                     logger.error(f"Error carving {file_path}: {e}")
-        
+
         return results
 
 
 class StreamCarver:
     """Carve files from streaming data (network captures, device streams)."""
-    
+
     def __init__(self, buffer_size: int = 1024 * 1024):
         self.buffer_size = buffer_size
         self.carver = CarverEngine()
         self.buffer = bytearray()
-    
+
     def feed(self, data: bytes) -> List[CarvedFile]:
         """Feed data into the carver and return completed files."""
         self.buffer.extend(data)
-        
+
         carved = self.carver.carve_data(bytes(self.buffer))
-        
+
         if carved:
             last_offset = carved[-1].offset + carved[-1].size
             self.buffer = self.buffer[last_offset:]
-        
+
         if len(self.buffer) > self.buffer_size * 2:
-            self.buffer = self.buffer[-self.buffer_size:]
-        
+            self.buffer = self.buffer[-self.buffer_size :]
+
         return carved
-    
+
     def finalize(self) -> List[CarvedFile]:
         """Process remaining buffer."""
         if self.buffer:

--- a/filo/carver.py
+++ b/filo/carver.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import List, Dict, Optional
+from typing import Any, List, Dict, Optional
 from dataclasses import dataclass
 
 from .formats import FormatDatabase
@@ -18,7 +18,7 @@ class CarvedFile:
     format: str
     confidence: float
     data: bytes
-    metadata: Dict[str, any] = None
+    metadata: Optional[Dict[str, Any]] = None
 
     def save(self, output_path: Path) -> None:
         output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -39,7 +39,7 @@ class CarverEngine:
 
     def _build_signature_index(self) -> Dict[bytes, List[str]]:
         """Build index of signatures to format names for fast scanning."""
-        sig_index = {}
+        sig_index: dict[bytes, list[str]] = {}
 
         for format_name in self.format_db.list_formats():
             spec = self.format_db.get_format(format_name)

--- a/filo/cli.py
+++ b/filo/cli.py
@@ -33,17 +33,14 @@ def _print_hex_dump(data: bytes, width: int = 16) -> None:
     for i in range(0, min(len(data), 256), width):
         # Offset
         offset = f"{i:08x}"
-        
+
         # Hex bytes
-        hex_part = " ".join(f"{b:02x}" for b in data[i:i+width])
+        hex_part = " ".join(f"{b:02x}" for b in data[i : i + width])
         hex_part = hex_part.ljust(width * 3)
-        
+
         # ASCII representation
-        ascii_part = "".join(
-            chr(b) if 32 <= b < 127 else "."
-            for b in data[i:i+width]
-        )
-        
+        ascii_part = "".join(chr(b) if 32 <= b < 127 else "." for b in data[i : i + width])
+
         console.print(f"  {offset}  {hex_part}  {ascii_part}")
 
 
@@ -62,7 +59,7 @@ def setup_logging(verbose: bool = False) -> None:
 def main(verbose: bool) -> None:
     """
     Filo - Forensic Intelligence & Ligation Orchestrator
-    
+
     Battle-tested file forensics platform for security professionals.
     """
     setup_logging(verbose)
@@ -77,17 +74,33 @@ def main(verbose: bool) -> None:
 @click.option("-e", "--all-embedded", is_flag=True, help="Show all embedded artifacts")
 @click.option("--explain", is_flag=True, help="Show detailed confidence breakdown")
 @click.option("--entropy-viz", is_flag=True, help="Show entropy visualization chart")
-@click.option("--yara", "yara_rules", type=click.Path(exists=True), multiple=True, help="YARA rule file(s) to scan against")
-def analyze(file_path: str, output_json: bool, deep: bool, no_ml: bool, all_evidence: bool, all_embedded: bool, explain: bool, entropy_viz: bool, yara_rules: tuple[str, ...]) -> None:
+@click.option(
+    "--yara",
+    "yara_rules",
+    type=click.Path(exists=True),
+    multiple=True,
+    help="YARA rule file(s) to scan against",
+)
+def analyze(
+    file_path: str,
+    output_json: bool,
+    deep: bool,
+    no_ml: bool,
+    all_evidence: bool,
+    all_embedded: bool,
+    explain: bool,
+    entropy_viz: bool,
+    yara_rules: tuple[str, ...],
+) -> None:
     """
     Analyze a file to detect its format.
-    
+
     FILE_PATH: Path to file to analyze
     """
     try:
         analyzer = Analyzer(use_ml=not no_ml, yara_rules=list(yara_rules) if yara_rules else None)
         result = analyzer.analyze_file(file_path)
-        
+
         if output_json:
             # JSON output
             output = {
@@ -95,8 +108,7 @@ def analyze(file_path: str, output_json: bool, deep: bool, no_ml: bool, all_evid
                 "format": result.primary_format,
                 "confidence": result.confidence,
                 "alternatives": [
-                    {"format": fmt, "confidence": conf}
-                    for fmt, conf in result.alternative_formats
+                    {"format": fmt, "confidence": conf} for fmt, conf in result.alternative_formats
                 ],
                 "contradictions": [
                     {
@@ -104,7 +116,7 @@ def analyze(file_path: str, output_json: bool, deep: bool, no_ml: bool, all_evid
                         "claimed_format": c.claimed_format,
                         "issue": c.issue,
                         "details": c.details,
-                        "category": c.category
+                        "category": c.category,
                     }
                     for c in result.contradictions
                 ],
@@ -115,7 +127,7 @@ def analyze(file_path: str, output_json: bool, deep: bool, no_ml: bool, all_evid
                         "confidence": obj.confidence,
                         "size": obj.size,
                         "description": obj.description,
-                        "data_snippet": obj.data_snippet.hex() if obj.data_snippet else ""
+                        "data_snippet": obj.data_snippet.hex() if obj.data_snippet else "",
                     }
                     for obj in result.embedded_objects
                 ],
@@ -134,52 +146,65 @@ def analyze(file_path: str, output_json: bool, deep: bool, no_ml: bool, all_evid
                     }
                     for m in result.yara_matches
                 ],
-                "office_macros": result.office_macros.model_dump() if result.office_macros else None,
+                "office_macros": (
+                    result.office_macros.model_dump() if result.office_macros else None
+                ),
             }
             console.print_json(json.dumps(output, indent=2))
         else:
             # Rich formatted output
-            console.print(Panel.fit(
-                f"[bold cyan]File Analysis:[/bold cyan] {file_path}",
-                border_style="cyan"
-            ))
-            
+            console.print(
+                Panel.fit(f"[bold cyan]File Analysis:[/bold cyan] {file_path}", border_style="cyan")
+            )
+
             # Main result
-            confidence_color = "green" if result.confidence > 0.8 else "yellow" if result.confidence > 0.5 else "red"
-            console.print(f"\n[bold]Detected Format:[/bold] [{confidence_color}]{result.primary_format}[/{confidence_color}]")
-            console.print(f"[bold]Confidence:[/bold] [{confidence_color}]{result.confidence:.1%}[/{confidence_color}]")
-            
+            confidence_color = (
+                "green"
+                if result.confidence > 0.8
+                else "yellow" if result.confidence > 0.5 else "red"
+            )
+            console.print(
+                f"\n[bold]Detected Format:[/bold] [{confidence_color}]{result.primary_format}[/{confidence_color}]"
+            )
+            console.print(
+                f"[bold]Confidence:[/bold] [{confidence_color}]{result.confidence:.1%}[/{confidence_color}]"
+            )
+
             # Show extraction command for archives
             from filo.formats import FormatDatabase
+
             db = FormatDatabase()
             format_spec = db.get_format(result.primary_format)
             if format_spec and format_spec.extraction:
-                console.print(f"\n[bold cyan]📦 Extraction:[/bold cyan] [green]{format_spec.extraction}[/green]")
-            
+                console.print(
+                    f"\n[bold cyan]📦 Extraction:[/bold cyan] [green]{format_spec.extraction}[/green]"
+                )
+
             # Confidence breakdown (if --explain flag is used)
             if explain:
                 console.print("\n[bold cyan]Confidence Breakdown:[/bold cyan]")
-                
+
                 # Group contributions by source type
                 from collections import defaultdict
+
                 grouped_contributions = defaultdict(list)
-                
+
                 # Collect contributions from evidence chain for the primary format
                 for evidence in result.evidence_chain:
                     fmt = evidence.get("format", "")
                     if fmt == result.primary_format:
                         module = evidence.get("module", "unknown")
                         module_weight = evidence.get("weight", 1.0)
-                        
+
                         # Map module names to display names
                         source_map = {
                             "signature_analysis": "Signature",
                             "structural_analysis": "Structure",
                             "zip_container_analysis": "ZIP Container",
-                            "ml_prediction": "ML Similarity"
+                            "ml_prediction": "ML Similarity",
                         }
                         source_name = source_map.get(module, module)
-                        
+
                         # Get contributions if they exist
                         contributions = evidence.get("contributions", [])
                         if contributions:
@@ -193,12 +218,14 @@ def analyze(file_path: str, output_json: bool, deep: bool, no_ml: bool, all_evid
                                     weighted_value = contrib["value"] * module_weight * 0.8
                                 else:
                                     weighted_value = contrib["value"]
-                                
-                                grouped_contributions[source_name].append({
-                                    "value": weighted_value,
-                                    "description": contrib["description"],
-                                    "is_penalty": contrib.get("is_penalty", False)
-                                })
+
+                                grouped_contributions[source_name].append(
+                                    {
+                                        "value": weighted_value,
+                                        "description": contrib["description"],
+                                        "is_penalty": contrib.get("is_penalty", False),
+                                    }
+                                )
                         else:
                             # Fallback: use module confidence * weight
                             conf = evidence.get("confidence", 0)
@@ -212,16 +239,20 @@ def analyze(file_path: str, output_json: bool, deep: bool, no_ml: bool, all_evid
                                 weighted_value = conf * 0.2
                             else:
                                 weighted_value = conf
-                            
-                            grouped_contributions[source_name].append({
-                                "value": weighted_value,
-                                "description": f"{source_name} match",
-                                "is_penalty": False
-                            })
-                
+
+                            grouped_contributions[source_name].append(
+                                {
+                                    "value": weighted_value,
+                                    "description": f"{source_name} match",
+                                    "is_penalty": False,
+                                }
+                            )
+
                 # Display contributions
-                console.print(f"\nPrimary: [bold]{result.primary_format.upper()}[/bold] ([cyan]{result.confidence:.1%}[/cyan])")
-                
+                console.print(
+                    f"\nPrimary: [bold]{result.primary_format.upper()}[/bold] ([cyan]{result.confidence:.1%}[/cyan])"
+                )
+
                 total_contrib = 0.0
                 for source_name in ["Signature", "Structure", "ZIP Container", "ML Similarity"]:
                     if source_name in grouped_contributions:
@@ -229,77 +260,85 @@ def analyze(file_path: str, output_json: bool, deep: bool, no_ml: bool, all_evid
                             value = contrib["value"]
                             desc = contrib["description"]
                             is_penalty = contrib["is_penalty"]
-                            
+
                             total_contrib += value
-                            
+
                             if is_penalty:
                                 console.print(f"  [red]-{abs(value):>5.1%}[/red]  {desc}")
                             else:
                                 console.print(f"  [green]+{value:>5.1%}[/green]  {desc}")
-            
+
             # Alternatives
             if result.alternative_formats:
                 console.print("\n[bold]Alternative Possibilities:[/bold]")
                 for fmt, conf in result.alternative_formats[:3]:
                     console.print(f"  • {fmt}: {conf:.1%}")
-            
+
             # Contradictions (always show if present - security critical)
             if result.contradictions:
                 console.print("\n[bold yellow]⚠ Structural Contradictions Detected:[/bold yellow]")
                 for contradiction in result.contradictions:
-                    severity_colors = {
-                        "warning": "yellow",
-                        "error": "orange3",
-                        "critical": "red"
-                    }
-                    severity_icons = {
-                        "warning": "⚠",
-                        "error": "⚠",
-                        "critical": "🚨"
-                    }
-                    
+                    severity_colors = {"warning": "yellow", "error": "orange3", "critical": "red"}
+                    severity_icons = {"warning": "⚠", "error": "⚠", "critical": "🚨"}
+
                     color = severity_colors.get(contradiction.severity, "yellow")
                     icon = severity_icons.get(contradiction.severity, "⚠")
-                    
-                    console.print(f"\n  [{color}]{icon} {contradiction.severity.upper()}: {contradiction.issue}[/{color}]")
+
+                    console.print(
+                        f"\n  [{color}]{icon} {contradiction.severity.upper()}: {contradiction.issue}[/{color}]"
+                    )
                     console.print(f"     [dim]Claims: {contradiction.claimed_format}[/dim]")
                     console.print(f"     [dim]{contradiction.details}[/dim]")
                     console.print(f"     [dim]Category: {contradiction.category}[/dim]")
-            
+
             # Embedded objects (malware hunter candy)
             if result.embedded_objects:
                 console.print("\n[bold magenta]🔍 Embedded Artifacts:[/bold magenta]")
-                
+
                 # Limit display unless --all-embedded flag is used
-                objects_to_show = result.embedded_objects if all_embedded else result.embedded_objects[:3]
-                
+                objects_to_show = (
+                    result.embedded_objects if all_embedded else result.embedded_objects[:3]
+                )
+
                 for obj in objects_to_show:
-                    conf_color = "green" if obj.confidence > 0.85 else "yellow" if obj.confidence > 0.70 else "red"
-                    
+                    conf_color = (
+                        "green"
+                        if obj.confidence > 0.85
+                        else "yellow" if obj.confidence > 0.70 else "red"
+                    )
+
                     # Format size display
                     size_str = f"{obj.size:,} bytes" if obj.size else "unknown size"
-                    
-                    console.print(f"  • Offset [cyan]0x{obj.offset:X}[/cyan]: [{conf_color}]{obj.format.upper()}[/{conf_color}] (prob. {obj.confidence:.0%})")
+
+                    console.print(
+                        f"  • Offset [cyan]0x{obj.offset:X}[/cyan]: [{conf_color}]{obj.format.upper()}[/{conf_color}] (prob. {obj.confidence:.0%})"
+                    )
                     console.print(f"    [dim]{size_str} - {obj.description}[/dim]")
-                    
+
                     # Show hex snippet
                     if obj.data_snippet:
                         hex_snippet = " ".join(f"{b:02x}" for b in obj.data_snippet[:8])
                         console.print(f"    [dim]Signature: {hex_snippet}...[/dim]")
-                
+
                 # Show message if embedded objects were truncated
                 if not all_embedded and len(result.embedded_objects) > 3:
                     remaining = len(result.embedded_objects) - 3
-                    console.print(f"\n  [dim]... and {remaining} more embedded artifact{'s' if remaining != 1 else ''}[/dim]")
+                    console.print(
+                        f"\n  [dim]... and {remaining} more embedded artifact{'s' if remaining != 1 else ''}[/dim]"
+                    )
                     console.print("  [dim]Use -e or --all-embedded flag to show all[/dim]")
-            
+
             # Tool/creator fingerprints
             if result.fingerprints:
                 console.print("\n[bold blue]🔧 Tool Fingerprints:[/bold blue]")
-                
+
                 for fp in result.fingerprints:
-                    conf_color = "green" if fp.confidence > 0.85 else "yellow" if fp.confidence > 0.70 else "red"
-                    
+                    conf_color = (
+                        "green"
+                        if fp.confidence > 0.85
+                        else "yellow" if fp.confidence > 0.70 else "red"
+                    )
+
                     parts = []
                     if fp.tool:
                         parts.append(f"{fp.tool}")
@@ -309,37 +348,53 @@ def analyze(file_path: str, output_json: bool, deep: bool, no_ml: bool, all_evid
                         parts.append(f"on {fp.os_hint}")
                     if fp.timestamp:
                         parts.append(f"at {fp.timestamp.strftime('%Y-%m-%d %H:%M:%S')}")
-                    
+
                     main_text = " ".join(parts) if parts else fp.category
-                    
-                    console.print(f"  • [{conf_color}]{main_text}[/{conf_color}] (prob. {fp.confidence:.0%})")
+
+                    console.print(
+                        f"  • [{conf_color}]{main_text}[/{conf_color}] (prob. {fp.confidence:.0%})"
+                    )
                     console.print(f"    [dim]{fp.evidence}[/dim]")
-            
+
             # Polyglot detections
             if result.polyglots:
                 console.print("\n[bold red]⚠ Polyglot Detected:[/bold red]")
-                
+
                 for poly in result.polyglots:
                     risk_colors = {"high": "red", "medium": "yellow", "low": "green"}
                     risk_color = risk_colors.get(poly.risk_level, "white")
-                    conf_color = "green" if poly.confidence > 0.85 else "yellow" if poly.confidence > 0.70 else "red"
-                    
+                    conf_color = (
+                        "green"
+                        if poly.confidence > 0.85
+                        else "yellow" if poly.confidence > 0.70 else "red"
+                    )
+
                     formats_str = " + ".join(f.upper() for f in poly.formats)
-                    
-                    console.print(f"  • [{conf_color}]{formats_str}[/{conf_color}] - {poly.description} (prob. {poly.confidence:.0%})")
-                    console.print(f"    [dim]Risk: [{risk_color}]{poly.risk_level.upper()}[/{risk_color}] | Pattern: {poly.pattern}[/dim]")
+
+                    console.print(
+                        f"  • [{conf_color}]{formats_str}[/{conf_color}] - {poly.description} (prob. {poly.confidence:.0%})"
+                    )
+                    console.print(
+                        f"    [dim]Risk: [{risk_color}]{poly.risk_level.upper()}[/{risk_color}] | Pattern: {poly.pattern}[/dim]"
+                    )
                     console.print(f"    [dim]{poly.evidence}[/dim]")
-            
+
             # CPU Architecture (for executable files)
             if result.architecture:
                 console.print("\n[bold cyan]🖥️  CPU Architecture:[/bold cyan]")
                 arch = result.architecture
-                console.print(f"  • [green]{arch.architecture}[/green] ({arch.bits}, {arch.endian})")
-                console.print(f"    [dim]Format: {arch.format} | Machine Code: 0x{arch.machine_code:04X}[/dim]")
-            
+                console.print(
+                    f"  • [green]{arch.architecture}[/green] ({arch.bits}, {arch.endian})"
+                )
+                console.print(
+                    f"    [dim]Format: {arch.format} | Machine Code: 0x{arch.machine_code:04X}[/dim]"
+                )
+
             # YARA matches
             if result.yara_matches:
-                console.print(f"\n[bold red]🐍 YARA Matches ({len(result.yara_matches)}):[/bold red]")
+                console.print(
+                    f"\n[bold red]🐍 YARA Matches ({len(result.yara_matches)}):[/bold red]"
+                )
                 for match in result.yara_matches[:10]:
                     tags_str = f" [{','.join(match.tags)}]" if match.tags else ""
                     desc_str = f" — {match.description}" if match.description else ""
@@ -351,7 +406,7 @@ def analyze(file_path: str, output_json: bool, deep: bool, no_ml: bool, all_evid
                             console.print(f"    [dim]  @ 0x{offset:X}: {data_hex}[/dim]")
                 if len(result.yara_matches) > 10:
                     console.print(f"    [dim]... and {len(result.yara_matches) - 10} more[/dim]")
-            
+
             # Office macro analysis
             if result.office_macros:
                 om = result.office_macros
@@ -366,55 +421,70 @@ def analyze(file_path: str, output_json: bool, deep: bool, no_ml: bool, all_evid
                     if om.has_macros:
                         console.print(f"  Macros: [bold]{om.macro_count}[/bold] module(s)")
                     if om.auto_exec_macros:
-                        console.print(f"  Auto-exec macros: [red]{', '.join(om.auto_exec_macros)}[/red]")
+                        console.print(
+                            f"  Auto-exec macros: [red]{', '.join(om.auto_exec_macros)}[/red]"
+                        )
                     if om.suspicious_keywords:
-                        console.print(f"  Suspicious keywords ({om.keyword_count}): [red]{', '.join(om.suspicious_keywords[:10])}[/red]")
+                        console.print(
+                            f"  Suspicious keywords ({om.keyword_count}): [red]{', '.join(om.suspicious_keywords[:10])}[/red]"
+                        )
                         if len(om.suspicious_keywords) > 10:
-                            console.print(f"    [dim]... and {len(om.suspicious_keywords) - 10} more[/dim]")
-            
+                            console.print(
+                                f"    [dim]... and {len(om.suspicious_keywords) - 10} more[/dim]"
+                            )
+
             # File info
             console.print(f"\n[bold]File Size:[/bold] {result.file_size:,} bytes")
             if result.entropy is not None:
                 console.print(f"[bold]Entropy:[/bold] {result.entropy:.2f} bits/byte")
-                
+
                 # Show crypto analysis if available
                 if result.crypto_analysis:
                     crypto = result.crypto_analysis
-                    entropy_desc = crypto.get('entropy_interpretation', '')
+                    entropy_desc = crypto.get("entropy_interpretation", "")
                     console.print(f"  [dim]({entropy_desc})[/dim]")
-                    
-                    if crypto.get('is_likely_encrypted'):
-                        confidence = crypto.get('confidence', 0) * 100
-                        console.print(f"\n[bold yellow]🔐 Encryption Detected:[/bold yellow] [yellow]{confidence:.0f}% confidence[/yellow]")
-                        
-                        indicators = crypto.get('encryption_indicators', [])
+
+                    if crypto.get("is_likely_encrypted"):
+                        confidence = crypto.get("confidence", 0) * 100
+                        console.print(
+                            f"\n[bold yellow]🔐 Encryption Detected:[/bold yellow] [yellow]{confidence:.0f}% confidence[/yellow]"
+                        )
+
+                        indicators = crypto.get("encryption_indicators", [])
                         if indicators:
                             for indicator in indicators:
                                 console.print(f"  • {indicator}")
-                        
-                        cipher_hints = crypto.get('cipher_hints', [])
+
+                        cipher_hints = crypto.get("cipher_hints", [])
                         if cipher_hints:
                             console.print("\n[bold]Possible Cipher Types:[/bold]")
                             for hint in cipher_hints:
                                 console.print(f"  • {hint}")
-                        
-                        block_info = crypto.get('block_alignment')
+
+                        block_info = crypto.get("block_alignment")
                         if block_info and all_evidence:
                             console.print("\n[dim]Block Analysis:[/dim]")
-                            if block_info.get('aes_aligned'):
-                                console.print(f"  [dim]• AES blocks: {block_info.get('aes_block_count')}[/dim]")
-                            if block_info.get('pkcs7_padding_possible'):
+                            if block_info.get("aes_aligned"):
+                                console.print(
+                                    f"  [dim]• AES blocks: {block_info.get('aes_block_count')}[/dim]"
+                                )
+                            if block_info.get("pkcs7_padding_possible"):
                                 console.print("  [dim]• PKCS#7 padding possible[/dim]")
-                    elif crypto.get('encryption_indicators'):
+                    elif crypto.get("encryption_indicators"):
                         # Show indicators even if not highly confident
-                        console.print(f"  [dim]Crypto indicators: {', '.join(crypto.get('encryption_indicators', []))}[/dim]")
-                
+                        console.print(
+                            f"  [dim]Crypto indicators: {', '.join(crypto.get('encryption_indicators', []))}[/dim]"
+                        )
+
                 if entropy_viz:
                     try:
                         from filo.analyzer import StatisticalAnalyzer
+
                         with open(file_path, "rb") as f:
                             file_data = f.read()
-                        entropies = StatisticalAnalyzer.chunk_entropy(file_data[:65536], chunk_size=256)
+                        entropies = StatisticalAnalyzer.chunk_entropy(
+                            file_data[:65536], chunk_size=256
+                        )
                         if entropies:
                             bar = StatisticalAnalyzer.format_entropy_bar(entropies)
                             console.print(f"[bold]Entropy Map:[/bold] {bar}")
@@ -423,29 +493,35 @@ def analyze(file_path: str, output_json: bool, deep: bool, no_ml: bool, all_evid
                     except Exception:
                         pass
             console.print(f"[bold]SHA256:[/bold] {result.checksum_sha256}")
-            
+
             # Evidence
             if result.evidence_chain:
                 console.print("\n[bold]Detection Evidence:[/bold]")
-                
+
                 # Limit evidence display unless --all-evidence flag is used
-                evidence_to_show = result.evidence_chain if all_evidence else result.evidence_chain[:3]
-                
+                evidence_to_show = (
+                    result.evidence_chain if all_evidence else result.evidence_chain[:3]
+                )
+
                 for evidence in evidence_to_show:
                     module = evidence.get("module", "unknown")
                     conf = evidence.get("confidence", 0)
                     evid_list = evidence.get("evidence", [])
-                    
+
                     console.print(f"\n  [cyan]{module}[/cyan] (confidence: {conf:.1%})")
                     for e in evid_list:
                         console.print(f"    • {e}")
-                
+
                 # Show message if evidence was truncated
                 if not all_evidence and len(result.evidence_chain) > 3:
                     remaining = len(result.evidence_chain) - 3
-                    console.print(f"\n  [dim]... and {remaining} more evidence item{'s' if remaining != 1 else ''}[/dim]")
-                    console.print("  [dim]Use --all-evidence flag to show all detection evidence[/dim]")
-        
+                    console.print(
+                        f"\n  [dim]... and {remaining} more evidence item{'s' if remaining != 1 else ''}[/dim]"
+                    )
+                    console.print(
+                        "  [dim]Use --all-evidence flag to show all detection evidence[/dim]"
+                    )
+
     except Exception as e:
         console.print(f"[red]Error:[/red] {e}", style="bold")
         sys.exit(1)
@@ -457,22 +533,22 @@ def analyze(file_path: str, output_json: bool, deep: bool, no_ml: bool, all_evid
 def teach(file_path: str, format_name: str) -> None:
     """
     Teach Filo the correct format for a file (ML learning).
-    
+
     FILE_PATH: Path to file to learn from
     """
     try:
         analyzer = Analyzer(use_ml=True)
-        
+
         with open(file_path, "rb") as f:
             data = f.read()
-        
+
         analyzer.teach(data, format_name)
-        
+
         console.print(f"[green]✓ Learned from {file_path} as {format_name}[/green]")
         model_path = analyzer.ml_detector.model_path if analyzer.ml_detector else None
         if model_path:
             console.print(f"[dim]Model saved to {model_path}[/dim]")
-    
+
     except Exception as e:
         console.print(f"[red]Error:[/red] {e}", style="bold")
         sys.exit(1)
@@ -495,74 +571,77 @@ def repair(
 ) -> None:
     """
     Repair a corrupted file.
-    
+
     FILE_PATH: Path to corrupted file
     """
     try:
         engine = RepairEngine()
-        
+
         # Read file
         with open(file_path, "rb") as f:
             data = f.read()
-        
+
         # Repair
         repaired_data, report = engine.repair(data, format_name, strategy)
-        
+
         # Display results
-        console.print(Panel.fit(
-            f"[bold cyan]File Repair:[/bold cyan] {file_path}",
-            border_style="cyan"
-        ))
-        
+        console.print(
+            Panel.fit(f"[bold cyan]File Repair:[/bold cyan] {file_path}", border_style="cyan")
+        )
+
         status_color = "green" if report.success else "red"
         status_text = "SUCCESS" if report.success else "FAILED"
         console.print(f"\n[{status_color}][bold]Status:[/bold] {status_text}[/{status_color}]")
         console.print(f"[bold]Strategy Used:[/bold] {report.strategy_used}")
         console.print(f"[bold]Original Size:[/bold] {report.original_size:,} bytes")
         console.print(f"[bold]Repaired Size:[/bold] {report.repaired_size:,} bytes")
-        
+
         if report.changes_made:
             console.print("\n[bold]Changes Made:[/bold]")
             for change in report.changes_made:
                 console.print(f"  • {change}")
-        
+
         if report.warnings:
             console.print("\n[bold yellow]Warnings:[/bold yellow]")
             for warning in report.warnings:
                 console.print(f"  ⚠ {warning}")
-        
+
         # Write output
         if report.success and not dry_run:
             file_path_obj = Path(file_path)
-            
+
             if output_path is None:
                 # No output specified - replace original with repaired, backup original
                 backup_path = Path(f"{file_path}.bak")
-                
+
                 if not no_backup:
                     # Backup original
                     backup_path.write_bytes(data)
                     console.print(f"\n[dim]✓ Original backed up to: {backup_path}[/dim]")
-                
+
                 # Write repaired to original location
                 file_path_obj.write_bytes(repaired_data)
                 console.print(f"[green]✓ Repaired file written to: {file_path}[/green]")
-                
+
                 # Suggest viewing the file if it's an image
-                if format_name in ['bmp', 'png', 'jpeg', 'gif', 'tiff']:
-                    console.print(f"\n[dim]💡 Tip: Open {file_path} in an image viewer to see the result[/dim]")
+                if format_name in ["bmp", "png", "jpeg", "gif", "tiff"]:
+                    console.print(
+                        f"\n[dim]💡 Tip: Open {file_path} in an image viewer to see the result[/dim]"
+                    )
             else:
                 # Output path specified - write repaired to new location, keep original
                 out_path = Path(output_path)
                 out_path.write_bytes(repaired_data)
                 console.print(f"[green]✓ Repaired file written to: {out_path}[/green]")
-                
+
                 # Suggest viewing the file if it's an image
-                if format_name in ['bmp', 'png', 'jpeg', 'gif', 'tiff']:
-                    console.print(f"\n[dim]💡 Tip: Open {out_path} in an image viewer to see the result[/dim]")
+                if format_name in ["bmp", "png", "jpeg", "gif", "tiff"]:
+                    console.print(
+                        f"\n[dim]💡 Tip: Open {out_path} in an image viewer to see the result[/dim]"
+                    )
         elif dry_run:
             console.print("\n[dim]Dry run - no files written[/dim]")
-    
+
     except Exception as e:
         console.print(f"[red]Error:[/red] {e}", style="bold")
         sys.exit(1)
@@ -579,23 +658,23 @@ def formats() -> None:
 def formats_list(category: Optional[str]) -> None:
     """List all available formats."""
     db = FormatDatabase()
-    
+
     if category:
         specs = db.get_formats_by_category(category)
     else:
         specs = [db.get_format(name) for name in db.list_formats()]
-    
+
     if not specs:
         console.print("[yellow]No formats found[/yellow]")
         return
-    
+
     # Create table
     table = Table(title="Available Formats")
     table.add_column("Format", style="cyan", no_wrap=True)
     table.add_column("Category", style="magenta")
     table.add_column("Extensions", style="green")
     table.add_column("Signatures", justify="right", style="blue")
-    
+
     for spec in specs:
         if spec:
             table.add_row(
@@ -604,7 +683,7 @@ def formats_list(category: Optional[str]) -> None:
                 ", ".join(spec.extensions[:3]),
                 str(len(spec.signatures)),
             )
-    
+
     console.print(table)
     console.print(f"\n[dim]Total: {len(specs)} formats[/dim]")
 
@@ -615,41 +694,42 @@ def formats_show(format_name: str) -> None:
     """Show detailed information about a format."""
     db = FormatDatabase()
     spec = db.get_format(format_name)
-    
+
     if not spec:
         console.print(f"[red]Format not found:[/red] {format_name}")
         sys.exit(1)
-    
-    console.print(Panel.fit(
-        f"[bold cyan]Format Specification:[/bold cyan] {spec.format}",
-        border_style="cyan"
-    ))
-    
+
+    console.print(
+        Panel.fit(
+            f"[bold cyan]Format Specification:[/bold cyan] {spec.format}", border_style="cyan"
+        )
+    )
+
     console.print(f"\n[bold]Version:[/bold] {spec.version}")
     console.print(f"[bold]Category:[/bold] {spec.category}")
     console.print(f"[bold]MIME Types:[/bold] {', '.join(spec.mime)}")
     console.print(f"[bold]Extensions:[/bold] {', '.join(spec.extensions)}")
-    
+
     if spec.description:
         console.print(f"\n[bold]Description:[/bold]\n{spec.description}")
-    
+
     # Signatures
     console.print(f"\n[bold]Signatures ({len(spec.signatures)}):[/bold]")
     for sig in spec.signatures:
         console.print(f"  • Offset {sig.offset}: {sig.hex} - {sig.description}")
-    
+
     # Footers
     if spec.footers:
         console.print(f"\n[bold]Footers ({len(spec.footers)}):[/bold]")
         for footer in spec.footers:
             console.print(f"  • {footer.hex} - {footer.description}")
-    
+
     # Templates
     if spec.templates:
         console.print(f"\n[bold]Templates ({len(spec.templates)}):[/bold]")
         for name in spec.templates:
             console.print(f"  • {name}")
-    
+
     # Repair strategies
     if spec.repair_strategies:
         console.print(f"\n[bold]Repair Strategies ({len(spec.repair_strategies)}):[/bold]")
@@ -663,55 +743,57 @@ def formats_show(format_name: str) -> None:
 @click.option("-o", "--output-dir", default="carved", help="Output directory")
 @click.option("--min-size", type=int, default=512, help="Minimum file size in bytes")
 @click.option("--max-size", type=int, help="Maximum file size in bytes")
-def carve(file_path: str, formats: Optional[str], output_dir: str, min_size: int, max_size: Optional[int]) -> None:
+def carve(
+    file_path: str, formats: Optional[str], output_dir: str, min_size: int, max_size: Optional[int]
+) -> None:
     """
     Carve embedded files from disk images or binary blobs.
-    
+
     FILE_PATH: Path to disk image or binary file to carve from
     """
     from pathlib import Path
-    
+
     source_path = Path(file_path)
     output_path = Path(output_dir)
-    
+
     console.print(f"[cyan]Carving files from:[/cyan] {source_path}")
     console.print(f"[dim]Output directory: {output_path}[/dim]")
     console.print(f"[dim]Min size: {min_size} bytes, Max size: {max_size or 'unlimited'}[/dim]\n")
-    
+
     try:
         carver = CarverEngine()
         carved_files = carver.carve_file(source_path, min_size=min_size, max_size=max_size)
-        
+
         if not carved_files:
             console.print("[yellow]No files carved[/yellow]")
             return
-        
+
         output_path.mkdir(parents=True, exist_ok=True)
-        
+
         table = Table(title=f"Carved {len(carved_files)} Files")
         table.add_column("Offset", style="cyan")
         table.add_column("Size", style="green")
         table.add_column("Format", style="yellow")
         table.add_column("Confidence", style="magenta")
         table.add_column("Output File", style="blue")
-        
+
         for i, carved in enumerate(carved_files):
             out_name = f"{source_path.stem}_carved_{i:04d}_{carved.format}.bin"
             out_file = output_path / out_name
-            
+
             carved.save(out_file)
-            
+
             table.add_row(
                 f"0x{carved.offset:08x}",
                 f"{carved.size:,} bytes",
                 carved.format.upper(),
                 f"{carved.confidence:.1%}",
-                out_name
+                out_name,
             )
-        
+
         console.print(table)
         console.print(f"\n[green]✓[/green] Saved {len(carved_files)} files to {output_path}")
-        
+
     except Exception as e:
         console.print(f"[red]Error during carving: {e}[/red]")
         sys.exit(1)
@@ -724,40 +806,47 @@ def carve(file_path: str, formats: Optional[str], output_dir: str, min_size: int
 @click.option("--max-size", default=100, type=int, help="Max file size in MB")
 @click.option("--export", type=click.Choice(["json", "sarif"]), help="Export results")
 @click.option("--output", "-o", type=click.Path(), help="Output file for export")
-def batch(directory: str, recursive: bool, workers: int, max_size: int, export: Optional[str], output: Optional[str]) -> None:
+def batch(
+    directory: str,
+    recursive: bool,
+    workers: int,
+    max_size: int,
+    export: Optional[str],
+    output: Optional[str],
+) -> None:
     """
     Batch analyze all files in a directory.
-    
+
     Examples:
         filo batch ./samples
         filo batch --workers=8 --export=json --output=results.json ./data
     """
     try:
         from pathlib import Path
-        
+
         config = BatchConfig(
             max_workers=workers,
             max_file_size=max_size * 1024 * 1024,
             recursive=recursive,
-            progress_callback=None
+            progress_callback=None,
         )
-        
+
         processor = BatchProcessor(config)
-        
+
         console.print(f"[bold]Batch Processing:[/bold] {directory}\n")
-        
+
         with Progress(
             SpinnerColumn(),
             TextColumn("[progress.description]{task.description}"),
             BarColumn(),
             TaskProgressColumn(),
-            console=console
+            console=console,
         ) as progress:
             task = progress.add_task("Analyzing files...", total=None)
-            
+
             result = processor.process_directory(Path(directory))
             progress.update(task, completed=result.total_files, total=result.total_files)
-        
+
         # Show summary
         console.print("\n[bold]Results Summary:[/bold]")
         console.print(f"Total files: {result.total_files}")
@@ -765,38 +854,38 @@ def batch(directory: str, recursive: bool, workers: int, max_size: int, export: 
         console.print(f"[red]Failed: {result.failed_files}[/red]")
         console.print(f"[yellow]Skipped: {result.skipped_files}[/yellow]")
         console.print(f"Duration: {result.duration:.2f}s ({result.files_per_second:.1f} files/sec)")
-        
+
         # Show format breakdown
         if result.results:
             format_counts = {}
             for path, res in result.results:
                 fmt = res.format_name
                 format_counts[fmt] = format_counts.get(fmt, 0) + 1
-            
+
             table = Table(title="Format Distribution", show_header=True)
             table.add_column("Format", style="cyan")
             table.add_column("Count", justify="right", style="green")
             table.add_column("Percentage", justify="right")
-            
+
             for fmt, count in sorted(format_counts.items(), key=lambda x: x[1], reverse=True)[:10]:
                 pct = count / result.analyzed_files * 100
                 table.add_row(fmt, str(count), f"{pct:.1f}%")
-            
+
             console.print(table)
-        
+
         # Export if requested
         if export and result.results:
             if export == "json":
                 exported = JSONExporter.export_batch(result.results, pretty=True)
             elif export == "sarif":
                 exported = SARIFExporter.export_batch(result.results, pretty=True)
-            
+
             if output:
                 export_to_file(exported, Path(output), overwrite=True)
                 console.print(f"\n[green]✓[/green] Exported to {output}")
             else:
                 console.print("\n" + exported)
-        
+
     except Exception as e:
         console.print(f"[red]Error during batch processing: {e}[/red]")
         sys.exit(1)
@@ -809,7 +898,7 @@ def batch(directory: str, recursive: bool, workers: int, max_size: int, export: 
 def profile(file_path: str, profile: bool, show_stats: bool) -> None:
     """
     Profile performance of file analysis.
-    
+
     Examples:
         filo profile large_file.bin
         filo profile --show-stats suspicious.dat
@@ -817,43 +906,43 @@ def profile(file_path: str, profile: bool, show_stats: bool) -> None:
     try:
         profiler = Profiler(enabled=True)
         profiler.start()
-        
+
         # Run analysis
         analyzer = Analyzer(use_ml=False)
-        
-        with open(file_path, 'rb') as f:
+
+        with open(file_path, "rb") as f:
             data = f.read()
-        
+
         with profiler.time_operation("analyze"):
             analyzer.analyze(data)
-        
+
         report = profiler.stop()
-        
+
         # Show results
         console.print(f"\n[bold]Performance Profile:[/bold] {file_path}\n")
         console.print(f"Total Duration: [cyan]{report.total_duration:.4f}s[/cyan]")
-        
+
         if report.timings:
             table = Table(show_header=True, header_style="bold magenta")
             table.add_column("Operation")
             table.add_column("Time (s)", justify="right")
             table.add_column("Calls", justify="right")
             table.add_column("Avg (s)", justify="right")
-            
+
             for timing in report.get_sorted_timings()[:10]:
                 table.add_row(
                     timing.name,
                     f"{timing.duration:.4f}",
                     str(timing.calls),
-                    f"{timing.avg_duration:.6f}"
+                    f"{timing.avg_duration:.6f}",
                 )
-            
+
             console.print(table)
-        
+
         if show_stats and report.profile_data:
             console.print("\n[bold]Detailed Statistics:[/bold]")
             console.print(report.profile_data)
-        
+
     except Exception as e:
         console.print(f"[red]Error during profiling: {e}[/red]")
         sys.exit(1)
@@ -861,14 +950,20 @@ def profile(file_path: str, profile: bool, show_stats: bool) -> None:
 
 @main.command()
 @click.argument("file_hash")
-@click.option("--format", "output_format", type=click.Choice(["text", "json"]), default="text", help="Output format")
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["text", "json"]),
+    default="text",
+    help="Output format",
+)
 @click.option("--output", "-o", type=click.Path(), help="Save to file")
 def lineage(file_hash: str, output_format: str, output: Optional[str]) -> None:
     """
     Show hash lineage chain-of-custody for a file.
-    
+
     FILE_HASH: SHA-256 hash to query (first 8+ characters accepted)
-    
+
     Examples:
         filo lineage abc123def456  # Show lineage for hash
         filo lineage abc123 --format json  # JSON output
@@ -876,20 +971,22 @@ def lineage(file_hash: str, output_format: str, output: Optional[str]) -> None:
     """
     try:
         tracker = LineageTracker()
-        
+
         # Support partial hash matching (minimum 8 chars)
         if len(file_hash) < 8:
             console.print("[red]Error: Hash must be at least 8 characters[/red]")
             sys.exit(1)
-        
+
         # For partial hashes, query may return multiple results
         if len(file_hash) != 64:
             console.print("[yellow]Warning: Partial hash provided, results may be limited[/yellow]")
-            console.print("[yellow]For best results, provide full 64-character SHA-256 hash[/yellow]\n")
-        
+            console.print(
+                "[yellow]For best results, provide full 64-character SHA-256 hash[/yellow]\n"
+            )
+
         if output_format == "json":
             result = tracker.export_chain_json(file_hash)
-            
+
             if output:
                 Path(output).write_text(result)
                 console.print(f"[green]✓ Lineage exported to {output}[/green]")
@@ -897,25 +994,29 @@ def lineage(file_hash: str, output_format: str, output: Optional[str]) -> None:
                 console.print(result)
         else:
             result = tracker.export_chain_report(file_hash)
-            
+
             if output:
                 Path(output).write_text(result)
                 console.print(f"[green]✓ Chain-of-custody report saved to {output}[/green]")
             else:
                 console.print(result)
-        
+
     except Exception as e:
         console.print(f"[red]Error querying lineage: {e}[/red]")
         sys.exit(1)
 
 
 @main.command()
-@click.option("--operation", type=click.Choice(["repair", "carve", "extract", "export", "teach", "analyze"]), help="Filter by operation type")
+@click.option(
+    "--operation",
+    type=click.Choice(["repair", "carve", "extract", "export", "teach", "analyze"]),
+    help="Filter by operation type",
+)
 @click.option("--limit", type=int, default=20, help="Maximum records to show")
 def lineage_history(operation: Optional[str], limit: int) -> None:
     """
     Show recent lineage tracking history.
-    
+
     Examples:
         filo lineage-history  # Show all recent operations
         filo lineage-history --operation repair  # Show only repairs
@@ -923,7 +1024,7 @@ def lineage_history(operation: Optional[str], limit: int) -> None:
     """
     try:
         tracker = LineageTracker()
-        
+
         if operation:
             op_type = OperationType(operation)
             records = tracker.get_by_operation(op_type)[:limit]
@@ -931,74 +1032,82 @@ def lineage_history(operation: Optional[str], limit: int) -> None:
         else:
             # Get stats to show overview
             stats = tracker.get_stats()
-            
+
             console.print("\n[bold]Lineage Tracking Statistics[/bold]")
             console.print(f"Total Records: {stats['total_records']}")
             console.print(f"Database: {stats['database_path']}\n")
-            
-            if stats['total_records'] == 0:
+
+            if stats["total_records"] == 0:
                 console.print("[yellow]No lineage records found[/yellow]")
-                console.print("[dim]Lineage tracking records chain-of-custody for file transformations[/dim]")
-                console.print("[dim]Use 'filo repair' or 'filo carve' with lineage tracking enabled[/dim]")
+                console.print(
+                    "[dim]Lineage tracking records chain-of-custody for file transformations[/dim]"
+                )
+                console.print(
+                    "[dim]Use 'filo repair' or 'filo carve' with lineage tracking enabled[/dim]"
+                )
                 return
-            
+
             console.print("[bold]Records by Operation:[/bold]")
-            for op, count in stats['by_operation'].items():
+            for op, count in stats["by_operation"].items():
                 if count > 0:
                     console.print(f"  {op}: {count}")
-            
+
             console.print(f"\nOldest: {stats['oldest_record']}")
             console.print(f"Newest: {stats['newest_record']}\n")
-            
+
             # Show recent records from all operations
             all_records = []
             for op in OperationType:
                 all_records.extend(tracker.get_by_operation(op))
-            
+
             # Sort by timestamp and take most recent
             all_records.sort(key=lambda r: r.timestamp, reverse=True)
             records = all_records[:limit]
             title = f"Recent Lineage Records (last {len(records)})"
-        
+
         if not records:
-            console.print(f"[yellow]No {operation} operations found[/yellow]" if operation else "[yellow]No records found[/yellow]")
+            console.print(
+                f"[yellow]No {operation} operations found[/yellow]"
+                if operation
+                else "[yellow]No records found[/yellow]"
+            )
             return
-        
+
         console.print(f"\n[bold]{title}[/bold]\n")
-        
+
         table = Table(show_header=True, header_style="bold magenta")
         table.add_column("Timestamp", width=20)
         table.add_column("Operation", width=10)
         table.add_column("Original Hash", width=16)
         table.add_column("Result Hash", width=16)
         table.add_column("Details", width=40)
-        
+
         for record in records:
             # Truncate hashes for display
             orig_hash = record.original_hash[:14] + "..."
             result_hash = record.result_hash[:14] + "..."
-            
+
             # Format metadata
             details = []
-            if 'format' in record.metadata:
+            if "format" in record.metadata:
                 details.append(f"fmt={record.metadata['format']}")
-            if 'strategy' in record.metadata:
+            if "strategy" in record.metadata:
                 details.append(f"strategy={record.metadata['strategy']}")
-            if 'offset' in record.metadata:
+            if "offset" in record.metadata:
                 details.append(f"offset={record.metadata['offset']}")
             details_str = ", ".join(details) if details else "-"
-            
+
             table.add_row(
-                record.timestamp[:19].replace('T', ' '),
+                record.timestamp[:19].replace("T", " "),
                 record.operation.value,
                 orig_hash,
                 result_hash,
-                details_str
+                details_str,
             )
-        
+
         console.print(table)
         console.print("\n[dim]Use 'filo lineage <hash>' to see full chain-of-custody[/dim]")
-        
+
     except Exception as e:
         console.print(f"[red]Error: {e}[/red]")
         sys.exit(1)
@@ -1010,22 +1119,24 @@ def lineage_stats() -> None:
     try:
         tracker = LineageTracker()
         stats = tracker.get_stats()
-        
+
         console.print("\n[bold cyan]═══════════════════════════════════════════[/bold cyan]")
         console.print("[bold cyan]  Lineage Tracking Statistics              [/bold cyan]")
         console.print("[bold cyan]═══════════════════════════════════════════[/bold cyan]\n")
-        
+
         console.print(f"[bold]Total Records:[/bold] {stats['total_records']}")
         console.print(f"[bold]Database Path:[/bold] {stats['database_path']}\n")
-        
-        if stats['total_records'] > 0:
+
+        if stats["total_records"] > 0:
             console.print("[bold]Operations:[/bold]")
             table = Table(show_header=False, box=None)
-            for op, count in sorted(stats['by_operation'].items(), key=lambda x: x[1], reverse=True):
+            for op, count in sorted(
+                stats["by_operation"].items(), key=lambda x: x[1], reverse=True
+            ):
                 if count > 0:
                     table.add_row(f"  • {op.upper()}", f"{count} records")
             console.print(table)
-            
+
             console.print("\n[bold]Time Range:[/bold]")
             console.print(f"  Oldest: {stats['oldest_record']}")
             console.print(f"  Newest: {stats['newest_record']}\n")
@@ -1035,7 +1146,7 @@ def lineage_stats() -> None:
             console.print("[dim]  • File repairs (original → repaired)[/dim]")
             console.print("[dim]  • File carving (container → extracted)[/dim]")
             console.print("[dim]  • File exports (source → exported format)[/dim]\n")
-        
+
     except Exception as e:
         console.print(f"[red]Error: {e}[/red]")
         sys.exit(1)
@@ -1049,25 +1160,27 @@ def reset_lineage(yes: bool) -> None:
         tracker = LineageTracker()
         db_path = tracker.db_path
         stats = tracker.get_stats()
-        
-        if stats['total_records'] == 0:
+
+        if stats["total_records"] == 0:
             console.print("[yellow]Lineage database is already empty[/yellow]")
             return
-        
+
         if not yes:
-            console.print(f"[yellow]Warning:[/yellow] This will delete {stats['total_records']} lineage records")
+            console.print(
+                f"[yellow]Warning:[/yellow] This will delete {stats['total_records']} lineage records"
+            )
             console.print(f"[dim]Database: {db_path}[/dim]\n")
-            
+
             if not click.confirm("Are you sure you want to reset the lineage database?"):
                 console.print("[dim]Cancelled[/dim]")
                 return
-        
+
         tracker.close()
         db_path.unlink(missing_ok=True)
-        
+
         console.print("[green]✓ Lineage database reset[/green]")
         console.print(f"[dim]Deleted {stats['total_records']} records from {db_path}[/dim]")
-        
+
     except Exception as e:
         console.print(f"[red]Error: {e}[/red]")
         sys.exit(1)
@@ -1076,17 +1189,30 @@ def reset_lineage(yes: bool) -> None:
 @main.command()
 @click.argument("file_path", type=click.Path(exists=True))
 @click.option("-a", "--all", "show_all", is_flag=True, help="Show all methods (slower)")
-@click.option("-E", "--extract", "extract_method", help="Extract data from specific method (e.g., 'b1,rgba,lsb,xy')")
-@click.option("-o", "--output", "output_path", type=click.Path(), help="Save extracted data to file")
+@click.option(
+    "-E",
+    "--extract",
+    "extract_method",
+    help="Extract data from specific method (e.g., 'b1,rgba,lsb,xy')",
+)
+@click.option(
+    "-o", "--output", "output_path", type=click.Path(), help="Save extracted data to file"
+)
 @click.option("--limit", default=256, type=int, help="Limit bytes checked (0 = no limit)")
-def stego(file_path: str, show_all: bool, extract_method: Optional[str], output_path: Optional[str], limit: int) -> None:
+def stego(
+    file_path: str,
+    show_all: bool,
+    extract_method: Optional[str],
+    output_path: Optional[str],
+    limit: int,
+) -> None:
     """
     Detect steganography in files (LSB analysis, metadata, etc.).
-    
+
     Supports:
     - PNG/BMP: LSB analysis (zsteg-compatible)
     - PDF: Metadata analysis
-    
+
     Examples:
         filo stego image.png
         filo stego document.pdf
@@ -1095,126 +1221,137 @@ def stego(file_path: str, show_all: bool, extract_method: Optional[str], output_
     try:
         if extract_method:
             # Extract specific method
-            with open(file_path, 'rb') as f:
+            with open(file_path, "rb") as f:
                 data = f.read()
-            
+
             from filo.stego import PNGStegoDetector, BMPStegoDetector, BitOrder
-            
-            if data.startswith(b'\x89PNG'):
+
+            if data.startswith(b"\x89PNG"):
                 detector = PNGStegoDetector()
-            elif data.startswith(b'BM'):
+            elif data.startswith(b"BM"):
                 detector = BMPStegoDetector()
             else:
                 console.print("[red]File is not a PNG or BMP image[/red]")
                 sys.exit(1)
-            
+
             # Parse method string (e.g., "b1,rgba,lsb,xy")
-            parts = extract_method.split(',')
+            parts = extract_method.split(",")
             if len(parts) < 4:
-                console.print("[red]Invalid method format. Use: 'bits,channels,order,pixelorder'[/red]")
+                console.print(
+                    "[red]Invalid method format. Use: 'bits,channels,order,pixelorder'[/red]"
+                )
                 console.print("[dim]Example: b1,rgba,lsb,xy[/dim]")
                 sys.exit(1)
-            
+
             bits_str = parts[0]
-            bits = int(bits_str.lstrip('b').rstrip('b'))
+            bits = int(bits_str.lstrip("b").rstrip("b"))
             parts[1]
             bit_order = parts[2]
             parts[3]
-            
+
             # Extract data using Python implementation
             png_info = detector.parse_png(data)
-            if png_info and png_info['clean_pixels']:
-                image_data = png_info['clean_pixels']
+            if png_info and png_info["clean_pixels"]:
+                image_data = png_info["clean_pixels"]
             else:
                 console.print("[red]Failed to parse image[/red]")
                 sys.exit(1)
-            
+
             extracted = detector.extractor.extract_bits(
-                image_data,
-                bits=bits,
-                order=BitOrder.LSB if bit_order == "lsb" else BitOrder.MSB
+                image_data, bits=bits, order=BitOrder.LSB if bit_order == "lsb" else BitOrder.MSB
             )
-            
+
             if output_path:
-                with open(output_path, 'wb') as f:
+                with open(output_path, "wb") as f:
                     f.write(extracted)
                 console.print(f"[green]✓ Extracted {len(extracted)} bytes to {output_path}[/green]")
             else:
                 # Try to display as text
                 try:
-                    text = extracted.decode('utf-8', errors='ignore')
+                    text = extracted.decode("utf-8", errors="ignore")
                     console.print(text)
                 except Exception:
                     # Show hex dump
                     console.print(f"[dim]Binary data ({len(extracted)} bytes):[/dim]")
                     _print_hex_dump(extracted[:256])
-            
+
             return
-        
+
         # Normal detection mode
-        console.print(Panel.fit(
-            f"[bold cyan]Steganography Analysis:[/bold cyan] {file_path}",
-            border_style="cyan"
-        ))
-        
-        with open(file_path, 'rb') as f:
+        console.print(
+            Panel.fit(
+                f"[bold cyan]Steganography Analysis:[/bold cyan] {file_path}", border_style="cyan"
+            )
+        )
+
+        with open(file_path, "rb") as f:
             data = f.read()
-        
+
         results = detect_steganography(data)
-        
+
         if not results:
             console.print("\n[yellow]No steganography detected[/yellow]")
             return
-        
+
         # Filter results: By default, hide metadata results (tEXt, iTXt, zTXt, tIME)
         # and imagedata results unless --all is specified
         if not show_all:
             # Only show LSB/MSB extraction results (the core stego results)
             filtered_results = [
-                r for r in results 
-                if not (r.channel in ('tEXt', 'iTXt', 'zTXt', 'tIME', 'pixels') or 
-                       r.method.startswith('meta') or
-                       r.method == 'imagedata')
+                r
+                for r in results
+                if not (
+                    r.channel in ("tEXt", "iTXt", "zTXt", "tIME", "pixels")
+                    or r.method.startswith("meta")
+                    or r.method == "imagedata"
+                )
             ]
-            
+
             # If we have no LSB results, show everything
             if filtered_results:
                 results = filtered_results
-        
+
         console.print(f"\nFound {len(results)} results:\n")
-        
+
         # Display results in zsteg-like format
         for i, result in enumerate(results):
             if not show_all and i >= 50:  # zsteg shows up to ~50 results by default
                 remaining = len(results) - 50
                 console.print(f"\n[dim]... and {remaining} more (use --all to show)[/dim]")
                 break
-            
+
             # Format: method .. description (like zsteg)
             # e.g., "b1,rgb,lsb,xy       .. text: \"picoCTF{...}\""
             method_str = f"{result.method:23}"  # Left-aligned, 23 chars wide
-            
+
             # Color based on data type
-            if 'FLAG' in result.description or result.data_type == 'flag' or 'picoCTF' in result.description:
+            if (
+                "FLAG" in result.description
+                or result.data_type == "flag"
+                or "picoCTF" in result.description
+            ):
                 color = "bright_green"
-            elif result.data_type == 'text':
+            elif result.data_type == "text":
                 color = "white"
-            elif result.data_type in ('file', 'zlib'):
+            elif result.data_type in ("file", "zlib"):
                 color = "cyan"
-            elif result.data_type in ('metadata', 'trailing'):
+            elif result.data_type in ("metadata", "trailing"):
                 color = "yellow"
             else:
                 color = "dim"
-            
+
             console.print(f"[{color}]{method_str}[/{color}] .. {result.description}")
-        
+
         console.print("\n[dim]Tip: Use --extract=METHOD to extract specific data[/dim]")
-        console.print(f"[dim]Example: filo stego {file_path} --extract=\"b1,rgba,lsb,xy\" -o output.txt[/dim]")
-        
+        console.print(
+            f'[dim]Example: filo stego {file_path} --extract="b1,rgba,lsb,xy" -o output.txt[/dim]'
+        )
+
     except Exception as e:
         console.print(f"[red]Error: {e}[/red]")
         import traceback
-        if '--verbose' in sys.argv or '-v' in sys.argv:
+
+        if "--verbose" in sys.argv or "-v" in sys.argv:
             traceback.print_exc()
         sys.exit(1)
 
@@ -1224,7 +1361,7 @@ def stego(file_path: str, show_all: bool, extract_method: Optional[str], output_
 def pcap(file_path: str) -> None:
     """
     Analyze PCAP network capture files.
-    
+
     Quick triage for CTF challenges:
     - Packet statistics
     - Protocol breakdown
@@ -1232,42 +1369,39 @@ def pcap(file_path: str) -> None:
     - Base64 data detection
     - Flag pattern search
     - HTTP requests
-    
+
     Examples:
         filo pcap capture.pcap
         filo pcap network.pcapng
     """
     try:
-        console.print(Panel(
-            f"PCAP Analysis: {Path(file_path).name}",
-            style="bold cyan"
-        ))
-        
+        console.print(Panel(f"PCAP Analysis: {Path(file_path).name}", style="bold cyan"))
+
         stats = analyze_pcap(file_path)
-        
+
         if not stats:
             console.print("[red]Error: Not a valid PCAP file[/red]")
             console.print("[dim]Supported: .pcap files (libpcap format)[/dim]")
             sys.exit(1)
-        
+
         # Display statistics
         console.print("\n[bold]📊 Statistics[/bold]")
         console.print(f"  Packets: {stats.packet_count:,}")
         console.print(f"  Total bytes: {stats.total_bytes:,}")
         console.print(f"  File size: {stats.file_size:,} bytes")
-        
+
         # Protocol breakdown
         if stats.protocols:
             console.print("\n[bold]🔌 Protocols[/bold]")
             for protocol, count in stats.protocols.most_common(10):
                 console.print(f"  {protocol}: {count:,} packets")
-        
+
         # Flags found
         if stats.flags:
             console.print(f"\n[bold green]🚩 FLAGS FOUND ({len(stats.flags)})[/bold green]")
             for flag in stats.flags:
                 console.print(f"  [red bold]{flag}[/red bold]")
-        
+
         # Base64 data
         if stats.base64_data:
             console.print(f"\n[bold]📝 Base64 Data ({len(stats.base64_data)} found)[/bold]")
@@ -1275,13 +1409,13 @@ def pcap(file_path: str) -> None:
                 console.print(f"  [cyan]{raw}...[/cyan]")
                 console.print(f"  → {decoded[:100]}")
                 console.print()
-        
+
         # HTTP requests
         if stats.http_requests:
             console.print(f"\n[bold]🌐 HTTP Requests ({len(stats.http_requests)} found)[/bold]")
             for req in stats.http_requests[:15]:
                 console.print(f"  {req}")
-        
+
         # Interesting strings
         if stats.strings:
             console.print(f"\n[bold]💬 Interesting Strings ({len(stats.strings)} found)[/bold]")
@@ -1289,20 +1423,25 @@ def pcap(file_path: str) -> None:
                 # Truncate long strings
                 display = s[:80] + "..." if len(s) > 80 else s
                 console.print(f"  {display}")
-        
+
         # Recommendations
         console.print("\n[bold]💡 Next Steps[/bold]")
         console.print("  • Open in Wireshark for detailed protocol analysis")
         console.print(f"  • Use 'tshark -r {file_path}' for packet inspection")
-        console.print(f"  • Export HTTP objects: tshark -r {file_path} --export-objects http,./output")
-        
+        console.print(
+            f"  • Export HTTP objects: tshark -r {file_path} --export-objects http,./output"
+        )
+
         if stats.flags:
-            console.print(f"\n[bold green]✓ Found {len(stats.flags)} flag(s) - check above![/bold green]")
-        
+            console.print(
+                f"\n[bold green]✓ Found {len(stats.flags)} flag(s) - check above![/bold green]"
+            )
+
     except Exception as e:
         console.print(f"[red]Error: {e}[/red]")
         import traceback
-        if '--verbose' in sys.argv or '-v' in sys.argv:
+
+        if "--verbose" in sys.argv or "-v" in sys.argv:
             traceback.print_exc()
         sys.exit(1)
 
@@ -1310,19 +1449,25 @@ def pcap(file_path: str) -> None:
 @main.command()
 @click.argument("file_path", type=click.Path(exists=True))
 @click.option("-o", "--output", type=click.Path(), help="Output directory for extracted files")
-@click.option("-r", "--recursive", is_flag=True, default=True, help="Recursively extract nested archives (default: on)")
+@click.option(
+    "-r",
+    "--recursive",
+    is_flag=True,
+    default=True,
+    help="Recursively extract nested archives (default: on)",
+)
 @click.option("--max-depth", type=int, default=10, help="Maximum nesting depth (default: 10)")
 def extract(file_path: str, output: Optional[str], recursive: bool, max_depth: int) -> None:
     """
     Extract nested archives and polyglots recursively.
-    
+
     Automatically detects and extracts:
     - ZIP archives embedded in images (polyglots)
     - Nested archives (zip in zip, etc.)
     - Trailing data after image markers
-    
+
     Perfect for CTF challenges like Matryoshka dolls!
-    
+
     Examples:
         filo extract dolls.jpg
         filo extract polyglot.png -o extracted/
@@ -1330,141 +1475,178 @@ def extract(file_path: str, output: Optional[str], recursive: bool, max_depth: i
     """
     import zipfile
     from pathlib import Path
-    
+
     try:
         file_path = Path(file_path)
-        
+
         # Set output directory
         if output:
             output_dir = Path(output)
         else:
             output_dir = Path.cwd() / f"{file_path.stem}_extracted"
-        
+
         output_dir.mkdir(parents=True, exist_ok=True)
-        
-        console.print(Panel(
-            f"[bold cyan]Recursive Extraction:[/bold cyan] {file_path.name}",
-            border_style="cyan"
-        ))
-        
+
+        console.print(
+            Panel(
+                f"[bold cyan]Recursive Extraction:[/bold cyan] {file_path.name}",
+                border_style="cyan",
+            )
+        )
+
         extracted_count = 0
         files_to_process = [(file_path, output_dir, 0)]
         processed_hashes = set()
-        
+
         while files_to_process:
             current_file, current_output, depth = files_to_process.pop(0)
-            
+
             if depth > max_depth:
                 console.print(f"[yellow]⚠ Max depth ({max_depth}) reached, stopping[/yellow]")
                 break
-            
+
             # Avoid processing the same file twice
             import hashlib
-            with open(current_file, 'rb') as f:
+
+            with open(current_file, "rb") as f:
                 file_hash = hashlib.sha256(f.read()).hexdigest()
-            
+
             if file_hash in processed_hashes:
                 continue
             processed_hashes.add(file_hash)
-            
+
             # Analyze the file
             analyzer = Analyzer()
             result = analyzer.analyze_file(current_file)
-            
+
             indent = "  " * depth
-            console.print(f"\n{indent}[cyan]→[/cyan] {current_file.name} ({result.primary_format}, {result.confidence:.1%})")
-            
+            console.print(
+                f"\n{indent}[cyan]→[/cyan] {current_file.name} ({result.primary_format}, {result.confidence:.1%})"
+            )
+
             # Check for polyglots
             extracted_from_polyglot = False
             if result.polyglots:
                 for polyglot in result.polyglots:
-                    if 'zip' in polyglot.formats:
-                        console.print(f"{indent}  [yellow]📦 Polyglot detected:[/yellow] {' + '.join(polyglot.formats)}")
-                        
+                    if "zip" in polyglot.formats:
+                        console.print(
+                            f"{indent}  [yellow]📦 Polyglot detected:[/yellow] {' + '.join(polyglot.formats)}"
+                        )
+
                         # Try to extract as ZIP
                         try:
-                            with zipfile.ZipFile(current_file, 'r') as zf:
+                            with zipfile.ZipFile(current_file, "r") as zf:
                                 for member in zf.namelist():
                                     extracted_path = current_output / member
                                     extracted_path.parent.mkdir(parents=True, exist_ok=True)
-                                    
-                                    with zf.open(member) as source, open(extracted_path, 'wb') as target:
+
+                                    with (
+                                        zf.open(member) as source,
+                                        open(extracted_path, "wb") as target,
+                                    ):
                                         target.write(source.read())
-                                    
-                                    console.print(f"{indent}    [green]✓[/green] Extracted: {member}")
+
+                                    console.print(
+                                        f"{indent}    [green]✓[/green] Extracted: {member}"
+                                    )
                                     extracted_count += 1
-                                    
+
                                     # Add to processing queue if recursive
-                                    if recursive and extracted_path.suffix.lower() in ['.jpg', '.jpeg', '.png', '.zip', '.gz', '.bz2', '.tar']:
-                                        files_to_process.append((extracted_path, extracted_path.parent, depth + 1))
-                                    
+                                    if recursive and extracted_path.suffix.lower() in [
+                                        ".jpg",
+                                        ".jpeg",
+                                        ".png",
+                                        ".zip",
+                                        ".gz",
+                                        ".bz2",
+                                        ".tar",
+                                    ]:
+                                        files_to_process.append(
+                                            (extracted_path, extracted_path.parent, depth + 1)
+                                        )
+
                                     extracted_from_polyglot = True
                         except zipfile.BadZipFile:
                             console.print(f"{indent}    [red]✗[/red] Failed to extract ZIP data")
                         except Exception as e:
                             console.print(f"{indent}    [red]✗[/red] Error: {e}")
-            
+
             # Check for regular archives
-            if not extracted_from_polyglot and result.primary_format in ['zip', 'tar', 'gzip', 'bzip2', '7z', 'rar']:
-                console.print(f"{indent}  [yellow]📦 Archive detected:[/yellow] {result.primary_format}")
-                
+            if not extracted_from_polyglot and result.primary_format in [
+                "zip",
+                "tar",
+                "gzip",
+                "bzip2",
+                "7z",
+                "rar",
+            ]:
+                console.print(
+                    f"{indent}  [yellow]📦 Archive detected:[/yellow] {result.primary_format}"
+                )
+
                 # Extract based on format
                 try:
-                    if result.primary_format == 'zip':
-                        with zipfile.ZipFile(current_file, 'r') as zf:
+                    if result.primary_format == "zip":
+                        with zipfile.ZipFile(current_file, "r") as zf:
                             for member in zf.namelist():
                                 extracted_path = current_output / member
                                 extracted_path.parent.mkdir(parents=True, exist_ok=True)
-                                
-                                with zf.open(member) as source, open(extracted_path, 'wb') as target:
+
+                                with (
+                                    zf.open(member) as source,
+                                    open(extracted_path, "wb") as target,
+                                ):
                                     target.write(source.read())
-                                
+
                                 console.print(f"{indent}    [green]✓[/green] Extracted: {member}")
                                 extracted_count += 1
-                                
+
                                 if recursive:
-                                    files_to_process.append((extracted_path, extracted_path.parent, depth + 1))
-                    
+                                    files_to_process.append(
+                                        (extracted_path, extracted_path.parent, depth + 1)
+                                    )
+
                     # Add support for other formats if needed
-                    
+
                 except Exception as e:
                     console.print(f"{indent}    [red]✗[/red] Error: {e}")
-        
+
         console.print("\n[bold green]✓ Extraction complete![/bold green]")
         console.print(f"  Total files extracted: {extracted_count}")
         console.print(f"  Output directory: {output_dir}")
-        
+
         # Search for flags in extracted text files
-        flag_pattern = re.compile(rb'(picoCTF|flag|ctf|HTB)\{[^}]+\}', re.IGNORECASE)
+        flag_pattern = re.compile(rb"(picoCTF|flag|ctf|HTB)\{[^}]+\}", re.IGNORECASE)
         flags_found = []
-        
-        for txt_file in output_dir.rglob('*.txt'):
+
+        for txt_file in output_dir.rglob("*.txt"):
             try:
-                with open(txt_file, 'rb') as f:
+                with open(txt_file, "rb") as f:
                     content = f.read()
                     matches = flag_pattern.findall(content)
                     for match in matches:
-                        flag_text = match.decode('utf-8', errors='ignore')
+                        flag_text = match.decode("utf-8", errors="ignore")
                         # Find the full flag including prefix
-                        full_match = re.search(rb'[a-zA-Z0-9_]+\{[^}]+\}', content)
+                        full_match = re.search(rb"[a-zA-Z0-9_]+\{[^}]+\}", content)
                         if full_match:
-                            flag_text = full_match.group(0).decode('utf-8', errors='ignore')
+                            flag_text = full_match.group(0).decode("utf-8", errors="ignore")
                         flags_found.append((txt_file.relative_to(output_dir), flag_text))
             except Exception:
                 pass
-        
+
         if flags_found:
             console.print("\n[bold yellow]🚩 Flags found:[/bold yellow]")
             for filename, flag in flags_found:
                 console.print(f"  [green]{filename}:[/green] {flag}")
-        
+
         if extracted_count == 0:
             console.print("\n[yellow]No archives or polyglots found to extract[/yellow]")
-    
+
     except Exception as e:
         console.print(f"[red]Error: {e}[/red]")
         if "--debug" in sys.argv:
             import traceback
+
             traceback.print_exc()
         sys.exit(1)
 
@@ -1472,14 +1654,16 @@ def extract(file_path: str, output: Optional[str], recursive: bool, max_depth: i
 @main.command(name="meta")
 @click.argument("file_path", type=click.Path(exists=True))
 @click.option("--json", "output_json", is_flag=True, help="Output as JSON")
-@click.option("-s", "--sus", "suspicious_only", is_flag=True, help="Only show suspicious/hidden metadata")
+@click.option(
+    "-s", "--sus", "suspicious_only", is_flag=True, help="Only show suspicious/hidden metadata"
+)
 def metadata(file_path: str, output_json: bool, suspicious_only: bool) -> None:
     """
     Extract metadata from image files (JPEG, PNG).
-    
+
     Similar to exiftool - extracts EXIF, IPTC, XMP, ICC profiles, and other metadata.
     Automatically flags suspicious content like base64-encoded data.
-    
+
     Examples:
         filo meta photo.jpg
         filo meta image.png -s
@@ -1487,12 +1671,12 @@ def metadata(file_path: str, output_json: bool, suspicious_only: bool) -> None:
     """
     try:
         from filo.metadata import extract_metadata
-        
-        with open(file_path, 'rb') as f:
+
+        with open(file_path, "rb") as f:
             data = f.read()
-        
+
         result = extract_metadata(data)
-        
+
         if output_json:
             # JSON output
             output = {
@@ -1504,34 +1688,34 @@ def metadata(file_path: str, output_json: bool, suspicious_only: bool) -> None:
                         "key": field.key,
                         "value": str(field.value),
                         "tag_id": field.tag_id,
-                        "description": field.description
+                        "description": field.description,
                     }
                     for field in result.fields
                 ],
                 "warnings": result.warnings,
                 "has_suspicious": result.has_suspicious,
-                "suspicious_fields": result.suspicious_fields
+                "suspicious_fields": result.suspicious_fields,
             }
             console.print_json(data=output)
             return
-        
+
         # Rich console output
         console.print(f"\n[bold]File:[/bold] {file_path}")
         console.print(f"[bold]Format:[/bold] {result.format}\n")
-        
+
         if result.warnings:
             console.print("[yellow]Warnings:[/yellow]")
             for warning in result.warnings:
                 console.print(f"  ⚠ {warning}")
             console.print()
-        
+
         # Group metadata by category
         grouped = {}
         for field in result.fields:
             if field.group not in grouped:
                 grouped[field.group] = []
             grouped[field.group].append(field)
-        
+
         # Filter to suspicious only if requested
         if suspicious_only and result.has_suspicious:
             console.print("[bold yellow]🚨 Suspicious Metadata Found:[/bold yellow]\n")
@@ -1543,30 +1727,35 @@ def metadata(file_path: str, output_json: bool, suspicious_only: bool) -> None:
             # Show all metadata grouped
             for group, fields in sorted(grouped.items()):
                 console.print(f"[bold cyan]{group}[/bold cyan]")
-                
+
                 for field in fields:
                     # Highlight suspicious fields
                     if field.key in result.suspicious_fields:
                         console.print(f"  [yellow]⚠ {field.key}:[/yellow] {field.value}")
                     else:
                         console.print(f"  {field.key}: {field.value}")
-                    
+
                     # Show tag ID if present
                     if field.tag_id is not None:
                         console.print(f"    [dim]Tag ID: 0x{field.tag_id:04X}[/dim]")
-                
+
                 console.print()
-        
+
         # Summary for suspicious content
         if result.has_suspicious:
-            console.print(f"[bold yellow]⚠ {len(result.suspicious_fields)} suspicious field(s) detected[/bold yellow]")
-            console.print("[dim]These may contain encoded/hidden data (e.g., base64, steghide passwords)[/dim]")
+            console.print(
+                f"[bold yellow]⚠ {len(result.suspicious_fields)} suspicious field(s) detected[/bold yellow]"
+            )
+            console.print(
+                "[dim]These may contain encoded/hidden data (e.g., base64, steghide passwords)[/dim]"
+            )
             console.print("[dim]Use -s or --sus to filter suspicious fields only[/dim]\n")
-    
+
     except Exception as e:
         console.print(f"[red]Error: {e}[/red]")
         if "--debug" in sys.argv:
             import traceback
+
             traceback.print_exc()
         sys.exit(1)
 
@@ -1577,31 +1766,33 @@ def reset_ml(yes: bool) -> None:
     """Reset ML model (deletes all learned patterns)."""
     try:
         model_path = Path.home() / ".filo" / "learned_patterns.pkl"
-        
+
         if not model_path.exists():
             console.print("[yellow]ML model does not exist (nothing to reset)[/yellow]")
             return
-        
+
         detector = MLDetector(model_path)
         pattern_count = len(detector.pattern_weights) + len(detector.negative_patterns)
-        
+
         if pattern_count == 0:
             console.print("[yellow]ML model is already empty[/yellow]")
             return
-        
+
         if not yes:
-            console.print(f"[yellow]Warning:[/yellow] This will delete {pattern_count} learned patterns")
+            console.print(
+                f"[yellow]Warning:[/yellow] This will delete {pattern_count} learned patterns"
+            )
             console.print(f"[dim]Model: {model_path}[/dim]\n")
-            
+
             if not click.confirm("Are you sure you want to reset the ML model?"):
                 console.print("[dim]Cancelled[/dim]")
                 return
-        
+
         model_path.unlink()
-        
+
         console.print("[green]✓ ML model reset[/green]")
         console.print(f"[dim]Deleted {pattern_count} patterns from {model_path}[/dim]")
-        
+
     except Exception as e:
         console.print(f"[red]Error: {e}[/red]")
         sys.exit(1)
@@ -1619,48 +1810,56 @@ def _extract_strings(data: bytes, min_len: int = 4) -> list[dict]:
             current.append(byte)
         else:
             if len(current) >= min_len:
-                results.append({
-                    "type": "ascii",
-                    "offset": offset,
-                    "data": bytes(current),
-                    "length": len(current),
-                })
+                results.append(
+                    {
+                        "type": "ascii",
+                        "offset": offset,
+                        "data": bytes(current),
+                        "length": len(current),
+                    }
+                )
             current = bytearray()
     if len(current) >= min_len:
-        results.append({
-            "type": "ascii",
-            "offset": len(data) - len(current),
-            "data": bytes(current),
-            "length": len(current),
-        })
+        results.append(
+            {
+                "type": "ascii",
+                "offset": len(data) - len(current),
+                "data": bytes(current),
+                "length": len(current),
+            }
+        )
 
     # Unicode (UTF-16LE) strings
     current = bytearray()
     offset = 0
     i = 0
     while i < len(data) - 1:
-        if data[i+1] == 0 and 32 <= data[i] < 127:
+        if data[i + 1] == 0 and 32 <= data[i] < 127:
             if not current:
                 offset = i
-            current.extend(data[i:i+2])
+            current.extend(data[i : i + 2])
             i += 2
         else:
             if len(current) >= min_len * 2:
-                results.append({
-                    "type": "unicode",
-                    "offset": offset,
-                    "data": bytes(current),
-                    "length": len(current) // 2,
-                })
+                results.append(
+                    {
+                        "type": "unicode",
+                        "offset": offset,
+                        "data": bytes(current),
+                        "length": len(current) // 2,
+                    }
+                )
             current = bytearray()
             i += 1
     if len(current) >= min_len * 2:
-        results.append({
-            "type": "unicode",
-            "offset": len(data) - len(current),
-            "data": bytes(current),
-            "length": len(current) // 2,
-        })
+        results.append(
+            {
+                "type": "unicode",
+                "offset": len(data) - len(current),
+                "data": bytes(current),
+                "length": len(current) // 2,
+            }
+        )
 
     results.sort(key=lambda r: r["offset"])
     return results
@@ -1673,6 +1872,7 @@ def _string_entropy(s: bytes) -> float:
     for b in s:
         freq[b] += 1
     import math
+
     entropy = 0.0
     for f in freq:
         if f > 0:
@@ -1683,6 +1883,7 @@ def _string_entropy(s: bytes) -> float:
 
 def _detect_encoding(s: bytes) -> Optional[str]:
     import base64
+
     try:
         decoded = base64.b64decode(s, validate=True)
         if len(decoded) > 2 and len(decoded) <= len(s) * 3 // 4:
@@ -1711,18 +1912,35 @@ def _detect_encoding(s: bytes) -> Optional[str]:
 @click.option("-e", "--entropy", "min_entropy", type=float, help="Minimum entropy filter")
 @click.option("--encode-detect", is_flag=True, help="Detect encoding (base64, utf-8)")
 @click.option("--regex", help="Regex pattern to search for")
-@click.option("--type", "string_type", type=click.Choice(["ascii", "unicode", "all"]), default="all", help="String type to extract")
+@click.option(
+    "--type",
+    "string_type",
+    type=click.Choice(["ascii", "unicode", "all"]),
+    default="all",
+    help="String type to extract",
+)
 @click.option("-c", "--count", type=int, default=0, help="Limit number of strings shown (0 = all)")
 @click.option("--json", "output_json", is_flag=True, help="Output as JSON")
 @click.option("--offsets/--no-offsets", default=True, help="Show byte offsets")
 @click.option("--entropy-colors/--no-entropy-colors", default=True, help="Color by entropy")
-def strings_cmd(file_path: str, min_len: int, min_entropy: float, encode_detect: bool, regex: str, string_type: str, count: int, output_json: bool, offsets: bool, entropy_colors: bool) -> None:
+def strings_cmd(
+    file_path: str,
+    min_len: int,
+    min_entropy: float,
+    encode_detect: bool,
+    regex: str,
+    string_type: str,
+    count: int,
+    output_json: bool,
+    offsets: bool,
+    entropy_colors: bool,
+) -> None:
     """
     Extract strings from binary files with advanced filtering.
-    
+
     Supports ASCII and Unicode strings, entropy filtering, encoding detection,
     and regex pattern matching.
-    
+
     Examples:
         filo strings file.bin
         filo strings file.bin -n 8                     # Minimum 8 chars
@@ -1737,23 +1955,24 @@ def strings_cmd(file_path: str, min_len: int, min_entropy: float, encode_detect:
             data = f.read()
 
         all_strings = _extract_strings(data, min_len)
-        
+
         # Filter by type
         if string_type == "ascii":
             all_strings = [s for s in all_strings if s["type"] == "ascii"]
         elif string_type == "unicode":
             all_strings = [s for s in all_strings if s["type"] == "unicode"]
-        
+
         # Filter by regex
         if regex:
             import re as re_module
+
             try:
                 pattern = re_module.compile(regex.encode())
                 all_strings = [s for s in all_strings if pattern.search(s["data"])]
             except re_module.error as e:
                 console.print(f"[red]Invalid regex: {e}[/red]")
                 sys.exit(1)
-        
+
         # Filter by entropy
         if min_entropy is not None:
             filtered = []
@@ -1762,13 +1981,14 @@ def strings_cmd(file_path: str, min_len: int, min_entropy: float, encode_detect:
                 if e >= min_entropy:
                     filtered.append(s)
             all_strings = filtered
-        
+
         # Limit count
         if count > 0:
             all_strings = all_strings[:count]
-        
+
         if output_json:
             import json as json_module
+
             output = []
             for s in all_strings:
                 entry = {
@@ -1786,18 +2006,20 @@ def strings_cmd(file_path: str, min_len: int, min_entropy: float, encode_detect:
             if not all_strings:
                 console.print("[yellow]No strings found matching criteria[/yellow]")
                 return
-            
+
             console.print(f"\n[bold]Strings in:[/bold] {file_path}")
-            console.print(f"[dim]{len(all_strings)} string(s) found (min length: {min_len})[/dim]\n")
-            
+            console.print(
+                f"[dim]{len(all_strings)} string(s) found (min length: {min_len})[/dim]\n"
+            )
+
             for s in all_strings:
                 entropy = _string_entropy(s["data"])
                 text = s["data"].decode("utf-8", errors="replace")
                 text = text.replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t")
-                
+
                 # Truncate long strings for display
                 display = text[:200] + "..." if len(text) > 200 else text
-                
+
                 # Color by entropy
                 if entropy_colors:
                     if entropy > 6.5:
@@ -1810,21 +2032,21 @@ def strings_cmd(file_path: str, min_len: int, min_entropy: float, encode_detect:
                         color = "white"
                 else:
                     color = "white"
-                
+
                 parts = []
                 if offsets:
                     parts.append(f"[dim]0x{s['offset']:08x}[/dim]")
                 parts.append(f"[{color}]{display}[/{color}]")
-                
+
                 if encode_detect:
                     enc = _detect_encoding(s["data"])
                     if enc:
                         parts.append(f"[green]({enc})[/green]")
-                
+
                 console.print("  ".join(parts))
-            
+
             console.print("\n[dim]Use --json for machine-readable output[/dim]")
-    
+
     except Exception as e:
         console.print(f"[red]Error: {e}[/red]")
         sys.exit(1)

--- a/filo/cli.py
+++ b/filo/cli.py
@@ -9,9 +9,7 @@ import click
 from rich.console import Console
 from rich.table import Table
 from rich.panel import Panel
-from rich.syntax import Syntax
 from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn, TaskProgressColumn
-from rich import print as rprint
 
 from filo import __version__
 from filo.analyzer import Analyzer
@@ -20,7 +18,7 @@ from filo.repair import RepairEngine
 from filo.carver import CarverEngine
 from filo.batch import BatchProcessor, BatchConfig
 from filo.export import JSONExporter, SARIFExporter, export_to_file
-from filo.container import ContainerDetector
+
 from filo.profiler import Profiler
 from filo.lineage import LineageTracker, OperationType
 from filo.ml import MLDetector
@@ -293,7 +291,7 @@ def analyze(file_path: str, output_json: bool, deep: bool, no_ml: bool, all_evid
                 if not all_embedded and len(result.embedded_objects) > 3:
                     remaining = len(result.embedded_objects) - 3
                     console.print(f"\n  [dim]... and {remaining} more embedded artifact{'s' if remaining != 1 else ''}[/dim]")
-                    console.print(f"  [dim]Use -e or --all-embedded flag to show all[/dim]")
+                    console.print("  [dim]Use -e or --all-embedded flag to show all[/dim]")
             
             # Tool/creator fingerprints
             if result.fingerprints:
@@ -334,7 +332,7 @@ def analyze(file_path: str, output_json: bool, deep: bool, no_ml: bool, all_evid
             
             # CPU Architecture (for executable files)
             if result.architecture:
-                console.print(f"\n[bold cyan]🖥️  CPU Architecture:[/bold cyan]")
+                console.print("\n[bold cyan]🖥️  CPU Architecture:[/bold cyan]")
                 arch = result.architecture
                 console.print(f"  • [green]{arch.architecture}[/green] ({arch.bits}, {arch.endian})")
                 console.print(f"    [dim]Format: {arch.format} | Machine Code: 0x{arch.machine_code:04X}[/dim]")
@@ -358,13 +356,13 @@ def analyze(file_path: str, output_json: bool, deep: bool, no_ml: bool, all_evid
             if result.office_macros:
                 om = result.office_macros
                 if om.has_macros or om.suspicious_keywords:
-                    console.print(f"\n[bold yellow]📜 Office Macro Analysis:[/bold yellow]")
+                    console.print("\n[bold yellow]📜 Office Macro Analysis:[/bold yellow]")
                     if om.app_name:
                         console.print(f"  Application: [cyan]{om.app_name}[/cyan]")
                     if om.is_encrypted:
-                        console.print(f"  [red]🔒 Encrypted document[/red]")
+                        console.print("  [red]🔒 Encrypted document[/red]")
                     if om.is_protected:
-                        console.print(f"  [yellow]🔒 Write-protected[/yellow]")
+                        console.print("  [yellow]🔒 Write-protected[/yellow]")
                     if om.has_macros:
                         console.print(f"  Macros: [bold]{om.macro_count}[/bold] module(s)")
                     if om.auto_exec_macros:
@@ -396,17 +394,17 @@ def analyze(file_path: str, output_json: bool, deep: bool, no_ml: bool, all_evid
                         
                         cipher_hints = crypto.get('cipher_hints', [])
                         if cipher_hints:
-                            console.print(f"\n[bold]Possible Cipher Types:[/bold]")
+                            console.print("\n[bold]Possible Cipher Types:[/bold]")
                             for hint in cipher_hints:
                                 console.print(f"  • {hint}")
                         
                         block_info = crypto.get('block_alignment')
                         if block_info and all_evidence:
-                            console.print(f"\n[dim]Block Analysis:[/dim]")
+                            console.print("\n[dim]Block Analysis:[/dim]")
                             if block_info.get('aes_aligned'):
                                 console.print(f"  [dim]• AES blocks: {block_info.get('aes_block_count')}[/dim]")
                             if block_info.get('pkcs7_padding_possible'):
-                                console.print(f"  [dim]• PKCS#7 padding possible[/dim]")
+                                console.print("  [dim]• PKCS#7 padding possible[/dim]")
                     elif crypto.get('encryption_indicators'):
                         # Show indicators even if not highly confident
                         console.print(f"  [dim]Crypto indicators: {', '.join(crypto.get('encryption_indicators', []))}[/dim]")
@@ -446,7 +444,7 @@ def analyze(file_path: str, output_json: bool, deep: bool, no_ml: bool, all_evid
                 if not all_evidence and len(result.evidence_chain) > 3:
                     remaining = len(result.evidence_chain) - 3
                     console.print(f"\n  [dim]... and {remaining} more evidence item{'s' if remaining != 1 else ''}[/dim]")
-                    console.print(f"  [dim]Use --all-evidence flag to show all detection evidence[/dim]")
+                    console.print("  [dim]Use --all-evidence flag to show all detection evidence[/dim]")
         
     except Exception as e:
         console.print(f"[red]Error:[/red] {e}", style="bold")
@@ -761,7 +759,7 @@ def batch(directory: str, recursive: bool, workers: int, max_size: int, export: 
             progress.update(task, completed=result.total_files, total=result.total_files)
         
         # Show summary
-        console.print(f"\n[bold]Results Summary:[/bold]")
+        console.print("\n[bold]Results Summary:[/bold]")
         console.print(f"Total files: {result.total_files}")
         console.print(f"[green]Analyzed: {result.analyzed_files}[/green]")
         console.print(f"[red]Failed: {result.failed_files}[/red]")
@@ -827,7 +825,7 @@ def profile(file_path: str, profile: bool, show_stats: bool) -> None:
             data = f.read()
         
         with profiler.time_operation("analyze"):
-            result = analyzer.analyze(data)
+            analyzer.analyze(data)
         
         report = profiler.stop()
         
@@ -999,7 +997,7 @@ def lineage_history(operation: Optional[str], limit: int) -> None:
             )
         
         console.print(table)
-        console.print(f"\n[dim]Use 'filo lineage <hash>' to see full chain-of-custody[/dim]")
+        console.print("\n[dim]Use 'filo lineage <hash>' to see full chain-of-custody[/dim]")
         
     except Exception as e:
         console.print(f"[red]Error: {e}[/red]")
@@ -1028,7 +1026,7 @@ def lineage_stats() -> None:
                     table.add_row(f"  • {op.upper()}", f"{count} records")
             console.print(table)
             
-            console.print(f"\n[bold]Time Range:[/bold]")
+            console.print("\n[bold]Time Range:[/bold]")
             console.print(f"  Oldest: {stats['oldest_record']}")
             console.print(f"  Newest: {stats['newest_record']}\n")
         else:
@@ -1067,7 +1065,7 @@ def reset_lineage(yes: bool) -> None:
         tracker.close()
         db_path.unlink(missing_ok=True)
         
-        console.print(f"[green]✓ Lineage database reset[/green]")
+        console.print("[green]✓ Lineage database reset[/green]")
         console.print(f"[dim]Deleted {stats['total_records']} records from {db_path}[/dim]")
         
     except Exception as e:
@@ -1119,9 +1117,9 @@ def stego(file_path: str, show_all: bool, extract_method: Optional[str], output_
             
             bits_str = parts[0]
             bits = int(bits_str.lstrip('b').rstrip('b'))
-            channels = parts[1]
+            parts[1]
             bit_order = parts[2]
-            pixel_order = parts[3]
+            parts[3]
             
             # Extract data using Python implementation
             png_info = detector.parse_png(data)
@@ -1146,7 +1144,7 @@ def stego(file_path: str, show_all: bool, extract_method: Optional[str], output_
                 try:
                     text = extracted.decode('utf-8', errors='ignore')
                     console.print(text)
-                except:
+                except Exception:
                     # Show hex dump
                     console.print(f"[dim]Binary data ({len(extracted)} bytes):[/dim]")
                     _print_hex_dump(extracted[:256])
@@ -1210,7 +1208,7 @@ def stego(file_path: str, show_all: bool, extract_method: Optional[str], output_
             
             console.print(f"[{color}]{method_str}[/{color}] .. {result.description}")
         
-        console.print(f"\n[dim]Tip: Use --extract=METHOD to extract specific data[/dim]")
+        console.print("\n[dim]Tip: Use --extract=METHOD to extract specific data[/dim]")
         console.print(f"[dim]Example: filo stego {file_path} --extract=\"b1,rgba,lsb,xy\" -o output.txt[/dim]")
         
     except Exception as e:
@@ -1253,14 +1251,14 @@ def pcap(file_path: str) -> None:
             sys.exit(1)
         
         # Display statistics
-        console.print(f"\n[bold]📊 Statistics[/bold]")
+        console.print("\n[bold]📊 Statistics[/bold]")
         console.print(f"  Packets: {stats.packet_count:,}")
         console.print(f"  Total bytes: {stats.total_bytes:,}")
         console.print(f"  File size: {stats.file_size:,} bytes")
         
         # Protocol breakdown
         if stats.protocols:
-            console.print(f"\n[bold]🔌 Protocols[/bold]")
+            console.print("\n[bold]🔌 Protocols[/bold]")
             for protocol, count in stats.protocols.most_common(10):
                 console.print(f"  {protocol}: {count:,} packets")
         
@@ -1293,8 +1291,8 @@ def pcap(file_path: str) -> None:
                 console.print(f"  {display}")
         
         # Recommendations
-        console.print(f"\n[bold]💡 Next Steps[/bold]")
-        console.print(f"  • Open in Wireshark for detailed protocol analysis")
+        console.print("\n[bold]💡 Next Steps[/bold]")
+        console.print("  • Open in Wireshark for detailed protocol analysis")
         console.print(f"  • Use 'tshark -r {file_path}' for packet inspection")
         console.print(f"  • Export HTTP objects: tshark -r {file_path} --export-objects http,./output")
         
@@ -1331,7 +1329,6 @@ def extract(file_path: str, output: Optional[str], recursive: bool, max_depth: i
         filo extract nested.zip --max-depth 5
     """
     import zipfile
-    import shutil
     from pathlib import Path
     
     try:
@@ -1351,10 +1348,8 @@ def extract(file_path: str, output: Optional[str], recursive: bool, max_depth: i
         ))
         
         extracted_count = 0
-        current_depth = 0
         files_to_process = [(file_path, output_dir, 0)]
         processed_hashes = set()
-        extraction_tree = []
         
         while files_to_process:
             current_file, current_output, depth = files_to_process.pop(0)
@@ -1435,7 +1430,7 @@ def extract(file_path: str, output: Optional[str], recursive: bool, max_depth: i
                 except Exception as e:
                     console.print(f"{indent}    [red]✗[/red] Error: {e}")
         
-        console.print(f"\n[bold green]✓ Extraction complete![/bold green]")
+        console.print("\n[bold green]✓ Extraction complete![/bold green]")
         console.print(f"  Total files extracted: {extracted_count}")
         console.print(f"  Output directory: {output_dir}")
         
@@ -1455,16 +1450,16 @@ def extract(file_path: str, output: Optional[str], recursive: bool, max_depth: i
                         if full_match:
                             flag_text = full_match.group(0).decode('utf-8', errors='ignore')
                         flags_found.append((txt_file.relative_to(output_dir), flag_text))
-            except:
+            except Exception:
                 pass
         
         if flags_found:
-            console.print(f"\n[bold yellow]🚩 Flags found:[/bold yellow]")
+            console.print("\n[bold yellow]🚩 Flags found:[/bold yellow]")
             for filename, flag in flags_found:
                 console.print(f"  [green]{filename}:[/green] {flag}")
         
         if extracted_count == 0:
-            console.print(f"\n[yellow]No archives or polyglots found to extract[/yellow]")
+            console.print("\n[yellow]No archives or polyglots found to extract[/yellow]")
     
     except Exception as e:
         console.print(f"[red]Error: {e}[/red]")
@@ -1604,7 +1599,7 @@ def reset_ml(yes: bool) -> None:
         
         model_path.unlink()
         
-        console.print(f"[green]✓ ML model reset[/green]")
+        console.print("[green]✓ ML model reset[/green]")
         console.print(f"[dim]Deleted {pattern_count} patterns from {model_path}[/dim]")
         
     except Exception as e:
@@ -1828,7 +1823,7 @@ def strings_cmd(file_path: str, min_len: int, min_entropy: float, encode_detect:
                 
                 console.print("  ".join(parts))
             
-            console.print(f"\n[dim]Use --json for machine-readable output[/dim]")
+            console.print("\n[dim]Use --json for machine-readable output[/dim]")
     
     except Exception as e:
         console.print(f"[red]Error: {e}[/red]")

--- a/filo/cli.py
+++ b/filo/cli.py
@@ -3,7 +3,7 @@ import logging
 import sys
 import re
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 import click
 from rich.console import Console
@@ -662,7 +662,7 @@ def formats_list(category: Optional[str]) -> None:
     if category:
         specs = db.get_formats_by_category(category)
     else:
-        specs = [db.get_format(name) for name in db.list_formats()]
+        specs = [spec for name in db.list_formats() if (spec := db.get_format(name)) is not None]
 
     if not specs:
         console.print("[yellow]No formats found[/yellow]")
@@ -857,9 +857,9 @@ def batch(
 
         # Show format breakdown
         if result.results:
-            format_counts = {}
+            format_counts: dict[str, int] = {}
             for path, res in result.results:
-                fmt = res.format_name
+                fmt = res.primary_format
                 format_counts[fmt] = format_counts.get(fmt, 0) + 1
 
             table = Table(title="Format Distribution", show_header=True)
@@ -1175,7 +1175,7 @@ def reset_lineage(yes: bool) -> None:
                 console.print("[dim]Cancelled[/dim]")
                 return
 
-        tracker.close()
+        tracker.close()  # type: ignore[attr-defined]
         db_path.unlink(missing_ok=True)
 
         console.print("[green]✓ Lineage database reset[/green]")
@@ -1227,7 +1227,7 @@ def stego(
             from filo.stego import PNGStegoDetector, BMPStegoDetector, BitOrder
 
             if data.startswith(b"\x89PNG"):
-                detector = PNGStegoDetector()
+                detector: Any = PNGStegoDetector()
             elif data.startswith(b"BM"):
                 detector = BMPStegoDetector()
             else:
@@ -1477,25 +1477,25 @@ def extract(file_path: str, output: Optional[str], recursive: bool, max_depth: i
     from pathlib import Path
 
     try:
-        file_path = Path(file_path)
+        file_path_obj = Path(file_path)
 
         # Set output directory
         if output:
             output_dir = Path(output)
         else:
-            output_dir = Path.cwd() / f"{file_path.stem}_extracted"
+            output_dir = Path.cwd() / f"{file_path_obj.stem}_extracted"
 
         output_dir.mkdir(parents=True, exist_ok=True)
 
         console.print(
             Panel(
-                f"[bold cyan]Recursive Extraction:[/bold cyan] {file_path.name}",
+                f"[bold cyan]Recursive Extraction:[/bold cyan] {file_path_obj.name}",
                 border_style="cyan",
             )
         )
 
         extracted_count = 0
-        files_to_process = [(file_path, output_dir, 0)]
+        files_to_process = [(file_path_obj, output_dir, 0)]
         processed_hashes = set()
 
         while files_to_process:
@@ -1710,7 +1710,7 @@ def metadata(file_path: str, output_json: bool, suspicious_only: bool) -> None:
             console.print()
 
         # Group metadata by category
-        grouped = {}
+        grouped: dict[str, list[Any]] = {}
         for field in result.fields:
             if field.group not in grouped:
                 grouped[field.group] = []
@@ -1798,8 +1798,8 @@ def reset_ml(yes: bool) -> None:
         sys.exit(1)
 
 
-def _extract_strings(data: bytes, min_len: int = 4) -> list[dict]:
-    results = []
+def _extract_strings(data: bytes, min_len: int = 4) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
     # ASCII strings
     current = bytearray()
     offset = 0
@@ -1970,15 +1970,16 @@ def strings_cmd(
                 pattern = re_module.compile(regex.encode())
                 all_strings = [s for s in all_strings if pattern.search(s["data"])]
             except re_module.error as e:
-                console.print(f"[red]Invalid regex: {e}[/red]")
+                saved_e = e
+                console.print(f"[red]Invalid regex: {saved_e}[/red]")
                 sys.exit(1)
 
         # Filter by entropy
         if min_entropy is not None:
             filtered = []
             for s in all_strings:
-                e = _string_entropy(s["data"])
-                if e >= min_entropy:
+                entropy_val = _string_entropy(s["data"])
+                if entropy_val >= min_entropy:
                     filtered.append(s)
             all_strings = filtered
 

--- a/filo/container.py
+++ b/filo/container.py
@@ -7,8 +7,7 @@ import logging
 import tarfile
 import zipfile
 from dataclasses import dataclass
-from pathlib import Path
-from typing import List, Optional, BinaryIO
+from typing import List, Optional
 
 from filo.analyzer import Analyzer
 from filo.models import AnalysisResult
@@ -136,7 +135,7 @@ class ContainerDetector:
         
         try:
             with zipfile.ZipFile(io.BytesIO(data)) as zf:
-                total = len(zf.namelist())
+                len(zf.namelist())
                 
                 for name in zf.namelist():
                     info = zf.getinfo(name)

--- a/filo/container.py
+++ b/filo/container.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 @dataclass
 class ContainerEntry:
     """Entry within a container."""
+
     path: str
     size: int
     is_dir: bool
@@ -28,6 +29,7 @@ class ContainerEntry:
 @dataclass
 class ContainerAnalysis:
     """Analysis result for a container file."""
+
     container_format: str
     total_entries: int
     analyzed_entries: int
@@ -38,82 +40,82 @@ class ContainerAnalysis:
 class ContainerDetector:
     """
     Detect and analyze container formats.
-    
+
     Supported formats:
     - ZIP archives
     - TAR archives (tar, tar.gz, tar.bz2, tar.xz)
     - ISO 9660 images (basic support)
     """
-    
+
     def __init__(self, max_depth: int = 3) -> None:
         """
         Initialize container detector.
-        
+
         Args:
             max_depth: Maximum recursion depth for nested containers
         """
         self.max_depth = max_depth
         self.analyzer = Analyzer(use_ml=False)
         self._depth = 0
-    
+
     def is_container(self, data: bytes) -> Optional[str]:
         """
         Check if data is a container format.
-        
+
         Args:
             data: Binary data to check
-            
+
         Returns:
             Container format name or None
         """
         # ZIP
         if data.startswith(b"PK\x03\x04") or data.startswith(b"PK\x05\x06"):
             return "zip"
-        
+
         # TAR (POSIX ustar)
         if len(data) >= 512:
             # Check for ustar magic at offset 257
             if data[257:262] == b"ustar":
                 return "tar"
-        
+
         # ISO 9660
         if len(data) >= 32768 + 6:
             # Check for CD001 signature at offset 32769
             if data[32769:32774] == b"CD001":
                 return "iso"
-        
+
         # GZIP (often used with tar)
         if data.startswith(b"\x1f\x8b"):
             return "gzip"
-        
+
         # BZIP2
         if data.startswith(b"BZ"):
             return "bzip2"
-        
+
         # XZ
         if data.startswith(b"\xfd7zXZ\x00"):
             return "xz"
-        
+
         return None
-    
+
     def analyze_container(self, data: bytes, recursive: bool = True) -> Optional[ContainerAnalysis]:
         """
         Analyze container contents.
-        
+
         Args:
             data: Container file data
             recursive: Recursively analyze nested containers
-            
+
         Returns:
             ContainerAnalysis or None if not a container
         """
         container_type = self.is_container(data)
-        
+
         if not container_type:
             return None
-        
+
         logger.info(f"Detected {container_type} container")
-        
+
         if container_type == "zip":
             return self._analyze_zip(data, recursive)
         elif container_type == "tar":
@@ -124,33 +126,29 @@ class ContainerDetector:
         elif container_type == "iso":
             logger.warning("ISO 9660 support is basic - full analysis not implemented")
             return None
-        
+
         return None
-    
+
     def _analyze_zip(self, data: bytes, recursive: bool) -> ContainerAnalysis:
         """Analyze ZIP archive."""
         entries = []
         warnings = []
         analyzed = 0
-        
+
         try:
             with zipfile.ZipFile(io.BytesIO(data)) as zf:
                 len(zf.namelist())
-                
+
                 for name in zf.namelist():
                     info = zf.getinfo(name)
-                    
-                    entry = ContainerEntry(
-                        path=name,
-                        size=info.file_size,
-                        is_dir=info.is_dir()
-                    )
-                    
+
+                    entry = ContainerEntry(path=name, size=info.file_size, is_dir=info.is_dir())
+
                     # Analyze file contents
                     if not info.is_dir() and info.file_size > 0:
                         try:
                             member_data = zf.read(name)
-                            
+
                             # Check if nested container
                             if recursive and self._depth < self.max_depth:
                                 nested = self.is_container(member_data)
@@ -158,99 +156,103 @@ class ContainerDetector:
                                     self._depth += 1
                                     nested_analysis = self.analyze_container(member_data, recursive)
                                     self._depth -= 1
-                                    
+
                                     if nested_analysis:
                                         warnings.append(f"Nested {nested} container: {name}")
-                            
+
                             # Analyze content
                             result = self.analyzer.analyze(member_data)
                             entry.result = result
                             analyzed += 1
-                            
+
                         except Exception as e:
                             entry.error = str(e)
                             logger.error(f"Error analyzing {name}: {e}")
-                    
+
                     entries.append(entry)
-                
+
         except zipfile.BadZipFile as e:
             warnings.append(f"Corrupted ZIP: {e}")
-        
+
         return ContainerAnalysis(
             container_format="zip",
             total_entries=len(entries),
             analyzed_entries=analyzed,
             entries=entries,
-            warnings=warnings
+            warnings=warnings,
         )
-    
+
     def _analyze_tar(self, data: bytes, recursive: bool) -> ContainerAnalysis:
         """Analyze TAR archive."""
         entries = []
         warnings = []
         analyzed = 0
-        
+
         try:
             with tarfile.open(fileobj=io.BytesIO(data)) as tf:
                 members = tf.getmembers()
-                
+
                 for member in members:
                     entry = ContainerEntry(
-                        path=member.name,
-                        size=member.size,
-                        is_dir=member.isdir()
+                        path=member.name, size=member.size, is_dir=member.isdir()
                     )
-                    
+
                     # Analyze file contents
                     if member.isfile() and member.size > 0:
                         try:
                             f = tf.extractfile(member)
                             if f:
                                 member_data = f.read()
-                                
+
                                 # Check if nested container
                                 if recursive and self._depth < self.max_depth:
                                     nested = self.is_container(member_data)
                                     if nested:
                                         self._depth += 1
-                                        nested_analysis = self.analyze_container(member_data, recursive)
+                                        nested_analysis = self.analyze_container(
+                                            member_data, recursive
+                                        )
                                         self._depth -= 1
-                                        
+
                                         if nested_analysis:
-                                            warnings.append(f"Nested {nested} container: {member.name}")
-                                
+                                            warnings.append(
+                                                f"Nested {nested} container: {member.name}"
+                                            )
+
                                 # Analyze content
                                 result = self.analyzer.analyze(member_data)
                                 entry.result = result
                                 analyzed += 1
-                                
+
                         except Exception as e:
                             entry.error = str(e)
                             logger.error(f"Error analyzing {member.name}: {e}")
-                    
+
                     entries.append(entry)
-                
+
         except tarfile.TarError as e:
             warnings.append(f"Corrupted TAR: {e}")
-        
+
         return ContainerAnalysis(
             container_format="tar",
             total_entries=len(entries),
             analyzed_entries=analyzed,
             entries=entries,
-            warnings=warnings
+            warnings=warnings,
         )
 
 
-def analyze_archive(data: bytes, recursive: bool = True, max_depth: int = 3) -> Optional[ContainerAnalysis]:
+def analyze_archive(
+    data: bytes, recursive: bool = True, max_depth: int = 3
+) -> Optional[ContainerAnalysis]:
     """
     Convenience function to analyze container/archive files.
-    
+
     Args:
         data: Archive file data
         recursive: Recursively analyze nested containers
         max_depth: Maximum recursion depth
-        
+
     Returns:
         ContainerAnalysis or None
     """

--- a/filo/contradictions.py
+++ b/filo/contradictions.py
@@ -111,7 +111,9 @@ class ContradictionDetector:
         return None
 
     @staticmethod
-    def check_embedded_formats(data: bytes, primary_format: str, **context: Any) -> list[Contradiction]:
+    def check_embedded_formats(
+        data: bytes, primary_format: str, **context: Any
+    ) -> list[Contradiction]:
         """Detect suspicious embedded format signatures."""
         contradictions = []
 

--- a/filo/contradictions.py
+++ b/filo/contradictions.py
@@ -196,7 +196,7 @@ class ContradictionDetector:
                     try:
                         zf.testzip()
                         break
-                    except Exception as e:
+                    except Exception:
                         corrupt_files.append(name)
                 
                 if corrupt_files:
@@ -408,7 +408,7 @@ class ContradictionDetector:
             import struct
             
             # Read BMP header fields
-            file_size = struct.unpack("<I", data[2:6])[0]
+            struct.unpack("<I", data[2:6])[0]
             pixel_offset = struct.unpack("<I", data[10:14])[0]
             dib_header_size = struct.unpack("<I", data[14:18])[0]
             width = struct.unpack("<I", data[18:22])[0]
@@ -440,7 +440,7 @@ class ContradictionDetector:
             
             # Calculate expected height from file size
             if bits_per_pixel > 0 and width > 0:
-                bytes_per_pixel = bits_per_pixel // 8
+                bits_per_pixel // 8
                 row_size = ((width * bits_per_pixel + 31) // 32) * 4  # Row size aligned to 4 bytes
                 
                 # Use the actual pixel offset if it seems valid

--- a/filo/contradictions.py
+++ b/filo/contradictions.py
@@ -9,7 +9,7 @@ This module detects when files exhibit contradictory traits that may indicate:
 """
 
 import logging
-from typing import Optional
+from typing import Any, Optional
 from filo.models import Contradiction
 
 logger = logging.getLogger(__name__)
@@ -111,7 +111,7 @@ class ContradictionDetector:
         return None
 
     @staticmethod
-    def check_embedded_formats(data: bytes, primary_format: str, **context) -> list[Contradiction]:
+    def check_embedded_formats(data: bytes, primary_format: str, **context: Any) -> list[Contradiction]:
         """Detect suspicious embedded format signatures."""
         contradictions = []
 
@@ -514,7 +514,7 @@ class ContradictionDetector:
         return None
 
     @staticmethod
-    def detect_all(data: bytes, primary_format: str, **context) -> list[Contradiction]:
+    def detect_all(data: bytes, primary_format: str, **context: Any) -> list[Contradiction]:
         """Run all contradiction checks and return findings."""
         contradictions = []
 

--- a/filo/contradictions.py
+++ b/filo/contradictions.py
@@ -17,41 +17,42 @@ logger = logging.getLogger(__name__)
 
 class ContradictionDetector:
     """Detects structural contradictions and format anomalies."""
-    
+
     @staticmethod
     def check_png_compression(data: bytes) -> Optional[Contradiction]:
         """Check if PNG has valid zlib compression in IDAT chunks."""
         if len(data) < 33:  # Minimum PNG size
             return None
-        
+
         # Collect all IDAT chunks (they should be consecutive)
         pos = 8  # After PNG signature
         idat_data_chunks = []
-        
+
         try:
             while pos < len(data) - 12:
                 if pos + 8 > len(data):
                     break
-                    
+
                 # Read chunk length and type
-                chunk_length = int.from_bytes(data[pos:pos+4], 'big')
-                chunk_type = data[pos+4:pos+8]
-                
-                if chunk_type == b'IDAT':
+                chunk_length = int.from_bytes(data[pos : pos + 4], "big")
+                chunk_type = data[pos + 4 : pos + 8]
+
+                if chunk_type == b"IDAT":
                     # Collect IDAT data (multiple IDAT chunks form one zlib stream)
-                    idat_data_chunks.append(data[pos+8:pos+8+chunk_length])
-                elif chunk_type == b'IEND' or (idat_data_chunks and chunk_type != b'IDAT'):
+                    idat_data_chunks.append(data[pos + 8 : pos + 8 + chunk_length])
+                elif chunk_type == b"IEND" or (idat_data_chunks and chunk_type != b"IDAT"):
                     # Reached end of IDAT sequence
                     break
-                
+
                 # Move to next chunk
                 pos += 12 + chunk_length
-            
+
             # If we found IDAT chunks, try to decompress the concatenated stream
             if idat_data_chunks:
                 import zlib
-                combined_idat = b''.join(idat_data_chunks)
-                
+
+                combined_idat = b"".join(idat_data_chunks)
+
                 try:
                     # Try to decompress - will raise error if invalid
                     zlib.decompress(combined_idat)
@@ -59,44 +60,44 @@ class ContradictionDetector:
                     # Only report as error if it's a serious corruption
                     # Some valid PNGs may have truncation warnings that viewers ignore
                     error_msg = str(e).lower()
-                    if 'unknown compression method' in error_msg or 'invalid' in error_msg:
+                    if "unknown compression method" in error_msg or "invalid" in error_msg:
                         return Contradiction(
                             severity="error",
                             claimed_format="png",
                             issue="Invalid compression stream",
                             details=f"IDAT chunk contains invalid zlib data: {str(e)}",
-                            category="compression"
+                            category="compression",
                         )
                     # Ignore truncation warnings if image otherwise works
-                
+
         except Exception as e:
             logger.debug(f"PNG compression check failed: {e}")
-        
+
         return None
-    
+
     @staticmethod
     def check_zip_ooxml_structure(data: bytes, namelist: list[str]) -> Optional[Contradiction]:
         """Check if ZIP claiming to be OOXML has required structure."""
-        has_content_types = any('[content_types].xml' in name.lower() for name in namelist)
-        
+        has_content_types = any("[content_types].xml" in name.lower() for name in namelist)
+
         if has_content_types:
             # This claims to be OOXML format
-            has_rels = any('_rels/.rels' in name.lower() for name in namelist)
-            
+            has_rels = any("_rels/.rels" in name.lower() for name in namelist)
+
             if not has_rels:
                 return Contradiction(
                     severity="warning",
                     claimed_format="ooxml",
                     issue="Missing mandatory _rels/.rels",
                     details="OOXML format requires _rels/.rels but it's absent",
-                    category="missing"
+                    category="missing",
                 )
-            
+
             # Check for specific format markers
-            has_word = any('word/document.xml' in name.lower() for name in namelist)
-            has_ppt = any('ppt/presentation.xml' in name.lower() for name in namelist)
-            has_xl = any('xl/workbook.xml' in name.lower() for name in namelist)
-            
+            has_word = any("word/document.xml" in name.lower() for name in namelist)
+            has_ppt = any("ppt/presentation.xml" in name.lower() for name in namelist)
+            has_xl = any("xl/workbook.xml" in name.lower() for name in namelist)
+
             # If it has Content_Types but no actual document
             if not (has_word or has_ppt or has_xl):
                 return Contradiction(
@@ -104,92 +105,107 @@ class ContradictionDetector:
                     claimed_format="ooxml",
                     issue="Missing core document file",
                     details="Has [Content_Types].xml but no document.xml, presentation.xml, or workbook.xml",
-                    category="structure"
+                    category="structure",
                 )
-        
+
         return None
-    
+
     @staticmethod
     def check_embedded_formats(data: bytes, primary_format: str, **context) -> list[Contradiction]:
         """Detect suspicious embedded format signatures."""
         contradictions = []
-        
+
         # For ZIP-based formats, also check inside compressed members
-        if primary_format in ['zip', 'docx', 'xlsx', 'pptx', 'jar', 'apk', 'odt', 'odp', 'ods', 'epub']:
+        if primary_format in [
+            "zip",
+            "docx",
+            "xlsx",
+            "pptx",
+            "jar",
+            "apk",
+            "odt",
+            "odp",
+            "ods",
+            "epub",
+        ]:
             try:
                 import zipfile
                 import io
-                
-                with zipfile.ZipFile(io.BytesIO(data), 'r') as zf:
+
+                with zipfile.ZipFile(io.BytesIO(data), "r") as zf:
                     for name in zf.namelist()[:20]:  # Check first 20 files
                         try:
                             member_data = zf.read(name)
                             # Check first 10KB of each member
-                            check_data = member_data[:min(len(member_data), 10240)]
-                            
+                            check_data = member_data[: min(len(member_data), 10240)]
+
                             # Suspicious patterns
                             suspicious_patterns = {
-                                b'\x7fELF': ('ELF executable', 'embedded'),
-                                b'MZ': ('PE/DOS executable', 'embedded'),
-                                b'\xca\xfe\xba\xbe': ('Mach-O executable', 'embedded'),
-                                b'#!/bin/sh': ('Shell script', 'embedded'),
-                                b'#!/bin/bash': ('Bash script', 'embedded'),
-                                b'<?php': ('PHP script', 'embedded'),
+                                b"\x7fELF": ("ELF executable", "embedded"),
+                                b"MZ": ("PE/DOS executable", "embedded"),
+                                b"\xca\xfe\xba\xbe": ("Mach-O executable", "embedded"),
+                                b"#!/bin/sh": ("Shell script", "embedded"),
+                                b"#!/bin/bash": ("Bash script", "embedded"),
+                                b"<?php": ("PHP script", "embedded"),
                             }
-                            
+
                             for pattern, (format_name, category) in suspicious_patterns.items():
                                 offset = check_data.find(pattern)
                                 if offset != -1 and offset < 8192:  # Within first 8KB
-                                    contradictions.append(Contradiction(
-                                        severity="critical",
-                                        claimed_format=primary_format,
-                                        issue=f"Embedded {format_name} signature",
-                                        details=f"Found {format_name} in ZIP member '{name}' at offset {offset}",
-                                        category=category
-                                    ))
+                                    contradictions.append(
+                                        Contradiction(
+                                            severity="critical",
+                                            claimed_format=primary_format,
+                                            issue=f"Embedded {format_name} signature",
+                                            details=f"Found {format_name} in ZIP member '{name}' at offset {offset}",
+                                            category=category,
+                                        )
+                                    )
                                     break  # One per member
                         except Exception:
                             pass
             except Exception as e:
                 logger.debug(f"ZIP member check failed: {e}")
-        
+
         # Also check main file data (for non-ZIP or polyglots)
         # Skip first 512 bytes (legitimate headers)
-        search_data = data[512:min(len(data), 10240)]  # Search next 10KB
-        
+        search_data = data[512 : min(len(data), 10240)]  # Search next 10KB
+
         # Suspicious magic bytes to look for
         suspicious_patterns = {
-            b'\x7fELF': ('ELF executable', 'embedded'),
-            b'MZ': ('PE/DOS executable', 'embedded'),
-            b'\x4d\x5a\x90': ('PE executable', 'embedded'),
-            b'\xca\xfe\xba\xbe': ('Mach-O executable', 'embedded'),
-            b'#!/bin/sh': ('Shell script', 'embedded'),
-            b'#!/bin/bash': ('Bash script', 'embedded'),
-            b'<?php': ('PHP script', 'embedded'),
+            b"\x7fELF": ("ELF executable", "embedded"),
+            b"MZ": ("PE/DOS executable", "embedded"),
+            b"\x4d\x5a\x90": ("PE executable", "embedded"),
+            b"\xca\xfe\xba\xbe": ("Mach-O executable", "embedded"),
+            b"#!/bin/sh": ("Shell script", "embedded"),
+            b"#!/bin/bash": ("Bash script", "embedded"),
+            b"<?php": ("PHP script", "embedded"),
         }
-        
+
         for pattern, (format_name, category) in suspicious_patterns.items():
             offset = search_data.find(pattern)
             if offset != -1:
-                contradictions.append(Contradiction(
-                    severity="critical",
-                    claimed_format=primary_format,
-                    issue=f"Embedded {format_name} signature",
-                    details=f"Found {format_name} magic bytes at offset {512 + offset}",
-                    category=category
-                ))
-        
+                contradictions.append(
+                    Contradiction(
+                        severity="critical",
+                        claimed_format=primary_format,
+                        issue=f"Embedded {format_name} signature",
+                        details=f"Found {format_name} magic bytes at offset {512 + offset}",
+                        category=category,
+                    )
+                )
+
         return contradictions
-    
+
     @staticmethod
     def check_zip_structure_integrity(data: bytes) -> Optional[Contradiction]:
         """Check ZIP structural integrity."""
         try:
             import zipfile
             import io
-            
+
             zip_buffer = io.BytesIO(data)
-            with zipfile.ZipFile(zip_buffer, 'r') as zf:
+            with zipfile.ZipFile(zip_buffer, "r") as zf:
                 # Test ZIP integrity
                 corrupt_files = []
                 for name in zf.namelist()[:10]:  # Check first 10 files
@@ -198,32 +214,32 @@ class ContradictionDetector:
                         break
                     except Exception:
                         corrupt_files.append(name)
-                
+
                 if corrupt_files:
                     return Contradiction(
                         severity="error",
                         claimed_format="zip",
                         issue="Corrupted ZIP entries",
                         details=f"ZIP structure corruption detected in: {', '.join(corrupt_files[:3])}",
-                        category="structure"
+                        category="structure",
                     )
         except Exception as e:
             logger.debug(f"ZIP integrity check failed: {e}")
-        
+
         return None
-    
+
     @staticmethod
     def check_png_header(data: bytes) -> Optional[Contradiction]:
         """Check PNG signature and chunk structure."""
         if len(data) < 33:  # Minimum: 8-byte signature + 25-byte IHDR chunk
             return None
-        
+
         # PNG signature: 89 50 4E 47 0D 0A 1A 0A
-        correct_sig = b'\x89PNG\r\n\x1a\n'
+        correct_sig = b"\x89PNG\r\n\x1a\n"
         actual_sig = data[0:8]
-        
+
         issues = []
-        
+
         # Check signature corruption
         if actual_sig != correct_sig:
             # Check if it's close to PNG signature (partial corruption)
@@ -231,30 +247,32 @@ class ContradictionDetector:
             for i, (actual, expected) in enumerate(zip(actual_sig, correct_sig)):
                 if actual != expected:
                     corrupted_bytes.append(f"byte {i}: 0x{actual:02X} should be 0x{expected:02X}")
-            
+
             if corrupted_bytes:
                 issues.append(f"Corrupted PNG signature: {'; '.join(corrupted_bytes)}")
-        
+
         # Check IHDR chunk (should be first chunk after signature)
         if len(data) >= 16:
-            ihdr_length = int.from_bytes(data[8:12], 'big')
+            ihdr_length = int.from_bytes(data[8:12], "big")
             ihdr_type = data[12:16]
-            
+
             # IHDR chunk type should be "IHDR"
-            if ihdr_type != b'IHDR':
+            if ihdr_type != b"IHDR":
                 # Check if it's corrupted
                 corrupted = []
-                for i, (actual, expected) in enumerate(zip(ihdr_type, b'IHDR')):
+                for i, (actual, expected) in enumerate(zip(ihdr_type, b"IHDR")):
                     if actual != expected:
-                        corrupted.append(f"byte {i}: '{chr(actual) if 32 <= actual < 127 else '?'}' (0x{actual:02X}) should be '{chr(expected)}' (0x{expected:02X})")
-                
+                        corrupted.append(
+                            f"byte {i}: '{chr(actual) if 32 <= actual < 127 else '?'}' (0x{actual:02X}) should be '{chr(expected)}' (0x{expected:02X})"
+                        )
+
                 if corrupted:
                     issues.append(f"Corrupted IHDR chunk name: {'; '.join(corrupted)}")
-            
+
             # IHDR length should be 13
             if ihdr_length != 13:
                 issues.append(f"Invalid IHDR chunk length: {ihdr_length} (should be 13)")
-        
+
         # Look for corrupted IDAT chunks (common in CTF challenges)
         # Start after IHDR chunk (8 bytes sig + 4 length + 4 type + 13 data + 4 CRC = 33)
         pos = 33
@@ -263,93 +281,115 @@ class ContradictionDetector:
             try:
                 if pos + 8 > len(data):
                     break
-                
-                chunk_length = int.from_bytes(data[pos:pos+4], 'big')
-                chunk_type = data[pos+4:pos+8]
-                
+
+                chunk_length = int.from_bytes(data[pos : pos + 4], "big")
+                chunk_type = data[pos + 4 : pos + 8]
+
                 # Check if chunk type looks corrupted
                 # Valid chunk types are all letters (A-Z, a-z)
                 if all(65 <= b <= 90 or 97 <= b <= 122 for b in chunk_type):
                     # Skip known valid chunks (sRGB, gAMA, pHYs, tEXt, etc.)
-                    known_chunks = {b'IDAT', b'IHDR', b'IEND', b'PLTE', b'sRGB', b'gAMA', 
-                                   b'pHYs', b'tEXt', b'iTXt', b'zTXt', b'bKGD', b'tRNS',
-                                   b'cHRM', b'sBIT', b'sPLT', b'hIST', b'tIME'}
-                    
+                    known_chunks = {
+                        b"IDAT",
+                        b"IHDR",
+                        b"IEND",
+                        b"PLTE",
+                        b"sRGB",
+                        b"gAMA",
+                        b"pHYs",
+                        b"tEXt",
+                        b"iTXt",
+                        b"zTXt",
+                        b"bKGD",
+                        b"tRNS",
+                        b"cHRM",
+                        b"sBIT",
+                        b"sPLT",
+                        b"hIST",
+                        b"tIME",
+                    }
+
                     # Check for near-IDAT patterns (but not other valid chunks)
                     # Pattern: 0xABDET or similar (ab 44 45 54)
                     if chunk_type not in known_chunks and (
-                        (chunk_type[0] == 0xAB and chunk_type[1:4] == b'DET') or  # Specific CTF pattern
-                        (chunk_type != b'IDAT' and 
-                         abs(chunk_type[0] - ord('I')) <= 3 and
-                         abs(chunk_type[1] - ord('D')) <= 3 and
-                         abs(chunk_type[2] - ord('A')) <= 3 and
-                         abs(chunk_type[3] - ord('T')) <= 3 and
-                         chunk_type not in known_chunks)
+                        (
+                            chunk_type[0] == 0xAB and chunk_type[1:4] == b"DET"
+                        )  # Specific CTF pattern
+                        or (
+                            chunk_type != b"IDAT"
+                            and abs(chunk_type[0] - ord("I")) <= 3
+                            and abs(chunk_type[1] - ord("D")) <= 3
+                            and abs(chunk_type[2] - ord("A")) <= 3
+                            and abs(chunk_type[3] - ord("T")) <= 3
+                            and chunk_type not in known_chunks
+                        )
                     ):
                         corrupted = []
-                        for i, (actual, expected) in enumerate(zip(chunk_type, b'IDAT')):
+                        for i, (actual, expected) in enumerate(zip(chunk_type, b"IDAT")):
                             if actual != expected:
-                                corrupted.append(f"'{chr(actual) if 32 <= actual < 127 else '?'}' (0x{actual:02X}) should be '{chr(expected)}' (0x{expected:02X})")
-                        
+                                corrupted.append(
+                                    f"'{chr(actual) if 32 <= actual < 127 else '?'}' (0x{actual:02X}) should be '{chr(expected)}' (0x{expected:02X})"
+                                )
+
                         idat_corruptions.append(f"Chunk at 0x{pos:X}: {'; '.join(corrupted)}")
                         break  # Report first corruption only
-                
+
                 # Move to next chunk
                 pos += 8 + chunk_length + 4  # length + type + data + CRC
-                
+
             except Exception:
                 break
-        
+
         if idat_corruptions:
             issues.append(f"Corrupted IDAT chunk: {idat_corruptions[0]}")
-        
+
         if issues:
             return Contradiction(
                 severity="critical",
                 claimed_format="png",
                 issue="Corrupted PNG header or chunks",
                 details="; ".join(issues),
-                category="header_corruption"
+                category="header_corruption",
             )
-        
+
         return None
-    
+
     @staticmethod
     def check_jpeg_structure(data: bytes) -> Optional[Contradiction]:
         """Check JPEG marker sequence validity."""
         if len(data) < 10:
             return None
-        
+
         # JPEG should start with SOI (0xFFD8)
-        if data[0:2] != b'\xff\xd8':
+        if data[0:2] != b"\xff\xd8":
             return None
-        
+
         # Check for common structural issues
         pos = 2
         has_sof = False
         has_sos = False
-        
+
         try:
             while pos < len(data) - 2:
                 if data[pos] != 0xFF:
                     # Not a marker
                     break
-                
-                marker = data[pos+1]
-                
+
+                marker = data[pos + 1]
+
                 # Start of Frame markers
                 if marker in [0xC0, 0xC1, 0xC2, 0xC3, 0xC5, 0xC6, 0xC7]:
                     has_sof = True
-                
+
                 # Start of Scan
                 if marker == 0xDA:
                     has_sos = True
                     break
-                
+
                 # End of Image
                 if marker == 0xD9:
                     break
-                
+
                 # Skip marker
                 if marker in [0xD0, 0xD1, 0xD2, 0xD3, 0xD4, 0xD5, 0xD6, 0xD7, 0xD8]:
                     # Standalone markers (no length)
@@ -358,9 +398,9 @@ class ContradictionDetector:
                     # Read length
                     if pos + 3 >= len(data):
                         break
-                    length = (data[pos+2] << 8) | data[pos+3]
+                    length = (data[pos + 2] << 8) | data[pos + 3]
                     pos += 2 + length
-            
+
             # JPEG should have SOF and SOS markers
             if has_sof and not has_sos:
                 return Contradiction(
@@ -368,45 +408,45 @@ class ContradictionDetector:
                     claimed_format="jpeg",
                     issue="Missing Start of Scan (SOS) marker",
                     details="JPEG has SOF but no SOS marker - likely truncated",
-                    category="structure"
+                    category="structure",
                 )
-            
+
         except Exception as e:
             logger.debug(f"JPEG structure check failed: {e}")
-        
+
         return None
-    
+
     @staticmethod
     def check_pdf_structure(data: bytes) -> Optional[Contradiction]:
         """Check PDF structural validity."""
         if len(data) < 8:
             return None
-        
+
         # PDF should start with %PDF-
-        if not data.startswith(b'%PDF-'):
+        if not data.startswith(b"%PDF-"):
             return None
-        
+
         # Check for EOF marker
-        if b'%%EOF' not in data[-1024:]:
+        if b"%%EOF" not in data[-1024:]:
             return Contradiction(
                 severity="warning",
                 claimed_format="pdf",
                 issue="Missing EOF marker",
                 details="PDF lacks %%EOF marker in last 1KB - may be truncated or corrupted",
-                category="structure"
+                category="structure",
             )
-        
+
         return None
-    
+
     @staticmethod
     def check_bmp_header(data: bytes) -> Optional[Contradiction]:
         """Check BMP header for corruption or tampering."""
-        if len(data) < 54 or not data.startswith(b'BM'):
+        if len(data) < 54 or not data.startswith(b"BM"):
             return None
-        
+
         try:
             import struct
-            
+
             # Read BMP header fields
             struct.unpack("<I", data[2:6])[0]
             pixel_offset = struct.unpack("<I", data[10:14])[0]
@@ -414,44 +454,50 @@ class ContradictionDetector:
             width = struct.unpack("<I", data[18:22])[0]
             height = struct.unpack("<I", data[22:26])[0]
             bits_per_pixel = struct.unpack("<H", data[28:30])[0]
-            
+
             issues = []
-            
+
             # Check for known "bad" patterns
             if dib_header_size == 0xBAD0 or dib_header_size == 0xD0BA:
-                issues.append(f"DIB header size is 0x{dib_header_size:X} (suspicious 'BAD0' pattern)")
-            
+                issues.append(
+                    f"DIB header size is 0x{dib_header_size:X} (suspicious 'BAD0' pattern)"
+                )
+
             if pixel_offset == 0xBAD0 or pixel_offset == 0xD0BA:
                 issues.append(f"Pixel offset is 0x{pixel_offset:X} (suspicious 'BAD0' pattern)")
-            
+
             # Check DIB header size validity
             valid_dib_sizes = [12, 40, 52, 56, 108, 124]  # Common DIB header sizes
             if dib_header_size not in valid_dib_sizes:
                 if dib_header_size not in [0xBAD0, 0xD0BA]:  # Don't double-report
-                    issues.append(f"Invalid DIB header size: {dib_header_size} (expected 40 for standard BMP)")
-            
+                    issues.append(
+                        f"Invalid DIB header size: {dib_header_size} (expected 40 for standard BMP)"
+                    )
+
             # Check pixel offset sanity
             expected_offset = 14 + dib_header_size  # BMP file header + DIB header
             if dib_header_size == 40:  # Standard BITMAPINFOHEADER
                 expected_offset = 54
-            
+
             if pixel_offset != expected_offset and pixel_offset not in [0xBAD0, 0xD0BA]:
                 issues.append(f"Unusual pixel offset: {pixel_offset} (expected {expected_offset})")
-            
+
             # Calculate expected height from file size
             if bits_per_pixel > 0 and width > 0:
                 bits_per_pixel // 8
                 row_size = ((width * bits_per_pixel + 31) // 32) * 4  # Row size aligned to 4 bytes
-                
+
                 # Use the actual pixel offset if it seems valid
                 actual_offset = 54 if pixel_offset > len(data) else pixel_offset
                 pixel_data_size = len(data) - actual_offset
                 calculated_height = pixel_data_size // row_size if row_size > 0 else 0
-                
+
                 # Allow some tolerance for rounding
                 if calculated_height > 0 and abs(calculated_height - height) > 2:
-                    issues.append(f"Height mismatch: header says {height}px but file size suggests {calculated_height}px ({calculated_height - height} rows hidden)")
-            
+                    issues.append(
+                        f"Height mismatch: header says {height}px but file size suggests {calculated_height}px ({calculated_height - height} rows hidden)"
+                    )
+
             if issues:
                 severity = "critical" if any("BAD0" in issue for issue in issues) else "error"
                 return Contradiction(
@@ -459,61 +505,61 @@ class ContradictionDetector:
                     claimed_format="bmp",
                     issue="Corrupted or tampered BMP header",
                     details="; ".join(issues),
-                    category="header_corruption"
+                    category="header_corruption",
                 )
-        
+
         except Exception as e:
             logger.debug(f"BMP header check failed: {e}")
-        
+
         return None
-    
+
     @staticmethod
     def detect_all(data: bytes, primary_format: str, **context) -> list[Contradiction]:
         """Run all contradiction checks and return findings."""
         contradictions = []
-        
+
         # Format-specific checks
-        if primary_format == 'png':
+        if primary_format == "png":
             contradiction = ContradictionDetector.check_png_header(data)
             if contradiction:
                 contradictions.append(contradiction)
-            
+
             contradiction = ContradictionDetector.check_png_compression(data)
             if contradiction:
                 contradictions.append(contradiction)
-        
-        elif primary_format == 'bmp':
+
+        elif primary_format == "bmp":
             contradiction = ContradictionDetector.check_bmp_header(data)
             if contradiction:
                 contradictions.append(contradiction)
-        
-        elif primary_format == 'jpeg':
+
+        elif primary_format == "jpeg":
             contradiction = ContradictionDetector.check_jpeg_structure(data)
             if contradiction:
                 contradictions.append(contradiction)
-        
-        elif primary_format == 'pdf':
+
+        elif primary_format == "pdf":
             contradiction = ContradictionDetector.check_pdf_structure(data)
             if contradiction:
                 contradictions.append(contradiction)
-        
-        elif primary_format in ['docx', 'xlsx', 'pptx']:
+
+        elif primary_format in ["docx", "xlsx", "pptx"]:
             # Check OOXML structure if we have namelist
-            namelist = context.get('namelist', [])
+            namelist = context.get("namelist", [])
             if namelist:
                 contradiction = ContradictionDetector.check_zip_ooxml_structure(data, namelist)
                 if contradiction:
                     contradictions.append(contradiction)
-        
-        elif primary_format == 'zip':
+
+        elif primary_format == "zip":
             contradiction = ContradictionDetector.check_zip_structure_integrity(data)
             if contradiction:
                 contradictions.append(contradiction)
-        
+
         # Universal checks
         # Check for embedded executables (malware triage)
-        if primary_format in ['zip', 'docx', 'xlsx', 'pptx', 'pdf', 'png', 'jpeg']:
+        if primary_format in ["zip", "docx", "xlsx", "pptx", "pdf", "png", "jpeg"]:
             embedded = ContradictionDetector.check_embedded_formats(data, primary_format)
             contradictions.extend(embedded)
-        
+
         return contradictions

--- a/filo/crypto.py
+++ b/filo/crypto.py
@@ -13,25 +13,30 @@ logger = logging.getLogger(__name__)
 
 class CryptoAnalysis(BaseModel):
     """Results of cryptographic analysis"""
+
     is_likely_encrypted: bool = Field(description="File likely contains encrypted data")
-    encryption_indicators: List[str] = Field(default_factory=list, description="Evidence of encryption")
+    encryption_indicators: List[str] = Field(
+        default_factory=list, description="Evidence of encryption"
+    )
     cipher_hints: List[str] = Field(default_factory=list, description="Possible cipher types")
-    block_alignment: Optional[Dict[str, Any]] = Field(default=None, description="Block cipher alignment info")
+    block_alignment: Optional[Dict[str, Any]] = Field(
+        default=None, description="Block cipher alignment info"
+    )
     entropy_interpretation: str = Field(description="Human-readable entropy interpretation")
     confidence: float = Field(ge=0.0, le=1.0, description="Confidence in crypto detection")
 
 
 class CryptoDetector:
     """Detects encrypted/encoded data patterns"""
-    
+
     @staticmethod
     def interpret_entropy(entropy: float) -> str:
         """
         Interpret entropy value for human understanding.
-        
+
         Args:
             entropy: Shannon entropy in bits/byte (0.0 - 8.0)
-            
+
         Returns:
             Human-readable interpretation
         """
@@ -45,20 +50,20 @@ class CryptoDetector:
             return "High - strong compression or encryption likely"
         else:
             return "Very high - strong encryption or cryptographically random data"
-    
+
     @staticmethod
     def analyze_block_alignment(data: bytes) -> Dict[str, Any]:
         """
         Analyze if file size suggests block cipher usage.
-        
+
         Args:
             data: File data to analyze
-            
+
         Returns:
             Dictionary with block alignment information
         """
         size = len(data)
-        
+
         result = {
             "file_size": size,
             "aes_aligned": size % 16 == 0,
@@ -67,88 +72,90 @@ class CryptoDetector:
             "des_block_count": size // 8 if size % 8 == 0 else None,
             "blowfish_aligned": size % 8 == 0,  # Same as DES
         }
-        
+
         # Check for padding (extra block at end)
         if size % 16 == 0 and size > 16:
             result["pkcs7_padding_possible"] = True
-        
+
         return result
-    
+
     @staticmethod
     def detect_ecb_mode(data: bytes, block_size: int = 16) -> bool:
         """
         Detect ECB mode by finding repeating blocks.
-        
+
         ECB mode encrypts identical plaintext blocks to identical ciphertext,
         making it cryptographically weak and detectable.
-        
+
         Args:
             data: Ciphertext to analyze
             block_size: Block size in bytes (16 for AES, 8 for DES)
-            
+
         Returns:
             True if repeating blocks detected (ECB mode likely)
         """
         if len(data) < block_size * 2:
             return False
-        
+
         if len(data) % block_size != 0:
             return False
-        
+
         # Split into blocks
-        blocks = [data[i:i+block_size] for i in range(0, len(data), block_size)]
-        
+        blocks = [data[i : i + block_size] for i in range(0, len(data), block_size)]
+
         # Check for duplicates
         unique_blocks = set(blocks)
         has_duplicates = len(blocks) != len(unique_blocks)
-        
+
         return has_duplicates
-    
+
     @staticmethod
     def detect_openssl_format(data: bytes) -> bool:
         """Detect OpenSSL command-line encrypted files"""
         return data.startswith(b"Salted__")
-    
+
     @staticmethod
     def detect_pgp_format(data: bytes) -> bool:
         """Detect PGP/GPG encrypted files"""
-        return (data.startswith(b"-----BEGIN PGP") or 
-                data.startswith(b"\x85\x01") or  # PGP binary
-                data.startswith(b"\x84"))  # Old PGP format
-    
+        return (
+            data.startswith(b"-----BEGIN PGP")
+            or data.startswith(b"\x85\x01")  # PGP binary
+            or data.startswith(b"\x84")
+        )  # Old PGP format
+
     @staticmethod
     def detect_pkcs7_padding(data: bytes) -> Optional[int]:
         """
         Detect PKCS#7 padding at end of data.
-        
+
         Returns:
             Padding length if detected, None otherwise
         """
         if len(data) < 16:
             return None
-        
+
         last_byte = data[-1]
-        
+
         # PKCS#7: padding value = number of padding bytes (1-16)
         if not (1 <= last_byte <= 16):
             return None
-        
+
         # Check if all padding bytes are the same
         padding_bytes = data[-last_byte:]
         if all(b == last_byte for b in padding_bytes):
             return last_byte
-        
+
         return None
-    
+
     @classmethod
     def analyze(cls, data: bytes, entropy: float) -> CryptoAnalysis:
         """
         Perform comprehensive cryptographic analysis.
-        
+
         Args:
             data: File data to analyze
             entropy: Pre-calculated Shannon entropy
-            
+
         Returns:
             CryptoAnalysis with detection results
         """
@@ -156,10 +163,10 @@ class CryptoDetector:
         cipher_hints = []
         is_encrypted = False
         confidence = 0.0
-        
+
         # Interpret entropy
         entropy_desc = cls.interpret_entropy(entropy)
-        
+
         # High entropy suggests encryption/compression
         if entropy > 7.5:
             indicators.append(f"Very high entropy ({entropy:.2f} bits/byte)")
@@ -172,60 +179,64 @@ class CryptoDetector:
         elif entropy > 6.5:
             indicators.append(f"Moderately high entropy ({entropy:.2f} bits/byte)")
             confidence = 0.5
-        
+
         # Block alignment analysis
         block_info = cls.analyze_block_alignment(data)
-        
+
         if block_info["aes_aligned"]:
             indicators.append(f"File size is AES-aligned ({block_info['aes_block_count']} blocks)")
             cipher_hints.append("AES (block size: 16 bytes)")
             confidence += 0.1
-        
+
         if block_info["des_aligned"] and not block_info["aes_aligned"]:
-            indicators.append(f"File size is DES/Blowfish-aligned ({block_info['des_block_count']} blocks)")
+            indicators.append(
+                f"File size is DES/Blowfish-aligned ({block_info['des_block_count']} blocks)"
+            )
             cipher_hints.append("DES or Blowfish (block size: 8 bytes)")
             confidence += 0.1
-        
+
         # ECB mode detection (security vulnerability)
         if block_info["aes_aligned"] and len(data) >= 32:
             if cls.detect_ecb_mode(data, 16):
                 indicators.append("⚠️  Repeating blocks detected - ECB mode (INSECURE)")
                 cipher_hints.append("AES-ECB (Electronic Codebook - deprecated)")
                 confidence += 0.2
-        
+
         if block_info["des_aligned"] and len(data) >= 16:
             if cls.detect_ecb_mode(data, 8):
                 indicators.append("⚠️  Repeating blocks detected - ECB mode (INSECURE)")
                 cipher_hints.append("DES-ECB or 3DES-ECB (deprecated)")
                 confidence += 0.2
-        
+
         # PKCS#7 padding detection
         padding_len = cls.detect_pkcs7_padding(data)
         if padding_len:
             indicators.append(f"PKCS#7 padding detected ({padding_len} bytes)")
             confidence += 0.1
-        
+
         # Known encrypted formats
         if cls.detect_openssl_format(data):
             indicators.append("OpenSSL command-line encryption format")
             cipher_hints.append("OpenSSL enc (likely AES-256-CBC)")
             is_encrypted = True
             confidence = 0.95
-        
+
         if cls.detect_pgp_format(data):
             indicators.append("PGP/GPG encrypted format")
             cipher_hints.append("PGP/GPG asymmetric encryption")
             is_encrypted = True
             confidence = 0.95
-        
+
         # Cap confidence at 1.0
         confidence = min(confidence, 1.0)
-        
+
         return CryptoAnalysis(
             is_likely_encrypted=is_encrypted,
             encryption_indicators=indicators,
             cipher_hints=cipher_hints,
-            block_alignment=block_info if (block_info["aes_aligned"] or block_info["des_aligned"]) else None,
+            block_alignment=(
+                block_info if (block_info["aes_aligned"] or block_info["des_aligned"]) else None
+            ),
             entropy_interpretation=entropy_desc,
-            confidence=confidence
+            confidence=confidence,
         )

--- a/filo/embedded.py
+++ b/filo/embedded.py
@@ -13,7 +13,6 @@ Author: Filo Forensics Team
 """
 
 import logging
-from pathlib import Path
 from typing import Optional
 
 from filo.formats import FormatDatabase

--- a/filo/embedded.py
+++ b/filo/embedded.py
@@ -24,158 +24,158 @@ logger = logging.getLogger(__name__)
 class EmbeddedDetector:
     """
     Detects files embedded within other files.
-    
+
     Scans entire file for signatures at arbitrary offsets,
     detects overlays, and identifies polyglot files.
     """
-    
+
     # Format exclusion rules: formats to skip when inside certain parent formats
     EXCLUSION_RULES = {
-        'elf': {'wasm', 'ico', 'text', 'markdown'},  # ELF binaries have random byte patterns
-        'pe': {'wasm', 'ico', 'text', 'markdown'},   # PE executables have random byte patterns
-        'dll': {'wasm', 'ico', 'text', 'markdown'},
-        'class': {'wasm', 'ico', 'text'},            # Java bytecode
-        'dex': {'wasm', 'ico', 'text'},              # Android DEX files
-        'text': {'text', 'markdown'},                # Don't report text inside text
-        'markdown': {'text', 'markdown'},
+        "elf": {"wasm", "ico", "text", "markdown"},  # ELF binaries have random byte patterns
+        "pe": {"wasm", "ico", "text", "markdown"},  # PE executables have random byte patterns
+        "dll": {"wasm", "ico", "text", "markdown"},
+        "class": {"wasm", "ico", "text"},  # Java bytecode
+        "dex": {"wasm", "ico", "text"},  # Android DEX files
+        "text": {"text", "markdown"},  # Don't report text inside text
+        "markdown": {"text", "markdown"},
     }
-    
+
     def __init__(self, formats_db: Optional[FormatDatabase] = None):
         """
         Initialize embedded object detector.
-        
+
         Args:
             formats_db: Format database (creates new if None)
         """
         self.formats_db = formats_db or FormatDatabase()
-        
+
     def detect_embedded(
-        self, 
-        data: bytes, 
+        self,
+        data: bytes,
         min_confidence: float = 0.75,
         skip_primary: bool = True,
-        parent_format: Optional[str] = None
+        parent_format: Optional[str] = None,
     ) -> list[EmbeddedObject]:
         """
         Detect all embedded objects in binary data.
-        
+
         Args:
             data: Binary data to scan
             min_confidence: Minimum confidence threshold (0.0-1.0)
             skip_primary: Skip signature at offset 0 (primary format)
-            
+
         Returns:
             List of detected embedded objects, sorted by offset
         """
         if not data or len(data) < 4:
             return []
-        
+
         embedded_objects: list[EmbeddedObject] = []
-        
+
         # Scan for all known signatures at any offset
         for format_name in self.formats_db.list_formats():
             spec = self.formats_db.get_format(format_name)
             if not spec or not spec.signatures:
                 continue
-            
+
             # Skip formats excluded for this parent format
             if parent_format and parent_format in self.EXCLUSION_RULES:
                 if format_name in self.EXCLUSION_RULES[parent_format]:
                     continue
-            
+
             # Check each signature
             for sig_spec in spec.signatures:
                 if not sig_spec.hex:
                     continue
-                
+
                 # Find all occurrences of this signature
                 magic_bytes = bytes.fromhex(sig_spec.hex.replace(" ", ""))
                 offset = 0
-                
+
                 while offset < len(data):
                     offset = data.find(magic_bytes, offset)
                     if offset == -1:
                         break
-                    
+
                     # Skip offset 0 if requested (primary format handled elsewhere)
                     if skip_primary and offset == 0:
                         offset += 1
                         continue
-                    
+
                     # Estimate size first (needed for validation)
                     size = self._estimate_size(data, offset, spec)
-                    
+
                     # Skip if insufficient data remaining
                     min_size = self._get_minimum_size(spec)
                     if len(data) - offset < min_size:
                         offset += 1
                         continue
-                    
+
                     # Calculate confidence based on signature quality
-                    confidence = self._calculate_confidence(
-                        data, offset, spec, sig_spec, size
-                    )
-                    
+                    confidence = self._calculate_confidence(data, offset, spec, sig_spec, size)
+
                     if confidence >= min_confidence:
                         # Extract data snippet for verification
-                        snippet = data[offset:offset + 16]
-                        
+                        snippet = data[offset : offset + 16]
+
                         # Auto-generate description
                         size_str = f"{size} bytes" if size else "unknown size"
                         description = f"{format_name.upper()} at offset 0x{offset:X} ({size_str})"
-                        
+
                         embedded_obj = EmbeddedObject(
                             offset=offset,
                             format=format_name,
                             confidence=confidence,
                             size=size,
                             description=description,
-                            data_snippet=snippet
+                            data_snippet=snippet,
                         )
-                        
+
                         embedded_objects.append(embedded_obj)
-                        logger.debug(f"Found embedded {format_name} at 0x{offset:X} (conf: {confidence:.0%})")
-                    
+                        logger.debug(
+                            f"Found embedded {format_name} at 0x{offset:X} (conf: {confidence:.0%})"
+                        )
+
                     offset += 1
-        
+
         # Deduplicate overlapping detections (keep highest confidence)
         embedded_objects = self._deduplicate(embedded_objects)
-        
+
         # Sort by offset
         embedded_objects.sort(key=lambda x: x.offset)
-        
+
         return embedded_objects
-    
+
     def detect_overlay(self, data: bytes, primary_format: str) -> Optional[EmbeddedObject]:
         """
         Detect overlay (data appended after logical EOF).
-        
+
         Common in malware where executables have ZIP/RAR appended.
-        
+
         Args:
             data: Binary data to check
             primary_format: Primary file format (e.g., 'pe', 'elf')
-            
+
         Returns:
             EmbeddedObject if overlay detected, None otherwise
         """
         spec = self.formats_db.get_format(primary_format)
         if not spec:
             return None
-        
+
         # Get logical EOF based on format
         eof_offset = self._get_logical_eof(data, spec)
         if eof_offset is None or eof_offset >= len(data):
             return None
-        
+
         # Check if there's significant data after EOF
         overlay_data = data[eof_offset:]
         if len(overlay_data) < 512:  # Ignore small trailing data
             return None
-        
+
         # Try to detect what the overlay contains
         overlay_objects = self.detect_embedded(overlay_data, skip_primary=False)
-        
+
         if overlay_objects:
             # Adjust offset to be relative to original file
             obj = overlay_objects[0]
@@ -185,7 +185,7 @@ class EmbeddedDetector:
                 confidence=obj.confidence,
                 size=obj.size,
                 description=f"Overlay: {obj.format.upper()} appended after EOF",
-                data_snippet=obj.data_snippet
+                data_snippet=obj.data_snippet,
             )
         else:
             # Unknown overlay data
@@ -195,20 +195,15 @@ class EmbeddedDetector:
                 confidence=0.50,
                 size=len(overlay_data),
                 description=f"Unknown overlay data ({len(overlay_data)} bytes)",
-                data_snippet=overlay_data[:16]
+                data_snippet=overlay_data[:16],
             )
-    
+
     def _calculate_confidence(
-        self, 
-        data: bytes, 
-        offset: int, 
-        spec: FormatSpec, 
-        sig_spec,
-        size: Optional[int] = None
+        self, data: bytes, offset: int, spec: FormatSpec, sig_spec, size: Optional[int] = None
     ) -> float:
         """
         Calculate confidence for embedded object detection.
-        
+
         Factors:
         - Signature strength (length, uniqueness)
         - Structural validation (if available)
@@ -216,7 +211,7 @@ class EmbeddedDetector:
         - Size reasonableness
         """
         confidence = 0.70  # Base confidence for signature match
-        
+
         # Boost for longer signatures
         magic_bytes = bytes.fromhex(sig_spec.hex.replace(" ", ""))
         if len(magic_bytes) >= 8:
@@ -225,21 +220,21 @@ class EmbeddedDetector:
             confidence += 0.10
         elif len(magic_bytes) >= 4:
             confidence += 0.05
-        
+
         # Boost for aligned offsets (many formats prefer alignment)
         if offset % 512 == 0:
             confidence += 0.05
         elif offset % 16 == 0:
             confidence += 0.02
-        
+
         # Penalize very short signatures (2-3 bytes) - too many false positives
         if len(magic_bytes) <= 3:
             confidence -= 0.15
-        
+
         # Boost if size is known and reasonable
         if size and 512 <= size <= 10_000_000:  # Between 512 bytes and 10MB
             confidence += 0.05
-        
+
         # Validate structure if possible
         if spec.format == "zip":
             # Check for valid ZIP structure
@@ -253,104 +248,104 @@ class EmbeddedDetector:
             # Check for valid ELF header
             if self._validate_elf_structure(data[offset:]):
                 confidence += 0.10
-        
+
         return min(confidence, 0.99)  # Cap at 99%
-    
+
     def _validate_zip_structure(self, data: bytes) -> bool:
         """Quick validation of ZIP structure."""
         if len(data) < 30:
             return False
-        
+
         # Check local file header signature
-        if data[:4] != b'PK\x03\x04':
+        if data[:4] != b"PK\x03\x04":
             return False
-        
+
         # Check version needed
-        version = int.from_bytes(data[4:6], 'little')
+        version = int.from_bytes(data[4:6], "little")
         if version > 100:  # Unreasonably high version
             return False
-        
+
         return True
-    
+
     def _validate_pe_structure(self, data: bytes) -> bool:
         """Quick validation of PE structure."""
         if len(data) < 64:
             return False
-        
+
         # Check MZ signature
-        if data[:2] != b'MZ':
+        if data[:2] != b"MZ":
             return False
-        
+
         # Check PE offset
-        pe_offset = int.from_bytes(data[60:64], 'little')
+        pe_offset = int.from_bytes(data[60:64], "little")
         if pe_offset > len(data) or pe_offset < 64:
             return False
-        
+
         # Check PE signature if within bounds
         if pe_offset + 4 <= len(data):
-            if data[pe_offset:pe_offset + 4] != b'PE\x00\x00':
+            if data[pe_offset : pe_offset + 4] != b"PE\x00\x00":
                 return False
-        
+
         return True
-    
+
     def _validate_elf_structure(self, data: bytes) -> bool:
         """Quick validation of ELF structure."""
         if len(data) < 52:
             return False
-        
+
         # Check ELF magic
-        if data[:4] != b'\x7fELF':
+        if data[:4] != b"\x7fELF":
             return False
-        
+
         # Check class (32-bit or 64-bit)
         if data[4] not in (1, 2):
             return False
-        
+
         # Check data encoding (little/big endian)
         if data[5] not in (1, 2):
             return False
-        
+
         return True
-    
+
     def _estimate_size(self, data: bytes, offset: int, spec: FormatSpec) -> Optional[int]:
         """
         Estimate size of embedded object.
-        
+
         Some formats have size headers, others need heuristics.
         """
         remaining = data[offset:]
-        
+
         # Format-specific size extraction
         if spec.format == "zip" and len(remaining) >= 30:
             # ZIP has compressed/uncompressed size in local header
             # This is a simplification - full ZIP parsing is complex
-            compressed_size = int.from_bytes(remaining[18:22], 'little')
+            compressed_size = int.from_bytes(remaining[18:22], "little")
             if 0 < compressed_size < len(remaining):
                 return compressed_size + 30  # Header + data
-        
+
         elif spec.format == "png" and len(remaining) >= 8:
             # PNG chunks have length prefix
             # Scan for IEND chunk to find end
             pos = 8  # Skip PNG signature
             while pos + 12 < len(remaining):
-                chunk_len = int.from_bytes(remaining[pos:pos + 4], 'big')
-                chunk_type = remaining[pos + 4:pos + 8]
-                
-                if chunk_type == b'IEND':
+                chunk_len = int.from_bytes(remaining[pos : pos + 4], "big")
+                chunk_type = remaining[pos + 4 : pos + 8]
+
+                if chunk_type == b"IEND":
                     return pos + 12
-                
+
                 pos += 12 + chunk_len
                 if chunk_len > 10_000_000:  # Sanity check
                     break
-        
+
         elif spec.format in ("pe", "elf") and len(remaining) >= 64:
             # Executables have size in headers
             if spec.format == "pe":
                 # PE size is in optional header
-                pe_offset = int.from_bytes(remaining[60:64], 'little')
+                pe_offset = int.from_bytes(remaining[60:64], "little")
                 if pe_offset + 24 <= len(remaining):
                     size_of_image = int.from_bytes(
-                        remaining[pe_offset + 80:pe_offset + 84], 'little'
+                        remaining[pe_offset + 80 : pe_offset + 84], "little"
                     )
                     if 0 < size_of_image < len(remaining):
                         return size_of_image
@@ -358,88 +353,88 @@ class EmbeddedDetector:
                 # ELF has program headers and section headers
                 # This is a simplification
                 pass
-        
+
         # Default: unknown size
         return None
-    
+
     def _get_minimum_size(self, spec: FormatSpec) -> int:
         """
         Get minimum valid size for a format.
-        
+
         Helps filter out false positives where signature appears
         but there's insufficient data for a valid file.
         """
         min_sizes = {
-            'zip': 30,      # Local file header minimum
-            'png': 57,      # Signature + IHDR + IEND minimum
-            'jpeg': 128,    # Reasonable JPEG minimum
-            'pdf': 256,     # Minimal PDF structure
-            'pe': 512,      # PE header + minimal code
-            'elf': 52,      # ELF header minimum (32-bit)
-            'gif': 800,     # GIF header + minimal image data
-            'bmp': 54,      # BMP header minimum
-            'wasm': 8,      # WASM header (often false positive)
-            'ico': 22,      # ICO header (often false positive)
-            'text': 20,     # Reasonable text minimum
-            'markdown': 20,
+            "zip": 30,  # Local file header minimum
+            "png": 57,  # Signature + IHDR + IEND minimum
+            "jpeg": 128,  # Reasonable JPEG minimum
+            "pdf": 256,  # Minimal PDF structure
+            "pe": 512,  # PE header + minimal code
+            "elf": 52,  # ELF header minimum (32-bit)
+            "gif": 800,  # GIF header + minimal image data
+            "bmp": 54,  # BMP header minimum
+            "wasm": 8,  # WASM header (often false positive)
+            "ico": 22,  # ICO header (often false positive)
+            "text": 20,  # Reasonable text minimum
+            "markdown": 20,
         }
-        
+
         return min_sizes.get(spec.format, 16)  # Default 16 bytes
-    
+
     def _get_logical_eof(self, data: bytes, spec: FormatSpec) -> Optional[int]:
         """
         Get logical end-of-file offset for a format.
-        
+
         Where the format structure ends, not physical file size.
         """
         if spec.format == "pe":
             # PE file size from SizeOfImage
             if len(data) < 64:
                 return None
-            
-            pe_offset = int.from_bytes(data[60:64], 'little')
+
+            pe_offset = int.from_bytes(data[60:64], "little")
             if pe_offset + 84 > len(data):
                 return None
-            
-            size_of_image = int.from_bytes(data[pe_offset + 80:pe_offset + 84], 'little')
+
+            size_of_image = int.from_bytes(data[pe_offset + 80 : pe_offset + 84], "little")
             if 0 < size_of_image < len(data):
                 return size_of_image
-        
+
         elif spec.format == "elf":
             # ELF file size from section headers
             # Simplified - just return None for now
             pass
-        
+
         elif spec.format == "zip":
             # ZIP end is EOCD (End of Central Directory)
             # Scan backwards for EOCD signature
-            eocd_sig = b'PK\x05\x06'
+            eocd_sig = b"PK\x05\x06"
             offset = data.rfind(eocd_sig)
             if offset != -1:
                 return offset + 22  # EOCD is 22 bytes minimum
-        
+
         return None
-    
+
     def _deduplicate(self, objects: list[EmbeddedObject]) -> list[EmbeddedObject]:
         """
         Remove duplicate detections at same/nearby offsets.
-        
+
         Keeps highest confidence detection when multiple formats
         match at the same location.
         """
         if not objects:
             return []
-        
+
         # Sort by offset, then by confidence (descending)
         objects.sort(key=lambda x: (x.offset, -x.confidence))
-        
+
         deduplicated = []
         last_offset = -1000
-        
+
         for obj in objects:
             # Consider offsets within 16 bytes as duplicates
             if obj.offset - last_offset > 16:
                 deduplicated.append(obj)
                 last_offset = obj.offset
-        
+
         return deduplicated

--- a/filo/embedded.py
+++ b/filo/embedded.py
@@ -13,7 +13,7 @@ Author: Filo Forensics Team
 """
 
 import logging
-from typing import Optional
+from typing import Any, Optional
 
 from filo.formats import FormatDatabase
 from filo.models import FormatSpec, EmbeddedObject
@@ -199,7 +199,7 @@ class EmbeddedDetector:
             )
 
     def _calculate_confidence(
-        self, data: bytes, offset: int, spec: FormatSpec, sig_spec, size: Optional[int] = None
+        self, data: bytes, offset: int, spec: FormatSpec, sig_spec: Any, size: Optional[int] = None
     ) -> float:
         """
         Calculate confidence for embedded object detection.

--- a/filo/export.py
+++ b/filo/export.py
@@ -5,12 +5,10 @@ Export functionality for JSON and SARIF reports.
 import json
 import logging
 from dataclasses import asdict
-from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
-import hashlib
 
-from filo.models import AnalysisResult, FormatSpec
+from filo.models import AnalysisResult
 from filo.repair import RepairReport
 
 logger = logging.getLogger(__name__)

--- a/filo/export.py
+++ b/filo/export.py
@@ -59,7 +59,7 @@ class JSONExporter:
         """
         from datetime import datetime, timezone
 
-        data = {
+        data: dict[str, Any] = {
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "total_files": len(results),
             "files": [],
@@ -197,7 +197,7 @@ class SARIFExporter:
             f"File identified as {result.primary_format} with {result.confidence:.1%} confidence"
         )
 
-        sarif_result = {
+        sarif_result: dict[str, Any] = {
             "ruleId": "FILE-001",
             "level": level,
             "message": {"text": message},

--- a/filo/export.py
+++ b/filo/export.py
@@ -16,16 +16,16 @@ logger = logging.getLogger(__name__)
 
 class JSONExporter:
     """Export analysis results to JSON format."""
-    
+
     @staticmethod
     def export_result(result: AnalysisResult, pretty: bool = True) -> str:
         """
         Export single analysis result to JSON.
-        
+
         Args:
             result: Analysis result to export
             pretty: Pretty-print JSON output
-            
+
         Returns:
             JSON string
         """
@@ -34,38 +34,37 @@ class JSONExporter:
             "confidence": result.confidence,
             "file_size": result.file_size,
             "alternative_formats": [
-                {"format": fmt, "confidence": conf}
-                for fmt, conf in result.alternative_formats
+                {"format": fmt, "confidence": conf} for fmt, conf in result.alternative_formats
             ],
             "evidence_chain": result.evidence_chain,
             "entropy": result.entropy,
             "crypto_analysis": result.crypto_analysis,
-            "checksum": result.checksum_sha256
+            "checksum": result.checksum_sha256,
         }
-        
+
         indent = 2 if pretty else None
         return json.dumps(data, indent=indent)
-    
+
     @staticmethod
     def export_batch(results: List[tuple[Path, AnalysisResult]], pretty: bool = True) -> str:
         """
         Export batch results to JSON.
-        
+
         Args:
             results: List of (path, result) tuples
             pretty: Pretty-print JSON output
-            
+
         Returns:
             JSON string
         """
         from datetime import datetime, timezone
-        
+
         data = {
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "total_files": len(results),
-            "files": []
+            "files": [],
         }
-        
+
         for path, result in results:
             file_data = {
                 "path": str(path),
@@ -73,24 +72,23 @@ class JSONExporter:
                 "confidence": result.confidence,
                 "file_size": result.file_size,
                 "alternative_formats": [
-                    {"format": fmt, "confidence": conf}
-                    for fmt, conf in result.alternative_formats
-                ]
+                    {"format": fmt, "confidence": conf} for fmt, conf in result.alternative_formats
+                ],
             }
             data["files"].append(file_data)
-        
+
         indent = 2 if pretty else None
         return json.dumps(data, indent=indent)
-    
+
     @staticmethod
     def export_repair(repair_report: RepairReport, pretty: bool = True) -> str:
         """
         Export repair report to JSON.
-        
+
         Args:
             repair_report: Repair report to export
             pretty: Pretty-print JSON output
-            
+
         Returns:
             JSON string
         """
@@ -102,28 +100,26 @@ class JSONExporter:
 class SARIFExporter:
     """
     Export analysis results to SARIF (Static Analysis Results Interchange Format).
-    
+
     SARIF is used by GitHub Advanced Security, VS Code, and other tools.
     Spec: https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html
     """
-    
+
     TOOL_NAME = "Filo"
     TOOL_VERSION = "1.0.0"
-    
+
     @staticmethod
     def export_result(
-        result: AnalysisResult,
-        file_path: Optional[Path] = None,
-        pretty: bool = True
+        result: AnalysisResult, file_path: Optional[Path] = None, pretty: bool = True
     ) -> str:
         """
         Export single analysis result to SARIF format.
-        
+
         Args:
             result: Analysis result to export
             file_path: Optional file path for location info
             pretty: Pretty-print JSON output
-            
+
         Returns:
             SARIF JSON string
         """
@@ -136,38 +132,35 @@ class SARIFExporter:
                         "driver": {
                             "name": SARIFExporter.TOOL_NAME,
                             "version": SARIFExporter.TOOL_VERSION,
-                            "informationUri": "https://github.com/example/filo"
+                            "informationUri": "https://github.com/example/filo",
                         }
                     },
-                    "results": SARIFExporter._result_to_sarif_results(result, file_path)
+                    "results": SARIFExporter._result_to_sarif_results(result, file_path),
                 }
-            ]
+            ],
         }
-        
+
         indent = 2 if pretty else None
         return json.dumps(sarif, indent=indent)
-    
+
     @staticmethod
-    def export_batch(
-        results: List[tuple[Path, AnalysisResult]],
-        pretty: bool = True
-    ) -> str:
+    def export_batch(results: List[tuple[Path, AnalysisResult]], pretty: bool = True) -> str:
         """
         Export batch results to SARIF format.
-        
+
         Args:
             results: List of (path, result) tuples
             pretty: Pretty-print JSON output
-            
+
         Returns:
             SARIF JSON string
         """
         all_results = []
-        
+
         for path, result in results:
             sarif_results = SARIFExporter._result_to_sarif_results(result, path)
             all_results.extend(sarif_results)
-        
+
         sarif = {
             "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
             "version": "2.1.0",
@@ -177,91 +170,79 @@ class SARIFExporter:
                         "driver": {
                             "name": SARIFExporter.TOOL_NAME,
                             "version": SARIFExporter.TOOL_VERSION,
-                            "informationUri": "https://github.com/example/filo"
+                            "informationUri": "https://github.com/example/filo",
                         }
                     },
-                    "results": all_results
+                    "results": all_results,
                 }
-            ]
+            ],
         }
-        
+
         indent = 2 if pretty else None
         return json.dumps(sarif, indent=indent)
-    
+
     @staticmethod
     def _result_to_sarif_results(
-        result: AnalysisResult,
-        file_path: Optional[Path] = None
+        result: AnalysisResult, file_path: Optional[Path] = None
     ) -> List[Dict[str, Any]]:
         """Convert AnalysisResult to SARIF results."""
         sarif_results = []
-        
+
         # Main result
         level = "note"
         if result.confidence < 0.5:
             level = "warning"
-        
-        message = f"File identified as {result.primary_format} with {result.confidence:.1%} confidence"
-        
+
+        message = (
+            f"File identified as {result.primary_format} with {result.confidence:.1%} confidence"
+        )
+
         sarif_result = {
             "ruleId": "FILE-001",
             "level": level,
-            "message": {
-                "text": message
-            },
+            "message": {"text": message},
             "properties": {
                 "format": result.primary_format,
                 "confidence": result.confidence,
                 "fileSize": result.file_size,
                 "alternativeFormats": [
-                    {"format": fmt, "confidence": conf}
-                    for fmt, conf in result.alternative_formats
+                    {"format": fmt, "confidence": conf} for fmt, conf in result.alternative_formats
                 ],
                 "entropy": result.entropy,
-                "checksum": result.checksum_sha256
-            }
+                "checksum": result.checksum_sha256,
+            },
         }
-        
+
         if file_path:
             sarif_result["locations"] = [
-                {
-                    "physicalLocation": {
-                        "artifactLocation": {
-                            "uri": str(file_path)
-                        }
-                    }
-                }
+                {"physicalLocation": {"artifactLocation": {"uri": str(file_path)}}}
             ]
-        
+
         sarif_results.append(sarif_result)
-        
+
         return sarif_results
 
 
-def export_to_file(
-    data: str,
-    output_path: Path,
-    overwrite: bool = False
-) -> None:
+def export_to_file(data: str, output_path: Path, overwrite: bool = False) -> None:
     """
     Write exported data to file.
-    
+
     Args:
         data: Exported data string
         output_path: Output file path
         overwrite: Allow overwriting existing files
-        
+
     Raises:
         FileExistsError: If file exists and overwrite=False
     """
     output_path = Path(output_path)
-    
+
     if output_path.exists() and not overwrite:
         raise FileExistsError(f"Output file already exists: {output_path}")
-    
+
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    
-    with open(output_path, 'w') as f:
+
+    with open(output_path, "w") as f:
         f.write(data)
-    
+
     logger.info(f"Exported to {output_path}")

--- a/filo/fingerprint.py
+++ b/filo/fingerprint.py
@@ -4,6 +4,7 @@ Temporal & Tool Fingerprinting - Forensic Attribution Engine
 Identifies how, when, and with what tools a file was created.
 Goes beyond format detection to answer: Who made this? When? How?
 """
+
 import struct
 import re
 from datetime import datetime
@@ -14,7 +15,7 @@ from filo.models import Fingerprint
 
 class ToolFingerprinter:
     """Extract tool/creator signatures from file formats."""
-    
+
     def __init__(self):
         self.zip_os_map = {
             0: "MS-DOS/FAT",
@@ -36,9 +37,9 @@ class ToolFingerprinter:
             16: "BeOS",
             17: "Tandem",
             18: "OS/400",
-            19: "OS X Darwin"
+            19: "OS X Darwin",
         }
-        
+
         self.zip_tool_hints = {
             (20, 3): "Unix (Info-ZIP)",
             (45, 3): "Unix (7-Zip)",
@@ -46,9 +47,9 @@ class ToolFingerprinter:
             (20, 0): "Windows (early)",
             (45, 10): "Windows (7-Zip 9.20+)",
             (51, 10): "Windows (WinZip)",
-            (63, 10): "Windows (modern)"
+            (63, 10): "Windows (modern)",
         }
-        
+
         self.pdf_producers = {
             "Adobe": re.compile(rb"Adobe\s+(Acrobat|PDF Library|PDFMaker)\s+([\d.]+)"),
             "Microsoft": re.compile(rb"Microsoft\s+(Word|Excel|PowerPoint)\s+([\d.]+)"),
@@ -61,7 +62,7 @@ class ToolFingerprinter:
             "ReportLab": re.compile(rb"ReportLab\s+PDF\s+Library\s+([\d.]+)"),
             "Prince": re.compile(rb"Prince\s+([\d.]+)"),
         }
-        
+
         self.office_build_patterns = {
             "Word": re.compile(rb"Microsoft Office Word ([\d.]+)"),
             "Excel": re.compile(rb"Microsoft Excel ([\d.]+)"),
@@ -69,216 +70,244 @@ class ToolFingerprinter:
             "LibreOffice": re.compile(rb"LibreOffice_([\d.]+)"),
             "OpenOffice": re.compile(rb"OpenOffice\.org_([\d.]+)"),
         }
-    
+
     def fingerprint_file(self, data: bytes, format_hint: Optional[str] = None) -> List[Fingerprint]:
         """Extract all fingerprints from file data."""
         fingerprints = []
-        
+
         if format_hint == "zip" or data.startswith(b"PK"):
             fingerprints.extend(self._fingerprint_zip(data))
-        
+
         if format_hint == "pdf" or data.startswith(b"%PDF"):
             fingerprints.extend(self._fingerprint_pdf(data))
-        
+
         if format_hint in ("docx", "xlsx", "pptx", "odt", "ods", "odp"):
             fingerprints.extend(self._fingerprint_office(data, format_hint))
-        
+
         return fingerprints
-    
+
     def _fingerprint_zip(self, data: bytes) -> List[Fingerprint]:
         """Extract ZIP tool signatures from extra fields and headers."""
         fingerprints = []
-        
+
         pos = 0
         while pos < len(data) - 30:
-            if data[pos:pos+4] == b"PK\x03\x04":
+            if data[pos : pos + 4] == b"PK\x03\x04":
                 try:
-                    version_needed = struct.unpack("<H", data[pos+4:pos+6])[0]
+                    version_needed = struct.unpack("<H", data[pos + 4 : pos + 6])[0]
                     version_made = version_needed
-                    struct.unpack("<H", data[pos+6:pos+8])[0]
-                    method = struct.unpack("<H", data[pos+8:pos+10])[0]
-                    mod_time = struct.unpack("<H", data[pos+10:pos+12])[0]
-                    mod_date = struct.unpack("<H", data[pos+12:pos+14])[0]
-                    
-                    filename_len = struct.unpack("<H", data[pos+26:pos+28])[0]
-                    extra_len = struct.unpack("<H", data[pos+28:pos+30])[0]
-                    
+                    struct.unpack("<H", data[pos + 6 : pos + 8])[0]
+                    method = struct.unpack("<H", data[pos + 8 : pos + 10])[0]
+                    mod_time = struct.unpack("<H", data[pos + 10 : pos + 12])[0]
+                    mod_date = struct.unpack("<H", data[pos + 12 : pos + 14])[0]
+
+                    filename_len = struct.unpack("<H", data[pos + 26 : pos + 28])[0]
+                    extra_len = struct.unpack("<H", data[pos + 28 : pos + 30])[0]
+
                     timestamp = self._parse_dos_datetime(mod_date, mod_time)
-                    
-                    if data[pos:pos+4] == b"PK\x01\x02":
-                        version_made = struct.unpack("<H", data[pos+4:pos+6])[0]
-                    
+
+                    if data[pos : pos + 4] == b"PK\x01\x02":
+                        version_made = struct.unpack("<H", data[pos + 4 : pos + 6])[0]
+
                     os_code = (version_made >> 8) & 0xFF
                     zip_version = version_made & 0xFF
-                    
+
                     os_name = self.zip_os_map.get(os_code, f"Unknown ({os_code})")
-                    
+
                     tool_hint = self.zip_tool_hints.get((zip_version, os_code))
                     confidence = 0.85 if tool_hint else 0.70
-                    
-                    fingerprints.append(Fingerprint(
-                        category="zip_creator",
-                        tool=tool_hint.split("(")[1].rstrip(")") if tool_hint else None,
-                        version=f"{zip_version / 10:.1f}",
-                        os_hint=os_name,
-                        timestamp=timestamp,
-                        confidence=confidence,
-                        evidence=f"Version {zip_version}, OS code {os_code}, method {method}"
-                    ))
-                    
+
+                    fingerprints.append(
+                        Fingerprint(
+                            category="zip_creator",
+                            tool=tool_hint.split("(")[1].rstrip(")") if tool_hint else None,
+                            version=f"{zip_version / 10:.1f}",
+                            os_hint=os_name,
+                            timestamp=timestamp,
+                            confidence=confidence,
+                            evidence=f"Version {zip_version}, OS code {os_code}, method {method}",
+                        )
+                    )
+
                     if extra_len > 0 and pos + 30 + filename_len + extra_len <= len(data):
                         extra_start = pos + 30 + filename_len
-                        extra_data = data[extra_start:extra_start + extra_len]
-                        
+                        extra_data = data[extra_start : extra_start + extra_len]
+
                         extra_pos = 0
                         while extra_pos < len(extra_data) - 4:
-                            header_id = struct.unpack("<H", extra_data[extra_pos:extra_pos+2])[0]
-                            data_size = struct.unpack("<H", extra_data[extra_pos+2:extra_pos+4])[0]
-                            
+                            header_id = struct.unpack("<H", extra_data[extra_pos : extra_pos + 2])[
+                                0
+                            ]
+                            data_size = struct.unpack(
+                                "<H", extra_data[extra_pos + 2 : extra_pos + 4]
+                            )[0]
+
                             if header_id == 0x5455:
-                                fingerprints.append(Fingerprint(
-                                    category="zip_extended_timestamp",
-                                    tool=None,
-                                    version=None,
-                                    os_hint="Unix",
-                                    timestamp=None,
-                                    confidence=0.90,
-                                    evidence="Extended timestamp field (0x5455) - Unix origin"
-                                ))
+                                fingerprints.append(
+                                    Fingerprint(
+                                        category="zip_extended_timestamp",
+                                        tool=None,
+                                        version=None,
+                                        os_hint="Unix",
+                                        timestamp=None,
+                                        confidence=0.90,
+                                        evidence="Extended timestamp field (0x5455) - Unix origin",
+                                    )
+                                )
                             elif header_id == 0x7875:
-                                fingerprints.append(Fingerprint(
-                                    category="zip_unix_uid",
-                                    tool=None,
-                                    version=None,
-                                    os_hint="Unix",
-                                    timestamp=None,
-                                    confidence=0.95,
-                                    evidence="Unix UID/GID field (0x7875)"
-                                ))
-                            
+                                fingerprints.append(
+                                    Fingerprint(
+                                        category="zip_unix_uid",
+                                        tool=None,
+                                        version=None,
+                                        os_hint="Unix",
+                                        timestamp=None,
+                                        confidence=0.95,
+                                        evidence="Unix UID/GID field (0x7875)",
+                                    )
+                                )
+
                             extra_pos += 4 + data_size
-                    
+
                     break
-                
+
                 except (struct.error, ValueError):
                     pass
-            
+
             pos += 1
-        
+
         return fingerprints
-    
+
     def _fingerprint_pdf(self, data: bytes) -> List[Fingerprint]:
         """Extract PDF producer and creator metadata."""
         fingerprints = []
-        
-        search_data = data[:min(len(data), 100000)]
-        
+
+        search_data = data[: min(len(data), 100000)]
+
         for tool_name, pattern in self.pdf_producers.items():
             match = pattern.search(search_data)
             if match:
-                version = match.group(2).decode('latin-1', errors='ignore') if match.lastindex >= 2 else None
-                match.group(1).decode('latin-1', errors='ignore') if match.lastindex >= 1 else tool_name
-                
-                fingerprints.append(Fingerprint(
-                    category="pdf_producer",
-                    tool=tool_name,
-                    version=version,
-                    os_hint=None,
-                    timestamp=None,
-                    confidence=0.92,
-                    evidence=f"Producer string: {match.group(0).decode('latin-1', errors='ignore')}"
-                ))
-        
+                version = (
+                    match.group(2).decode("latin-1", errors="ignore")
+                    if match.lastindex >= 2
+                    else None
+                )
+                (
+                    match.group(1).decode("latin-1", errors="ignore")
+                    if match.lastindex >= 1
+                    else tool_name
+                )
+
+                fingerprints.append(
+                    Fingerprint(
+                        category="pdf_producer",
+                        tool=tool_name,
+                        version=version,
+                        os_hint=None,
+                        timestamp=None,
+                        confidence=0.92,
+                        evidence=f"Producer string: {match.group(0).decode('latin-1', errors='ignore')}",
+                    )
+                )
+
         creation_date = re.search(rb"/CreationDate\s*\(D:(\d{14})", search_data)
         if creation_date:
             try:
-                date_str = creation_date.group(1).decode('ascii')
+                date_str = creation_date.group(1).decode("ascii")
                 timestamp = datetime.strptime(date_str, "%Y%m%d%H%M%S")
-                
-                fingerprints.append(Fingerprint(
-                    category="pdf_creation_date",
-                    tool=None,
-                    version=None,
-                    os_hint=None,
-                    timestamp=timestamp,
-                    confidence=0.88,
-                    evidence=f"Creation date: {timestamp.isoformat()}"
-                ))
+
+                fingerprints.append(
+                    Fingerprint(
+                        category="pdf_creation_date",
+                        tool=None,
+                        version=None,
+                        os_hint=None,
+                        timestamp=timestamp,
+                        confidence=0.88,
+                        evidence=f"Creation date: {timestamp.isoformat()}",
+                    )
+                )
             except (ValueError, AttributeError):
                 pass
-        
+
         mod_date = re.search(rb"/ModDate\s*\(D:(\d{14})", search_data)
         if mod_date:
             try:
-                date_str = mod_date.group(1).decode('ascii')
+                date_str = mod_date.group(1).decode("ascii")
                 timestamp = datetime.strptime(date_str, "%Y%m%d%H%M%S")
-                
-                fingerprints.append(Fingerprint(
-                    category="pdf_modification_date",
-                    tool=None,
-                    version=None,
-                    os_hint=None,
-                    timestamp=timestamp,
-                    confidence=0.88,
-                    evidence=f"Modification date: {timestamp.isoformat()}"
-                ))
+
+                fingerprints.append(
+                    Fingerprint(
+                        category="pdf_modification_date",
+                        tool=None,
+                        version=None,
+                        os_hint=None,
+                        timestamp=timestamp,
+                        confidence=0.88,
+                        evidence=f"Modification date: {timestamp.isoformat()}",
+                    )
+                )
             except (ValueError, AttributeError):
                 pass
-        
+
         return fingerprints
-    
+
     def _fingerprint_office(self, data: bytes, format_hint: str) -> List[Fingerprint]:
         """Extract Office document build fingerprints."""
         fingerprints = []
-        
-        search_data = data[:min(len(data), 100000)]
-        
+
+        search_data = data[: min(len(data), 100000)]
+
         for app_name, pattern in self.office_build_patterns.items():
             match = pattern.search(search_data)
             if match:
-                version = match.group(1).decode('latin-1', errors='ignore')
-                
+                version = match.group(1).decode("latin-1", errors="ignore")
+
                 os_hint = "Windows" if "Microsoft" in app_name else "Cross-platform"
-                
-                fingerprints.append(Fingerprint(
-                    category="office_application",
-                    tool=app_name,
-                    version=version,
-                    os_hint=os_hint,
-                    timestamp=None,
-                    confidence=0.90,
-                    evidence=f"Application: {app_name} {version}"
-                ))
-        
+
+                fingerprints.append(
+                    Fingerprint(
+                        category="office_application",
+                        tool=app_name,
+                        version=version,
+                        os_hint=os_hint,
+                        timestamp=None,
+                        confidence=0.90,
+                        evidence=f"Application: {app_name} {version}",
+                    )
+                )
+
         app_version = re.search(rb"AppVersion\s*=\s*\"([\d.]+)\"", search_data)
         if app_version:
-            version = app_version.group(1).decode('ascii')
-            fingerprints.append(Fingerprint(
-                category="office_app_version",
-                tool=None,
-                version=version,
-                os_hint=None,
-                timestamp=None,
-                confidence=0.85,
-                evidence=f"AppVersion property: {version}"
-            ))
-        
+            version = app_version.group(1).decode("ascii")
+            fingerprints.append(
+                Fingerprint(
+                    category="office_app_version",
+                    tool=None,
+                    version=version,
+                    os_hint=None,
+                    timestamp=None,
+                    confidence=0.85,
+                    evidence=f"AppVersion property: {version}",
+                )
+            )
+
         return fingerprints
-    
+
     def _parse_dos_datetime(self, dos_date: int, dos_time: int) -> Optional[datetime]:
         """Convert DOS date/time to Python datetime."""
         try:
             year = ((dos_date >> 9) & 0x7F) + 1980
             month = (dos_date >> 5) & 0x0F
             day = dos_date & 0x1F
-            
+
             hour = (dos_time >> 11) & 0x1F
             minute = (dos_time >> 5) & 0x3F
             second = (dos_time & 0x1F) * 2
-            
+
             if 1980 <= year <= 2107 and 1 <= month <= 12 and 1 <= day <= 31:
                 return datetime(year, month, day, hour, minute, second)
         except (ValueError, OverflowError):
             pass
-        
+
         return None

--- a/filo/fingerprint.py
+++ b/filo/fingerprint.py
@@ -7,8 +7,7 @@ Goes beyond format detection to answer: Who made this? When? How?
 import struct
 import re
 from datetime import datetime
-from typing import Dict, List, Optional, Any
-from pathlib import Path
+from typing import List, Optional
 
 from filo.models import Fingerprint
 
@@ -96,7 +95,7 @@ class ToolFingerprinter:
                 try:
                     version_needed = struct.unpack("<H", data[pos+4:pos+6])[0]
                     version_made = version_needed
-                    flags = struct.unpack("<H", data[pos+6:pos+8])[0]
+                    struct.unpack("<H", data[pos+6:pos+8])[0]
                     method = struct.unpack("<H", data[pos+8:pos+10])[0]
                     mod_time = struct.unpack("<H", data[pos+10:pos+12])[0]
                     mod_date = struct.unpack("<H", data[pos+12:pos+14])[0]
@@ -178,7 +177,7 @@ class ToolFingerprinter:
             match = pattern.search(search_data)
             if match:
                 version = match.group(2).decode('latin-1', errors='ignore') if match.lastindex >= 2 else None
-                app_name = match.group(1).decode('latin-1', errors='ignore') if match.lastindex >= 1 else tool_name
+                match.group(1).decode('latin-1', errors='ignore') if match.lastindex >= 1 else tool_name
                 
                 fingerprints.append(Fingerprint(
                     category="pdf_producer",

--- a/filo/fingerprint.py
+++ b/filo/fingerprint.py
@@ -16,7 +16,7 @@ from filo.models import Fingerprint
 class ToolFingerprinter:
     """Extract tool/creator signatures from file formats."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.zip_os_map = {
             0: "MS-DOS/FAT",
             1: "Amiga",
@@ -189,12 +189,12 @@ class ToolFingerprinter:
             if match:
                 version = (
                     match.group(2).decode("latin-1", errors="ignore")
-                    if match.lastindex >= 2
+                    if (match.lastindex or 0) >= 2
                     else None
                 )
                 (
                     match.group(1).decode("latin-1", errors="ignore")
-                    if match.lastindex >= 1
+                    if (match.lastindex or 0) >= 1
                     else tool_name
                 )
 

--- a/filo/formats.py
+++ b/filo/formats.py
@@ -12,14 +12,14 @@ logger = logging.getLogger(__name__)
 class FormatDatabase:
     """
     Machine-readable database of file format specifications.
-    
+
     Loads and queries format specifications from YAML files.
     """
-    
+
     def __init__(self, formats_dir: Optional[Path] = None) -> None:
         """
         Initialize format database.
-        
+
         Args:
             formats_dir: Directory containing format YAML files.
                         Defaults to bundled formats.
@@ -27,21 +27,19 @@ class FormatDatabase:
         if formats_dir is None:
             # Use bundled formats directory
             formats_dir = Path(__file__).parent / "formats"
-        
+
         self.formats_dir = Path(formats_dir)
         self._formats: dict[str, FormatSpec] = {}
         self._load_formats()
-    
+
     def _load_formats(self) -> None:
         """Load all format specifications from YAML files."""
         if not self.formats_dir.exists():
             logger.warning(f"Formats directory not found: {self.formats_dir}")
             return
-        
-        yaml_files = list(self.formats_dir.glob("*.yaml")) + list(
-            self.formats_dir.glob("*.yml")
-        )
-        
+
+        yaml_files = list(self.formats_dir.glob("*.yaml")) + list(self.formats_dir.glob("*.yml"))
+
         for yaml_file in yaml_files:
             try:
                 with open(yaml_file, "r", encoding="utf-8") as f:
@@ -51,67 +49,61 @@ class FormatDatabase:
                     logger.debug(f"Loaded format: {spec.format}")
             except Exception as e:
                 logger.error(f"Failed to load format from {yaml_file}: {e}")
-    
+
     def get_format(self, format_name: str) -> Optional[FormatSpec]:
         """
         Get format specification by name.
-        
+
         Args:
             format_name: Format identifier (e.g., 'png')
-        
+
         Returns:
             FormatSpec if found, None otherwise
         """
         return self._formats.get(format_name)
-    
+
     def list_formats(self) -> list[str]:
         """
         List all available format identifiers.
-        
+
         Returns:
             Sorted list of format names
         """
         return sorted(self._formats.keys())
-    
+
     def get_formats_by_category(self, category: str) -> list[FormatSpec]:
         """
         Get all formats in a category.
-        
+
         Args:
             category: Category name (e.g., 'raster_image')
-        
+
         Returns:
             List of matching format specifications
         """
-        return [
-            spec for spec in self._formats.values() if spec.category == category
-        ]
-    
+        return [spec for spec in self._formats.values() if spec.category == category]
+
     def get_formats_by_extension(self, extension: str) -> list[FormatSpec]:
         """
         Get formats that use a file extension.
-        
+
         Args:
             extension: File extension (with or without leading dot)
-        
+
         Returns:
             List of matching format specifications
         """
         ext = extension.lstrip(".")
-        return [
-            spec
-            for spec in self._formats.values()
-            if ext in spec.extensions
-        ]
-    
+        return [spec for spec in self._formats.values() if ext in spec.extensions]
+
     def count(self) -> int:
         """Return number of loaded formats."""
         return len(self._formats)
-    
+
     def __contains__(self, format_name: str) -> bool:
         """Check if format exists in database."""
         return format_name in self._formats
-    
+
     def __len__(self) -> int:
         """Return number of loaded formats."""
         return len(self._formats)

--- a/filo/lineage.py
+++ b/filo/lineage.py
@@ -17,6 +17,7 @@ from enum import Enum
 
 class OperationType(str, Enum):
     """Types of operations that create lineage records"""
+
     REPAIR = "repair"
     CARVE = "carve"
     EXTRACT = "extract"
@@ -29,7 +30,7 @@ class OperationType(str, Enum):
 class FileLineage:
     """
     Single lineage record tracking a file transformation.
-    
+
     Attributes:
         original_hash: SHA-256 hash of source file
         result_hash: SHA-256 hash of resulting file
@@ -39,6 +40,7 @@ class FileLineage:
         result_path: Path to result file (optional)
         metadata: Operation-specific details (repair strategy, offset, etc.)
     """
+
     original_hash: str
     result_hash: str
     operation: OperationType
@@ -46,43 +48,43 @@ class FileLineage:
     original_path: Optional[str] = None
     result_path: Optional[str] = None
     metadata: Dict[str, Any] = field(default_factory=dict)
-    
+
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary for JSON export"""
         data = asdict(self)
-        data['operation'] = self.operation.value
+        data["operation"] = self.operation.value
         return data
-    
+
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> 'FileLineage':
+    def from_dict(cls, data: Dict[str, Any]) -> "FileLineage":
         """Create from dictionary"""
-        data['operation'] = OperationType(data['operation'])
+        data["operation"] = OperationType(data["operation"])
         return cls(**data)
 
 
 class LineageTracker:
     """
     Tracks and queries file transformation lineage using SQLite.
-    
+
     Maintains chain-of-custody for forensic investigations by recording
     cryptographic hashes across all file transformations.
     """
-    
+
     def __init__(self, db_path: Optional[Path] = None):
         """
         Initialize lineage tracker.
-        
+
         Args:
             db_path: Path to SQLite database (default: ~/.filo/lineage.db)
         """
         if db_path is None:
             db_path = Path.home() / ".filo" / "lineage.db"
-        
+
         self.db_path = Path(db_path)
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
-        
+
         self._init_database()
-    
+
     def _init_database(self):
         """Initialize SQLite database schema"""
         with sqlite3.connect(self.db_path) as conn:
@@ -99,7 +101,7 @@ class LineageTracker:
                     UNIQUE(original_hash, result_hash, operation, timestamp)
                 )
             """)
-            
+
             # Indexes for efficient queries
             conn.execute("""
                 CREATE INDEX IF NOT EXISTS idx_original_hash 
@@ -117,7 +119,7 @@ class LineageTracker:
                 CREATE INDEX IF NOT EXISTS idx_timestamp 
                 ON lineage(timestamp)
             """)
-    
+
     def record(
         self,
         original_data: bytes,
@@ -125,11 +127,11 @@ class LineageTracker:
         operation: OperationType,
         original_path: Optional[str] = None,
         result_path: Optional[str] = None,
-        **metadata
+        **metadata,
     ) -> FileLineage:
         """
         Record a file transformation.
-        
+
         Args:
             original_data: Original file bytes
             result_data: Resulting file bytes
@@ -137,14 +139,14 @@ class LineageTracker:
             original_path: Path to original file
             result_path: Path to result file
             **metadata: Additional operation details
-        
+
         Returns:
             FileLineage record
         """
         original_hash = hashlib.sha256(original_data).hexdigest()
         result_hash = hashlib.sha256(result_data).hexdigest()
-        timestamp = datetime.utcnow().isoformat() + 'Z'
-        
+        timestamp = datetime.utcnow().isoformat() + "Z"
+
         lineage = FileLineage(
             original_hash=original_hash,
             result_hash=result_hash,
@@ -152,9 +154,9 @@ class LineageTracker:
             timestamp=timestamp,
             original_path=original_path,
             result_path=result_path,
-            metadata=metadata
+            metadata=metadata,
         )
-        
+
         with sqlite3.connect(self.db_path) as conn:
             conn.execute(
                 """
@@ -170,50 +172,46 @@ class LineageTracker:
                     timestamp,
                     original_path,
                     result_path,
-                    json.dumps(metadata)
-                )
+                    json.dumps(metadata),
+                ),
             )
-        
+
         return lineage
-    
+
     def record_from_files(
-        self,
-        original_path: Path,
-        result_path: Path,
-        operation: OperationType,
-        **metadata
+        self, original_path: Path, result_path: Path, operation: OperationType, **metadata
     ) -> FileLineage:
         """
         Record transformation using file paths.
-        
+
         Args:
             original_path: Path to original file
             result_path: Path to result file
             operation: Type of operation
             **metadata: Additional details
-        
+
         Returns:
             FileLineage record
         """
         original_data = original_path.read_bytes()
         result_data = result_path.read_bytes()
-        
+
         return self.record(
             original_data=original_data,
             result_data=result_data,
             operation=operation,
             original_path=str(original_path),
             result_path=str(result_path),
-            **metadata
+            **metadata,
         )
-    
+
     def get_descendants(self, file_hash: str) -> List[FileLineage]:
         """
         Get all files derived from this hash (forward lineage).
-        
+
         Args:
             file_hash: SHA-256 hash to query
-        
+
         Returns:
             List of lineage records where this is the original
         """
@@ -225,30 +223,32 @@ class LineageTracker:
                 WHERE original_hash = ? 
                 ORDER BY timestamp ASC
                 """,
-                (file_hash,)
+                (file_hash,),
             )
-            
+
             records = []
             for row in cursor:
-                records.append(FileLineage(
-                    original_hash=row['original_hash'],
-                    result_hash=row['result_hash'],
-                    operation=OperationType(row['operation']),
-                    timestamp=row['timestamp'],
-                    original_path=row['original_path'],
-                    result_path=row['result_path'],
-                    metadata=json.loads(row['metadata']) if row['metadata'] else {}
-                ))
-            
+                records.append(
+                    FileLineage(
+                        original_hash=row["original_hash"],
+                        result_hash=row["result_hash"],
+                        operation=OperationType(row["operation"]),
+                        timestamp=row["timestamp"],
+                        original_path=row["original_path"],
+                        result_path=row["result_path"],
+                        metadata=json.loads(row["metadata"]) if row["metadata"] else {},
+                    )
+                )
+
             return records
-    
+
     def get_ancestors(self, file_hash: str) -> List[FileLineage]:
         """
         Get all files this was derived from (backward lineage).
-        
+
         Args:
             file_hash: SHA-256 hash to query
-        
+
         Returns:
             List of lineage records where this is the result
         """
@@ -260,30 +260,32 @@ class LineageTracker:
                 WHERE result_hash = ? 
                 ORDER BY timestamp DESC
                 """,
-                (file_hash,)
+                (file_hash,),
             )
-            
+
             records = []
             for row in cursor:
-                records.append(FileLineage(
-                    original_hash=row['original_hash'],
-                    result_hash=row['result_hash'],
-                    operation=OperationType(row['operation']),
-                    timestamp=row['timestamp'],
-                    original_path=row['original_path'],
-                    result_path=row['result_path'],
-                    metadata=json.loads(row['metadata']) if row['metadata'] else {}
-                ))
-            
+                records.append(
+                    FileLineage(
+                        original_hash=row["original_hash"],
+                        result_hash=row["result_hash"],
+                        operation=OperationType(row["operation"]),
+                        timestamp=row["timestamp"],
+                        original_path=row["original_path"],
+                        result_path=row["result_path"],
+                        metadata=json.loads(row["metadata"]) if row["metadata"] else {},
+                    )
+                )
+
             return records
-    
+
     def get_full_chain(self, file_hash: str) -> Dict[str, Any]:
         """
         Get complete lineage chain (ancestors + descendants).
-        
+
         Args:
             file_hash: SHA-256 hash to query
-        
+
         Returns:
             Dictionary with ancestors, hash, and descendants
         """
@@ -291,51 +293,51 @@ class LineageTracker:
         ancestors = []
         current = file_hash
         visited = {current}
-        
+
         while True:
             parents = self.get_ancestors(current)
             if not parents:
                 break
-            
+
             # Take most recent parent
             parent = parents[0]
             if parent.original_hash in visited:
                 break  # Circular reference
-            
+
             ancestors.insert(0, parent)
             visited.add(parent.original_hash)
             current = parent.original_hash
-        
+
         # Recursively walk forward to find all descendants
         descendants = []
         to_visit = [file_hash]
         visited = {file_hash}
-        
+
         while to_visit:
             current = to_visit.pop(0)
             children = self.get_descendants(current)
-            
+
             for child in children:
                 if child.result_hash not in visited:
                     descendants.append(child)
                     visited.add(child.result_hash)
                     to_visit.append(child.result_hash)
-        
+
         return {
             "root_hash": ancestors[0].original_hash if ancestors else file_hash,
             "query_hash": file_hash,
             "ancestors": [a.to_dict() for a in ancestors],
             "descendants": [d.to_dict() for d in descendants],
-            "chain_length": len(ancestors) + len(descendants) + 1
+            "chain_length": len(ancestors) + len(descendants) + 1,
         }
-    
+
     def get_by_operation(self, operation: OperationType) -> List[FileLineage]:
         """
         Get all lineage records for a specific operation type.
-        
+
         Args:
             operation: Operation type to filter by
-        
+
         Returns:
             List of matching lineage records
         """
@@ -347,59 +349,61 @@ class LineageTracker:
                 WHERE operation = ? 
                 ORDER BY timestamp DESC
                 """,
-                (operation.value,)
+                (operation.value,),
             )
-            
+
             records = []
             for row in cursor:
-                records.append(FileLineage(
-                    original_hash=row['original_hash'],
-                    result_hash=row['result_hash'],
-                    operation=OperationType(row['operation']),
-                    timestamp=row['timestamp'],
-                    original_path=row['original_path'],
-                    result_path=row['result_path'],
-                    metadata=json.loads(row['metadata']) if row['metadata'] else {}
-                ))
-            
+                records.append(
+                    FileLineage(
+                        original_hash=row["original_hash"],
+                        result_hash=row["result_hash"],
+                        operation=OperationType(row["operation"]),
+                        timestamp=row["timestamp"],
+                        original_path=row["original_path"],
+                        result_path=row["result_path"],
+                        metadata=json.loads(row["metadata"]) if row["metadata"] else {},
+                    )
+                )
+
             return records
-    
+
     def export_chain_json(self, file_hash: str) -> str:
         """
         Export lineage chain as JSON for court documentation.
-        
+
         Args:
             file_hash: Hash to generate chain for
-        
+
         Returns:
             JSON string with complete chain-of-custody
         """
         chain = self.get_full_chain(file_hash)
-        
+
         # Add forensic metadata
         export = {
             "lineage_export": {
                 "version": "1.0",
-                "export_timestamp": datetime.utcnow().isoformat() + 'Z',
+                "export_timestamp": datetime.utcnow().isoformat() + "Z",
                 "query_hash": file_hash,
-                "chain": chain
+                "chain": chain,
             }
         }
-        
+
         return json.dumps(export, indent=2)
-    
+
     def export_chain_report(self, file_hash: str) -> str:
         """
         Export human-readable chain-of-custody report.
-        
+
         Args:
             file_hash: Hash to generate report for
-        
+
         Returns:
             Formatted report suitable for court documentation
         """
         chain = self.get_full_chain(file_hash)
-        
+
         lines = [
             "=" * 70,
             "FORENSIC CHAIN-OF-CUSTODY REPORT",
@@ -413,87 +417,82 @@ class LineageTracker:
             "=" * 70,
             "LINEAGE CHAIN",
             "=" * 70,
-            ""
+            "",
         ]
-        
+
         # Show ancestors (backward chain)
-        if chain['ancestors']:
+        if chain["ancestors"]:
             lines.append("BACKWARD CHAIN (Origins):")
             lines.append("-" * 70)
-            for i, record in enumerate(chain['ancestors'], 1):
+            for i, record in enumerate(chain["ancestors"], 1):
                 lines.append(f"\n{i}. {record['operation'].upper()}")
                 lines.append(f"   Timestamp:     {record['timestamp']}")
                 lines.append(f"   Original Hash: {record['original_hash']}")
                 lines.append(f"   Result Hash:   {record['result_hash']}")
-                if record['original_path']:
+                if record["original_path"]:
                     lines.append(f"   Original Path: {record['original_path']}")
-                if record['result_path']:
+                if record["result_path"]:
                     lines.append(f"   Result Path:   {record['result_path']}")
-                if record['metadata']:
+                if record["metadata"]:
                     lines.append(f"   Metadata:      {json.dumps(record['metadata'])}")
             lines.append("")
-        
+
         # Current file
         lines.append("=" * 70)
         lines.append(f"CURRENT FILE: {file_hash}")
         lines.append("=" * 70)
         lines.append("")
-        
+
         # Show descendants (forward chain)
-        if chain['descendants']:
+        if chain["descendants"]:
             lines.append("FORWARD CHAIN (Derived Files):")
             lines.append("-" * 70)
-            for i, record in enumerate(chain['descendants'], 1):
+            for i, record in enumerate(chain["descendants"], 1):
                 lines.append(f"\n{i}. {record['operation'].upper()}")
                 lines.append(f"   Timestamp:     {record['timestamp']}")
                 lines.append(f"   Original Hash: {record['original_hash']}")
                 lines.append(f"   Result Hash:   {record['result_hash']}")
-                if record['original_path']:
+                if record["original_path"]:
                     lines.append(f"   Original Path: {record['original_path']}")
-                if record['result_path']:
+                if record["result_path"]:
                     lines.append(f"   Result Path:   {record['result_path']}")
-                if record['metadata']:
+                if record["metadata"]:
                     lines.append(f"   Metadata:      {json.dumps(record['metadata'])}")
             lines.append("")
-        
-        lines.extend([
-            "=" * 70,
-            "END OF CHAIN-OF-CUSTODY REPORT",
-            "=" * 70
-        ])
-        
+
+        lines.extend(["=" * 70, "END OF CHAIN-OF-CUSTODY REPORT", "=" * 70])
+
         return "\n".join(lines)
-    
+
     def clear_all(self):
         """Clear all lineage records (use with caution)"""
         with sqlite3.connect(self.db_path) as conn:
             conn.execute("DELETE FROM lineage")
-    
+
     def get_stats(self) -> Dict[str, Any]:
         """Get lineage database statistics"""
         with sqlite3.connect(self.db_path) as conn:
             total = conn.execute("SELECT COUNT(*) FROM lineage").fetchone()[0]
-            
+
             by_operation = {}
             for op in OperationType:
                 count = conn.execute(
-                    "SELECT COUNT(*) FROM lineage WHERE operation = ?",
-                    (op.value,)
+                    "SELECT COUNT(*) FROM lineage WHERE operation = ?", (op.value,)
                 ).fetchone()[0]
                 by_operation[op.value] = count
-            
+
             oldest = conn.execute(
                 "SELECT timestamp FROM lineage ORDER BY timestamp ASC LIMIT 1"
             ).fetchone()
-            
+
             newest = conn.execute(
                 "SELECT timestamp FROM lineage ORDER BY timestamp DESC LIMIT 1"
             ).fetchone()
-            
+
             return {
                 "total_records": total,
                 "by_operation": by_operation,
                 "oldest_record": oldest[0] if oldest else None,
                 "newest_record": newest[0] if newest else None,
-                "database_path": str(self.db_path)
+                "database_path": str(self.db_path),
             }

--- a/filo/lineage.py
+++ b/filo/lineage.py
@@ -70,7 +70,7 @@ class LineageTracker:
     cryptographic hashes across all file transformations.
     """
 
-    def __init__(self, db_path: Optional[Path] = None):
+    def __init__(self, db_path: Optional[Path] = None) -> None:
         """
         Initialize lineage tracker.
 
@@ -85,7 +85,7 @@ class LineageTracker:
 
         self._init_database()
 
-    def _init_database(self):
+    def _init_database(self) -> None:
         """Initialize SQLite database schema"""
         with sqlite3.connect(self.db_path) as conn:
             conn.execute("""
@@ -127,7 +127,7 @@ class LineageTracker:
         operation: OperationType,
         original_path: Optional[str] = None,
         result_path: Optional[str] = None,
-        **metadata,
+        **metadata: Any,
     ) -> FileLineage:
         """
         Record a file transformation.
@@ -179,7 +179,7 @@ class LineageTracker:
         return lineage
 
     def record_from_files(
-        self, original_path: Path, result_path: Path, operation: OperationType, **metadata
+        self, original_path: Path, result_path: Path, operation: OperationType, **metadata: Any
     ) -> FileLineage:
         """
         Record transformation using file paths.
@@ -290,7 +290,7 @@ class LineageTracker:
             Dictionary with ancestors, hash, and descendants
         """
         # Recursively walk backward to find root
-        ancestors = []
+        ancestors: list[FileLineage] = []
         current = file_hash
         visited = {current}
 
@@ -464,7 +464,7 @@ class LineageTracker:
 
         return "\n".join(lines)
 
-    def clear_all(self):
+    def clear_all(self) -> None:
         """Clear all lineage records (use with caution)"""
         with sqlite3.connect(self.db_path) as conn:
             conn.execute("DELETE FROM lineage")

--- a/filo/metadata.py
+++ b/filo/metadata.py
@@ -5,8 +5,7 @@ Extracts EXIF, IPTC, XMP, and other metadata from images and documents.
 
 import struct
 import logging
-from typing import Dict, List, Optional, Any
-from datetime import datetime
+from typing import List, Optional, Any
 from pydantic import BaseModel, Field
 
 logger = logging.getLogger(__name__)
@@ -621,7 +620,7 @@ class JPEGMetadataExtractor:
                             if self._is_suspicious(value):
                                 result.has_suspicious = True
                                 result.suspicious_fields.append(field_name)
-                    except:
+                    except Exception:
                         pass
             
             offset = value_start + length
@@ -726,7 +725,7 @@ class JPEGMetadataExtractor:
                                             value=desc_text,
                                             group="ICC_Profile"
                                         ))
-                            except:
+                            except Exception:
                                 pass
         
         except Exception as e:
@@ -855,7 +854,7 @@ class PNGMetadataExtractor:
                                 if self._is_suspicious(text):
                                     result.has_suspicious = True
                                     result.suspicious_fields.append(keyword)
-                            except:
+                            except Exception:
                                 pass
                 
                 # tIME chunk

--- a/filo/metadata.py
+++ b/filo/metadata.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
 
 class MetadataField(BaseModel):
     """Individual metadata field"""
+
     key: str = Field(description="Metadata field name")
     value: Any = Field(description="Field value")
     group: str = Field(description="Metadata group (e.g., 'EXIF', 'IPTC', 'XMP', 'File')")
@@ -22,16 +23,21 @@ class MetadataField(BaseModel):
 
 class MetadataResult(BaseModel):
     """Complete metadata extraction result"""
+
     format: str = Field(description="File format")
-    fields: List[MetadataField] = Field(default_factory=list, description="Extracted metadata fields")
+    fields: List[MetadataField] = Field(
+        default_factory=list, description="Extracted metadata fields"
+    )
     warnings: List[str] = Field(default_factory=list, description="Parsing warnings")
     has_suspicious: bool = Field(default=False, description="Contains suspicious/hidden data")
-    suspicious_fields: List[str] = Field(default_factory=list, description="List of suspicious field names")
+    suspicious_fields: List[str] = Field(
+        default_factory=list, description="List of suspicious field names"
+    )
 
 
 class JPEGMetadataExtractor:
     """Extract metadata from JPEG files (JFIF, EXIF, IPTC, XMP)"""
-    
+
     # EXIF tag names (most common ones)
     EXIF_TAGS = {
         # TIFF Tags
@@ -45,7 +51,6 @@ class JPEGMetadataExtractor:
         0x0132: "DateTime",
         0x013B: "Artist",
         0x8298: "Copyright",
-        
         # EXIF Tags
         0x829A: "ExposureTime",
         0x829D: "FNumber",
@@ -79,114 +84,122 @@ class JPEGMetadataExtractor:
         0xA300: "FileSource",
         0xA301: "SceneType",
     }
-    
+
     def extract(self, data: bytes) -> MetadataResult:
         """Extract all metadata from JPEG file"""
         result = MetadataResult(format="JPEG")
-        
-        if not data.startswith(b'\xff\xd8\xff'):
+
+        if not data.startswith(b"\xff\xd8\xff"):
             result.warnings.append("Not a valid JPEG file")
             return result
-        
+
         # Track width/height for computed fields
         image_width = None
         image_height = None
         encoding_process = None
         subsampling = None
-        
+
         # Extract basic file info
-        result.fields.append(MetadataField(
-            key="FileType",
-            value="JPEG",
-            group="File",
-            description="JPEG image"
-        ))
-        
-        result.fields.append(MetadataField(
-            key="MIMEType",
-            value="image/jpeg",
-            group="File",
-            description="MIME type"
-        ))
-        
-        result.fields.append(MetadataField(
-            key="FileSize",
-            value=f"{len(data)} bytes",
-            group="File"
-        ))
-        
+        result.fields.append(
+            MetadataField(key="FileType", value="JPEG", group="File", description="JPEG image")
+        )
+
+        result.fields.append(
+            MetadataField(key="MIMEType", value="image/jpeg", group="File", description="MIME type")
+        )
+
+        result.fields.append(
+            MetadataField(key="FileSize", value=f"{len(data)} bytes", group="File")
+        )
+
         # Parse JPEG segments
         offset = 2  # Skip SOI marker (FFD8)
-        
+
         while offset < len(data) - 1:
             # Look for marker
             if data[offset] != 0xFF:
                 break
-            
+
             marker = data[offset + 1]
             offset += 2
-            
+
             # Check for markers without length
             if marker in (0xD8, 0xD9, 0x01) or (0xD0 <= marker <= 0xD7):
                 continue
-            
+
             # EOI marker
             if marker == 0xD9:
                 break
-            
+
             # Read segment length
             if offset + 2 > len(data):
                 break
-            
-            segment_len = struct.unpack('>H', data[offset:offset+2])[0]
-            segment_data = data[offset+2:offset+segment_len]
-            
+
+            segment_len = struct.unpack(">H", data[offset : offset + 2])[0]
+            segment_data = data[offset + 2 : offset + segment_len]
+
             # APP0 - JFIF
-            if marker == 0xE0 and segment_data.startswith(b'JFIF\x00'):
+            if marker == 0xE0 and segment_data.startswith(b"JFIF\x00"):
                 self._extract_jfif(segment_data, result)
-            
+
             # APP1 - EXIF
-            elif marker == 0xE1 and segment_data.startswith(b'Exif\x00\x00'):
+            elif marker == 0xE1 and segment_data.startswith(b"Exif\x00\x00"):
                 self._extract_exif(segment_data[6:], result)
-            
+
             # APP1 - XMP
-            elif marker == 0xE1 and segment_data.startswith(b'http://ns.adobe.com/xap/1.0/\x00'):
+            elif marker == 0xE1 and segment_data.startswith(b"http://ns.adobe.com/xap/1.0/\x00"):
                 self._extract_xmp(segment_data[29:], result)
-            
+
             # APP2 - ICC Profile
-            elif marker == 0xE2 and segment_data.startswith(b'ICC_PROFILE\x00'):
+            elif marker == 0xE2 and segment_data.startswith(b"ICC_PROFILE\x00"):
                 self._extract_icc_profile(segment_data[12:], result)
-            
+
             # APP13 - IPTC/Photoshop
-            elif marker == 0xED and segment_data.startswith(b'Photoshop 3.0\x00'):
+            elif marker == 0xED and segment_data.startswith(b"Photoshop 3.0\x00"):
                 self._extract_iptc(segment_data[14:], result)
-            
+
             # COM - Comment
             elif marker == 0xFE:
-                comment = segment_data.decode('utf-8', errors='ignore').strip()
+                comment = segment_data.decode("utf-8", errors="ignore").strip()
                 if comment:
-                    result.fields.append(MetadataField(
-                        key="Comment",
-                        value=comment,
-                        group="JPEG",
-                        description="JPEG comment marker"
-                    ))
+                    result.fields.append(
+                        MetadataField(
+                            key="Comment",
+                            value=comment,
+                            group="JPEG",
+                            description="JPEG comment marker",
+                        )
+                    )
                     # Check for suspicious patterns
                     if self._is_suspicious(comment):
                         result.has_suspicious = True
                         result.suspicious_fields.append("Comment")
-            
+
             # SOF markers - image info
-            elif marker in (0xC0, 0xC1, 0xC2, 0xC3, 0xC5, 0xC6, 0xC7, 0xC9, 0xCA, 0xCB, 0xCD, 0xCE, 0xCF):
+            elif marker in (
+                0xC0,
+                0xC1,
+                0xC2,
+                0xC3,
+                0xC5,
+                0xC6,
+                0xC7,
+                0xC9,
+                0xCA,
+                0xCB,
+                0xCD,
+                0xCE,
+                0xCF,
+            ):
                 if len(segment_data) >= 6:
                     bits_per_sample = segment_data[0]
-                    height = struct.unpack('>H', segment_data[1:3])[0]
-                    width = struct.unpack('>H', segment_data[3:5])[0]
+                    height = struct.unpack(">H", segment_data[1:3])[0]
+                    width = struct.unpack(">H", segment_data[3:5])[0]
                     num_components = segment_data[5]
-                    
+
                     image_width = width
                     image_height = height
-                    
+
                     # Determine encoding process
                     sof_types = {
                         0xC0: "Baseline DCT, Huffman coding",
@@ -201,10 +214,10 @@ class JPEGMetadataExtractor:
                         0xCB: "Lossless, Arithmetic coding",
                         0xCD: "Differential sequential DCT, Arithmetic coding",
                         0xCE: "Differential progressive DCT, Arithmetic coding",
-                        0xCF: "Differential lossless, Arithmetic coding"
+                        0xCF: "Differential lossless, Arithmetic coding",
                     }
                     encoding_process = sof_types.get(marker, f"Unknown SOF marker 0x{marker:02X}")
-                    
+
                     # Extract subsampling if available
                     if len(segment_data) >= 17 and num_components == 3:
                         # YCbCr subsampling
@@ -212,296 +225,291 @@ class JPEGMetadataExtractor:
                         y_v = segment_data[7] & 0x0F
                         cb_h = (segment_data[10] >> 4) & 0x0F
                         cb_v = segment_data[10] & 0x0F
-                        
+
                         subsampling = f"YCbCr4:{cb_h*4//y_h}:{cb_v*4//y_v} ({y_h} {y_v})"
-                    
-                    result.fields.append(MetadataField(
-                        key="ImageWidth",
-                        value=width,
-                        group="JPEG",
-                        description="Image width in pixels"
-                    ))
-                    result.fields.append(MetadataField(
-                        key="ImageHeight",
-                        value=height,
-                        group="JPEG",
-                        description="Image height in pixels"
-                    ))
-                    result.fields.append(MetadataField(
-                        key="EncodingProcess",
-                        value=encoding_process,
-                        group="JPEG"
-                    ))
-                    result.fields.append(MetadataField(
-                        key="BitsPerSample",
-                        value=bits_per_sample,
-                        group="JPEG"
-                    ))
-                    result.fields.append(MetadataField(
-                        key="ColorComponents",
-                        value=num_components,
-                        group="JPEG"
-                    ))
+
+                    result.fields.append(
+                        MetadataField(
+                            key="ImageWidth",
+                            value=width,
+                            group="JPEG",
+                            description="Image width in pixels",
+                        )
+                    )
+                    result.fields.append(
+                        MetadataField(
+                            key="ImageHeight",
+                            value=height,
+                            group="JPEG",
+                            description="Image height in pixels",
+                        )
+                    )
+                    result.fields.append(
+                        MetadataField(key="EncodingProcess", value=encoding_process, group="JPEG")
+                    )
+                    result.fields.append(
+                        MetadataField(key="BitsPerSample", value=bits_per_sample, group="JPEG")
+                    )
+                    result.fields.append(
+                        MetadataField(key="ColorComponents", value=num_components, group="JPEG")
+                    )
                     if subsampling:
-                        result.fields.append(MetadataField(
-                            key="YCbCrSubSampling",
-                            value=subsampling,
-                            group="JPEG"
-                        ))
-            
+                        result.fields.append(
+                            MetadataField(key="YCbCrSubSampling", value=subsampling, group="JPEG")
+                        )
+
             offset += segment_len
-        
+
         # Add computed fields
         if image_width and image_height:
-            result.fields.append(MetadataField(
-                key="ImageSize",
-                value=f"{image_width}x{image_height}",
-                group="Computed"
-            ))
+            result.fields.append(
+                MetadataField(
+                    key="ImageSize", value=f"{image_width}x{image_height}", group="Computed"
+                )
+            )
             megapixels = (image_width * image_height) / 1_000_000
-            result.fields.append(MetadataField(
-                key="Megapixels",
-                value=f"{megapixels:.1f}",
-                group="Computed"
-            ))
-        
+            result.fields.append(
+                MetadataField(key="Megapixels", value=f"{megapixels:.1f}", group="Computed")
+            )
+
         return result
-    
+
     def _extract_jfif(self, data: bytes, result: MetadataResult):
         """Extract JFIF metadata"""
         if len(data) < 14:
             return
-        
+
         version = f"{data[5]}.{data[6]:02d}"
         density_units_map = {0: "None", 1: "inches", 2: "cm"}
         density_units = density_units_map.get(data[7], "Unknown")
-        x_density = struct.unpack('>H', data[8:10])[0]
-        y_density = struct.unpack('>H', data[10:12])[0]
-        
-        result.fields.append(MetadataField(
-            key="JFIFVersion",
-            value=version,
-            group="JFIF"
-        ))
-        result.fields.append(MetadataField(
-            key="ResolutionUnit",
-            value=density_units,
-            group="JFIF"
-        ))
-        result.fields.append(MetadataField(
-            key="XResolution",
-            value=x_density,
-            group="JFIF"
-        ))
-        result.fields.append(MetadataField(
-            key="YResolution",
-            value=y_density,
-            group="JFIF"
-        ))
-    
+        x_density = struct.unpack(">H", data[8:10])[0]
+        y_density = struct.unpack(">H", data[10:12])[0]
+
+        result.fields.append(MetadataField(key="JFIFVersion", value=version, group="JFIF"))
+        result.fields.append(MetadataField(key="ResolutionUnit", value=density_units, group="JFIF"))
+        result.fields.append(MetadataField(key="XResolution", value=x_density, group="JFIF"))
+        result.fields.append(MetadataField(key="YResolution", value=y_density, group="JFIF"))
+
     def _extract_exif(self, data: bytes, result: MetadataResult):
         """Extract EXIF metadata"""
         if len(data) < 8:
             return
-        
+
         # Check byte order
         byte_order = data[0:2]
-        if byte_order == b'II':  # Intel (little-endian)
-            endian = '<'
-        elif byte_order == b'MM':  # Motorola (big-endian)
-            endian = '>'
+        if byte_order == b"II":  # Intel (little-endian)
+            endian = "<"
+        elif byte_order == b"MM":  # Motorola (big-endian)
+            endian = ">"
         else:
             result.warnings.append("Invalid EXIF byte order")
             return
-        
+
         # Verify TIFF magic number
-        magic = struct.unpack(f'{endian}H', data[2:4])[0]
+        magic = struct.unpack(f"{endian}H", data[2:4])[0]
         if magic != 42:
             result.warnings.append("Invalid TIFF magic number in EXIF")
             return
-        
+
         # Get IFD0 offset
-        ifd0_offset = struct.unpack(f'{endian}I', data[4:8])[0]
-        
+        ifd0_offset = struct.unpack(f"{endian}I", data[4:8])[0]
+
         # Parse IFD0
         self._parse_ifd(data, ifd0_offset, endian, result, "EXIF")
-    
+
     def _parse_ifd(self, data: bytes, offset: int, endian: str, result: MetadataResult, group: str):
         """Parse an Image File Directory (IFD)"""
         if offset + 2 > len(data):
             return
-        
-        num_entries = struct.unpack(f'{endian}H', data[offset:offset+2])[0]
+
+        num_entries = struct.unpack(f"{endian}H", data[offset : offset + 2])[0]
         offset += 2
-        
+
         for i in range(num_entries):
             if offset + 12 > len(data):
                 break
-            
-            tag = struct.unpack(f'{endian}H', data[offset:offset+2])[0]
-            field_type = struct.unpack(f'{endian}H', data[offset+2:offset+4])[0]
-            count = struct.unpack(f'{endian}I', data[offset+4:offset+8])[0]
+
+            tag = struct.unpack(f"{endian}H", data[offset : offset + 2])[0]
+            field_type = struct.unpack(f"{endian}H", data[offset + 2 : offset + 4])[0]
+            count = struct.unpack(f"{endian}I", data[offset + 4 : offset + 8])[0]
             value_offset = offset + 8
-            
+
             # Extract value based on type
             value = self._extract_exif_value(data, value_offset, field_type, count, endian)
-            
+
             # Get tag name
             tag_name = self.EXIF_TAGS.get(tag, f"Tag_{tag:04X}")
-            
+
             if value is not None:
-                result.fields.append(MetadataField(
-                    key=tag_name,
-                    value=value,
-                    group=group,
-                    tag_id=tag
-                ))
-                
+                result.fields.append(
+                    MetadataField(key=tag_name, value=value, group=group, tag_id=tag)
+                )
+
                 # Check for suspicious content
                 if isinstance(value, str) and self._is_suspicious(value):
                     result.has_suspicious = True
                     result.suspicious_fields.append(tag_name)
-            
+
             offset += 12
-    
-    def _extract_exif_value(self, data: bytes, offset: int, field_type: int, count: int, endian: str) -> Any:
+
+    def _extract_exif_value(
+        self, data: bytes, offset: int, field_type: int, count: int, endian: str
+    ) -> Any:
         """Extract EXIF field value based on type"""
         try:
             # Type 1: BYTE
             if field_type == 1:
                 if count == 1:
                     return data[offset]
-                return list(data[offset:offset+count])
-            
+                return list(data[offset : offset + count])
+
             # Type 2: ASCII
             elif field_type == 2:
                 if offset + count > len(data):
                     # Value is stored at offset specified in value field
-                    value_offset = struct.unpack(f'{endian}I', data[offset:offset+4])[0]
+                    value_offset = struct.unpack(f"{endian}I", data[offset : offset + 4])[0]
                     if value_offset + count <= len(data):
-                        return data[value_offset:value_offset+count].rstrip(b'\x00').decode('utf-8', errors='ignore')
+                        return (
+                            data[value_offset : value_offset + count]
+                            .rstrip(b"\x00")
+                            .decode("utf-8", errors="ignore")
+                        )
                 else:
-                    return data[offset:offset+count].rstrip(b'\x00').decode('utf-8', errors='ignore')
-            
+                    return (
+                        data[offset : offset + count]
+                        .rstrip(b"\x00")
+                        .decode("utf-8", errors="ignore")
+                    )
+
             # Type 3: SHORT
             elif field_type == 3:
                 if count == 1:
-                    return struct.unpack(f'{endian}H', data[offset:offset+2])[0]
+                    return struct.unpack(f"{endian}H", data[offset : offset + 2])[0]
                 values = []
                 for i in range(min(count, 2)):
-                    values.append(struct.unpack(f'{endian}H', data[offset+i*2:offset+i*2+2])[0])
+                    values.append(
+                        struct.unpack(f"{endian}H", data[offset + i * 2 : offset + i * 2 + 2])[0]
+                    )
                 return values if len(values) > 1 else values[0]
-            
+
             # Type 4: LONG
             elif field_type == 4:
                 if count == 1:
-                    return struct.unpack(f'{endian}I', data[offset:offset+4])[0]
-            
+                    return struct.unpack(f"{endian}I", data[offset : offset + 4])[0]
+
             # Type 5: RATIONAL
             elif field_type == 5:
                 if count == 1:
-                    value_offset = struct.unpack(f'{endian}I', data[offset:offset+4])[0]
+                    value_offset = struct.unpack(f"{endian}I", data[offset : offset + 4])[0]
                     if value_offset + 8 <= len(data):
-                        numerator = struct.unpack(f'{endian}I', data[value_offset:value_offset+4])[0]
-                        denominator = struct.unpack(f'{endian}I', data[value_offset+4:value_offset+8])[0]
+                        numerator = struct.unpack(
+                            f"{endian}I", data[value_offset : value_offset + 4]
+                        )[0]
+                        denominator = struct.unpack(
+                            f"{endian}I", data[value_offset + 4 : value_offset + 8]
+                        )[0]
                         if denominator != 0:
                             return f"{numerator}/{denominator}"
-            
+
             # Type 7: UNDEFINED
             elif field_type == 7:
                 if count <= 4:
-                    return data[offset:offset+count]
-            
+                    return data[offset : offset + count]
+
             # Type 9: SLONG
             elif field_type == 9:
                 if count == 1:
-                    return struct.unpack(f'{endian}i', data[offset:offset+4])[0]
-            
+                    return struct.unpack(f"{endian}i", data[offset : offset + 4])[0]
+
             # Type 10: SRATIONAL
             elif field_type == 10:
                 if count == 1:
-                    value_offset = struct.unpack(f'{endian}I', data[offset:offset+4])[0]
+                    value_offset = struct.unpack(f"{endian}I", data[offset : offset + 4])[0]
                     if value_offset + 8 <= len(data):
-                        numerator = struct.unpack(f'{endian}i', data[value_offset:value_offset+4])[0]
-                        denominator = struct.unpack(f'{endian}i', data[value_offset+4:value_offset+8])[0]
+                        numerator = struct.unpack(
+                            f"{endian}i", data[value_offset : value_offset + 4]
+                        )[0]
+                        denominator = struct.unpack(
+                            f"{endian}i", data[value_offset + 4 : value_offset + 8]
+                        )[0]
                         if denominator != 0:
                             return f"{numerator}/{denominator}"
-        
+
         except Exception as e:
             logger.debug(f"Failed to extract EXIF value: {e}")
-        
+
         return None
-    
+
     def _extract_xmp(self, data: bytes, result: MetadataResult):
         """Extract XMP metadata (parse key fields from XML)"""
         try:
-            xmp = data.decode('utf-8', errors='ignore')
-            
+            xmp = data.decode("utf-8", errors="ignore")
+
             # Extract common XMP fields using simple parsing
             import re
-            
+
             # cc:license - often contains hidden data
             license_match = re.search(r"<cc:license[^>]*rdf:resource=['\"]([^'\"]+)['\"]", xmp)
             if license_match:
                 license_value = license_match.group(1)
-                result.fields.append(MetadataField(
-                    key="License",
-                    value=license_value,
-                    group="XMP",
-                    description="Creative Commons license"
-                ))
+                result.fields.append(
+                    MetadataField(
+                        key="License",
+                        value=license_value,
+                        group="XMP",
+                        description="Creative Commons license",
+                    )
+                )
                 if self._is_suspicious(license_value):
                     result.has_suspicious = True
                     result.suspicious_fields.append("License")
-            
+
             # dc:rights
-            rights_match = re.search(r"<dc:rights>\s*<rdf:Alt>\s*<rdf:li[^>]*>([^<]+)", xmp, re.DOTALL)
+            rights_match = re.search(
+                r"<dc:rights>\s*<rdf:Alt>\s*<rdf:li[^>]*>([^<]+)", xmp, re.DOTALL
+            )
             if rights_match:
                 rights_value = rights_match.group(1).strip()
-                result.fields.append(MetadataField(
-                    key="Rights",
-                    value=rights_value,
-                    group="XMP"
-                ))
-            
+                result.fields.append(MetadataField(key="Rights", value=rights_value, group="XMP"))
+
             # dc:creator
             creator_match = re.search(r"<dc:creator>\s*<rdf:Seq>\s*<rdf:li>([^<]+)", xmp)
             if creator_match:
-                result.fields.append(MetadataField(
-                    key="Creator",
-                    value=creator_match.group(1),
-                    group="XMP"
-                ))
-            
+                result.fields.append(
+                    MetadataField(key="Creator", value=creator_match.group(1), group="XMP")
+                )
+
             # dc:title
-            title_match = re.search(r"<dc:title>\s*<rdf:Alt>\s*<rdf:li[^>]*>([^<]+)", xmp, re.DOTALL)
+            title_match = re.search(
+                r"<dc:title>\s*<rdf:Alt>\s*<rdf:li[^>]*>([^<]+)", xmp, re.DOTALL
+            )
             if title_match:
-                result.fields.append(MetadataField(
-                    key="Title",
-                    value=title_match.group(1).strip(),
-                    group="XMP"
-                ))
-            
+                result.fields.append(
+                    MetadataField(key="Title", value=title_match.group(1).strip(), group="XMP")
+                )
+
             # xmp:CreatorTool / tiff:Software
             tool_match = re.search(r"<(?:xmp:CreatorTool|tiff:Software)>([^<]+)", xmp)
             if tool_match:
-                result.fields.append(MetadataField(
-                    key="XMPToolkit",
-                    value=tool_match.group(1),
-                    group="XMP"
-                ))
-            
+                result.fields.append(
+                    MetadataField(key="XMPToolkit", value=tool_match.group(1), group="XMP")
+                )
+
             # Store full XMP as well (truncated for display)
-            result.fields.append(MetadataField(
-                key="XMP_Raw",
-                value=xmp[:500] if len(xmp) > 500 else xmp,
-                group="XMP",
-                description="Raw XMP metadata (truncated)" if len(xmp) > 500 else "Raw XMP metadata"
-            ))
-            
+            result.fields.append(
+                MetadataField(
+                    key="XMP_Raw",
+                    value=xmp[:500] if len(xmp) > 500 else xmp,
+                    group="XMP",
+                    description=(
+                        "Raw XMP metadata (truncated)" if len(xmp) > 500 else "Raw XMP metadata"
+                    ),
+                )
+            )
+
         except Exception as e:
             result.warnings.append(f"Failed to extract XMP: {e}")
-    
+
     def _extract_iptc(self, data: bytes, result: MetadataResult):
         """Extract IPTC metadata"""
         try:
@@ -509,48 +517,50 @@ class JPEGMetadataExtractor:
             offset = 0
             while offset < len(data) - 12:
                 # Look for 8BIM signature
-                if data[offset:offset+4] == b'8BIM':
-                    resource_id = struct.unpack('>H', data[offset+4:offset+6])[0]
-                    
+                if data[offset : offset + 4] == b"8BIM":
+                    resource_id = struct.unpack(">H", data[offset + 4 : offset + 6])[0]
+
                     # Skip name (pascal string)
-                    name_len = data[offset+6]
+                    name_len = data[offset + 6]
                     # Name length is padded to even
                     name_padding = 1 if name_len % 2 == 0 else 0
                     name_offset = offset + 7 + name_len + name_padding
-                    
+
                     if name_offset + 4 > len(data):
                         break
-                    
+
                     # Resource data size
-                    data_size = struct.unpack('>I', data[name_offset:name_offset+4])[0]
+                    data_size = struct.unpack(">I", data[name_offset : name_offset + 4])[0]
                     data_start = name_offset + 4
-                    
+
                     if data_start + data_size > len(data):
                         break
-                    
+
                     # Resource 0x0404 = IPTC data
                     if resource_id == 0x0404:
-                        iptc_data = data[data_start:data_start+data_size]
+                        iptc_data = data[data_start : data_start + data_size]
                         self._parse_iptc_records(iptc_data, result)
                         return
-                    
+
                     # Move to next resource (pad to even)
                     offset = data_start + data_size
                     if data_size % 2 == 1:
                         offset += 1
                 else:
                     offset += 1
-            
+
             # If we didn't find detailed IPTC, just note presence
-            result.fields.append(MetadataField(
-                key="IPTC",
-                value="Present",
-                group="IPTC",
-                description="IPTC/Photoshop metadata block found"
-            ))
+            result.fields.append(
+                MetadataField(
+                    key="IPTC",
+                    value="Present",
+                    group="IPTC",
+                    description="IPTC/Photoshop metadata block found",
+                )
+            )
         except Exception as e:
             logger.debug(f"Failed to extract IPTC: {e}")
-    
+
     def _parse_iptc_records(self, data: bytes, result: MetadataResult):
         """Parse IPTC records from data"""
         offset = 0
@@ -559,31 +569,31 @@ class JPEGMetadataExtractor:
             if data[offset] != 0x1C:
                 offset += 1
                 continue
-            
-            record_num = data[offset+1]
-            dataset_num = data[offset+2]
-            
+
+            record_num = data[offset + 1]
+            dataset_num = data[offset + 2]
+
             # Get length (can be 2 or 4 bytes)
             if offset + 4 > len(data):
                 break
-            
-            length_bytes = struct.unpack('>H', data[offset+3:offset+5])[0]
-            
+
+            length_bytes = struct.unpack(">H", data[offset + 3 : offset + 5])[0]
+
             # Extended format (length > 32767)
             if length_bytes > 0x7FFF:
                 if offset + 7 > len(data):
                     break
-                length = struct.unpack('>I', data[offset+5:offset+9])[0]
+                length = struct.unpack(">I", data[offset + 5 : offset + 9])[0]
                 value_start = offset + 9
             else:
                 length = length_bytes
                 value_start = offset + 5
-            
+
             if value_start + length > len(data):
                 break
-            
-            value_data = data[value_start:value_start+length]
-            
+
+            value_data = data[value_start : value_start + length]
+
             # Common IPTC fields (Application Record 2)
             if record_num == 2:
                 iptc_fields = {
@@ -602,34 +612,32 @@ class JPEGMetadataExtractor:
                     116: "CopyrightNotice",
                     118: "Contact",
                     120: "Caption",
-                    122: "CaptionWriter"
+                    122: "CaptionWriter",
                 }
-                
+
                 field_name = iptc_fields.get(dataset_num)
                 if field_name:
                     try:
-                        value = value_data.decode('utf-8', errors='ignore').strip()
+                        value = value_data.decode("utf-8", errors="ignore").strip()
                         if value:
-                            result.fields.append(MetadataField(
-                                key=field_name,
-                                value=value,
-                                group="IPTC"
-                            ))
-                            
+                            result.fields.append(
+                                MetadataField(key=field_name, value=value, group="IPTC")
+                            )
+
                             # Check for suspicious content
                             if self._is_suspicious(value):
                                 result.has_suspicious = True
                                 result.suspicious_fields.append(field_name)
                     except Exception:
                         pass
-            
+
             offset = value_start + length
-    
+
     def _extract_icc_profile(self, data: bytes, result: MetadataResult):
         """Extract ICC color profile metadata"""
         if len(data) < 128:
             return
-        
+
         try:
             # ICC Profile header structure
             # Bytes 0-3: Profile size
@@ -638,318 +646,300 @@ class JPEGMetadataExtractor:
             # Bytes 12-15: Profile class
             # Bytes 16-19: Color space
             # Bytes 20-23: PCS (Profile Connection Space)
-            
+
             if len(data) >= 4:
                 # Skip sequence number (first 2 bytes in APP2 ICC)
                 if data[0] in range(1, 256) and data[1] in range(1, 256):
                     data = data[2:]  # Skip sequence marker
-            
+
             if len(data) >= 128:
                 # CMM Type (bytes 4-7)
-                cmm_type = data[4:8].decode('ascii', errors='ignore').strip()
+                cmm_type = data[4:8].decode("ascii", errors="ignore").strip()
                 if cmm_type:
-                    result.fields.append(MetadataField(
-                        key="ProfileCMMType",
-                        value=cmm_type,
-                        group="ICC_Profile"
-                    ))
-                
+                    result.fields.append(
+                        MetadataField(key="ProfileCMMType", value=cmm_type, group="ICC_Profile")
+                    )
+
                 # Profile version (bytes 8-11)
                 if len(data) >= 12:
                     major = data[8]
                     minor = data[9] >> 4
                     patch = data[9] & 0x0F
                     version = f"{major}.{minor}.{patch}"
-                    result.fields.append(MetadataField(
-                        key="ProfileVersion",
-                        value=version,
-                        group="ICC_Profile"
-                    ))
-                
+                    result.fields.append(
+                        MetadataField(key="ProfileVersion", value=version, group="ICC_Profile")
+                    )
+
                 # Profile class (bytes 12-15)
                 if len(data) >= 16:
                     profile_class_map = {
-                        b'scnr': 'Input Device Profile',
-                        b'mntr': 'Display Device Profile',
-                        b'prtr': 'Output Device Profile',
-                        b'link': 'DeviceLink Profile',
-                        b'spac': 'ColorSpace Profile',
-                        b'abst': 'Abstract Profile',
-                        b'nmcl': 'NamedColor Profile'
+                        b"scnr": "Input Device Profile",
+                        b"mntr": "Display Device Profile",
+                        b"prtr": "Output Device Profile",
+                        b"link": "DeviceLink Profile",
+                        b"spac": "ColorSpace Profile",
+                        b"abst": "Abstract Profile",
+                        b"nmcl": "NamedColor Profile",
                     }
                     profile_class_sig = data[12:16]
-                    profile_class = profile_class_map.get(profile_class_sig, profile_class_sig.decode('ascii', errors='ignore'))
-                    result.fields.append(MetadataField(
-                        key="ProfileClass",
-                        value=profile_class,
-                        group="ICC_Profile"
-                    ))
-                
+                    profile_class = profile_class_map.get(
+                        profile_class_sig, profile_class_sig.decode("ascii", errors="ignore")
+                    )
+                    result.fields.append(
+                        MetadataField(key="ProfileClass", value=profile_class, group="ICC_Profile")
+                    )
+
                 # Color space (bytes 16-19)
                 if len(data) >= 20:
-                    color_space = data[16:20].decode('ascii', errors='ignore').strip()
-                    result.fields.append(MetadataField(
-                        key="ColorSpaceData",
-                        value=color_space,
-                        group="ICC_Profile"
-                    ))
-                
+                    color_space = data[16:20].decode("ascii", errors="ignore").strip()
+                    result.fields.append(
+                        MetadataField(key="ColorSpaceData", value=color_space, group="ICC_Profile")
+                    )
+
                 # Profile Connection Space (bytes 20-23)
                 if len(data) >= 24:
-                    pcs = data[20:24].decode('ascii', errors='ignore').strip()
-                    result.fields.append(MetadataField(
-                        key="ProfileConnectionSpace",
-                        value=pcs,
-                        group="ICC_Profile"
-                    ))
-                
+                    pcs = data[20:24].decode("ascii", errors="ignore").strip()
+                    result.fields.append(
+                        MetadataField(key="ProfileConnectionSpace", value=pcs, group="ICC_Profile")
+                    )
+
                 # Copyright (tag 'cprt' - search in tag table)
                 # Profile Description (tag 'desc')
                 if len(data) >= 128:
                     # Simple search for common text tags
-                    desc_start = data.find(b'desc\x00\x00\x00\x00')
+                    desc_start = data.find(b"desc\x00\x00\x00\x00")
                     if desc_start > 0 and desc_start + 12 < len(data):
                         # Try to extract description
-                        desc_offset = struct.unpack('>I', data[desc_start+4:desc_start+8])[0]
-                        desc_size = struct.unpack('>I', data[desc_start+8:desc_start+12])[0]
+                        desc_offset = struct.unpack(">I", data[desc_start + 4 : desc_start + 8])[0]
+                        desc_size = struct.unpack(">I", data[desc_start + 8 : desc_start + 12])[0]
                         if desc_offset < len(data) and desc_size < 1000:
                             try:
                                 # Skip to actual description text (usually has length prefix)
-                                desc_data = data[desc_offset:desc_offset+min(desc_size, 200)]
+                                desc_data = data[desc_offset : desc_offset + min(desc_size, 200)]
                                 if len(desc_data) > 12:
                                     # Skip length prefix and try to extract text
-                                    desc_text = desc_data[12:].split(b'\x00')[0].decode('ascii', errors='ignore')
+                                    desc_text = (
+                                        desc_data[12:]
+                                        .split(b"\x00")[0]
+                                        .decode("ascii", errors="ignore")
+                                    )
                                     if desc_text:
-                                        result.fields.append(MetadataField(
-                                            key="ProfileDescription",
-                                            value=desc_text,
-                                            group="ICC_Profile"
-                                        ))
+                                        result.fields.append(
+                                            MetadataField(
+                                                key="ProfileDescription",
+                                                value=desc_text,
+                                                group="ICC_Profile",
+                                            )
+                                        )
                             except Exception:
                                 pass
-        
+
         except Exception as e:
             logger.debug(f"Failed to extract ICC profile: {e}")
-    
+
     def _is_suspicious(self, text: str) -> bool:
         """Check if text contains suspicious patterns (base64, encoded data, etc.)"""
         if not text:
             return False
-        
+
         # Check for base64-like patterns
         import re
-        
+
         # Long base64 strings (likely encoded data) - reduced threshold for CTF scenarios
-        if re.search(r'[A-Za-z0-9+/]{20,}={0,2}', text):
+        if re.search(r"[A-Za-z0-9+/]{20,}={0,2}", text):
             return True
-        
+
         # Steghide signature
-        if 'steghide' in text.lower():
+        if "steghide" in text.lower():
             return True
-        
+
         # Common encoding prefixes
         suspicious_patterns = [
-            'data:',
-            'base64:',
-            'encrypted:',
-            'hidden:',
-            '0x[0-9a-fA-F]{20,}',
+            "data:",
+            "base64:",
+            "encrypted:",
+            "hidden:",
+            "0x[0-9a-fA-F]{20,}",
         ]
-        
+
         for pattern in suspicious_patterns:
             if re.search(pattern, text, re.IGNORECASE):
                 return True
-        
+
         return False
 
 
 class PNGMetadataExtractor:
     """Extract metadata from PNG files"""
-    
+
     def extract(self, data: bytes) -> MetadataResult:
         """Extract PNG metadata from text chunks"""
         result = MetadataResult(format="PNG")
-        
-        if not data.startswith(b'\x89PNG\r\n\x1a\n'):
+
+        if not data.startswith(b"\x89PNG\r\n\x1a\n"):
             result.warnings.append("Not a valid PNG file")
             return result
-        
-        result.fields.append(MetadataField(
-            key="FileType",
-            value="PNG",
-            group="File"
-        ))
-        
+
+        result.fields.append(MetadataField(key="FileType", value="PNG", group="File"))
+
         offset = 8  # Skip PNG signature
-        
+
         while offset < len(data):
             if offset + 8 > len(data):
                 break
-            
+
             try:
-                chunk_len = struct.unpack('>I', data[offset:offset+4])[0]
-                chunk_type = data[offset+4:offset+8]
-                chunk_data = data[offset+8:offset+8+chunk_len]
-                
+                chunk_len = struct.unpack(">I", data[offset : offset + 4])[0]
+                chunk_type = data[offset + 4 : offset + 8]
+                chunk_data = data[offset + 8 : offset + 8 + chunk_len]
+
                 # IHDR - Image header
-                if chunk_type == b'IHDR' and len(chunk_data) >= 13:
-                    width = struct.unpack('>I', chunk_data[0:4])[0]
-                    height = struct.unpack('>I', chunk_data[4:8])[0]
+                if chunk_type == b"IHDR" and len(chunk_data) >= 13:
+                    width = struct.unpack(">I", chunk_data[0:4])[0]
+                    height = struct.unpack(">I", chunk_data[4:8])[0]
                     bit_depth = chunk_data[8]
                     color_type = chunk_data[9]
-                    
-                    result.fields.append(MetadataField(
-                        key="ImageWidth",
-                        value=width,
-                        group="PNG"
-                    ))
-                    result.fields.append(MetadataField(
-                        key="ImageHeight",
-                        value=height,
-                        group="PNG"
-                    ))
-                    result.fields.append(MetadataField(
-                        key="BitDepth",
-                        value=bit_depth,
-                        group="PNG"
-                    ))
-                    result.fields.append(MetadataField(
-                        key="ColorType",
-                        value=color_type,
-                        group="PNG"
-                    ))
-                
+
+                    result.fields.append(MetadataField(key="ImageWidth", value=width, group="PNG"))
+                    result.fields.append(
+                        MetadataField(key="ImageHeight", value=height, group="PNG")
+                    )
+                    result.fields.append(
+                        MetadataField(key="BitDepth", value=bit_depth, group="PNG")
+                    )
+                    result.fields.append(
+                        MetadataField(key="ColorType", value=color_type, group="PNG")
+                    )
+
                 # tEXt chunk
-                elif chunk_type == b'tEXt':
-                    null_pos = chunk_data.find(b'\x00')
+                elif chunk_type == b"tEXt":
+                    null_pos = chunk_data.find(b"\x00")
                     if null_pos > 0:
-                        keyword = chunk_data[:null_pos].decode('latin1', errors='ignore')
-                        text = chunk_data[null_pos+1:].decode('latin1', errors='ignore')
-                        
-                        result.fields.append(MetadataField(
-                            key=keyword,
-                            value=text,
-                            group="PNG_Text"
-                        ))
-                        
+                        keyword = chunk_data[:null_pos].decode("latin1", errors="ignore")
+                        text = chunk_data[null_pos + 1 :].decode("latin1", errors="ignore")
+
+                        result.fields.append(
+                            MetadataField(key=keyword, value=text, group="PNG_Text")
+                        )
+
                         if self._is_suspicious(text):
                             result.has_suspicious = True
                             result.suspicious_fields.append(keyword)
-                
+
                 # zTXt chunk (compressed text)
-                elif chunk_type == b'zTXt':
-                    null_pos = chunk_data.find(b'\x00')
+                elif chunk_type == b"zTXt":
+                    null_pos = chunk_data.find(b"\x00")
                     if null_pos > 0:
-                        keyword = chunk_data[:null_pos].decode('latin1', errors='ignore')
+                        keyword = chunk_data[:null_pos].decode("latin1", errors="ignore")
                         if len(chunk_data) > null_pos + 2:
                             import zlib
+
                             try:
-                                text = zlib.decompress(chunk_data[null_pos+2:]).decode('latin1', errors='ignore')
-                                result.fields.append(MetadataField(
-                                    key=keyword,
-                                    value=text,
-                                    group="PNG_Text"
-                                ))
-                                
+                                text = zlib.decompress(chunk_data[null_pos + 2 :]).decode(
+                                    "latin1", errors="ignore"
+                                )
+                                result.fields.append(
+                                    MetadataField(key=keyword, value=text, group="PNG_Text")
+                                )
+
                                 if self._is_suspicious(text):
                                     result.has_suspicious = True
                                     result.suspicious_fields.append(keyword)
                             except Exception:
                                 pass
-                
+
                 # tIME chunk
-                elif chunk_type == b'tIME' and len(chunk_data) >= 7:
-                    year = struct.unpack('>H', chunk_data[0:2])[0]
+                elif chunk_type == b"tIME" and len(chunk_data) >= 7:
+                    year = struct.unpack(">H", chunk_data[0:2])[0]
                     month = chunk_data[2]
                     day = chunk_data[3]
                     hour = chunk_data[4]
                     minute = chunk_data[5]
                     second = chunk_data[6]
-                    time_str = f"{year:04d}-{month:02d}-{day:02d} {hour:02d}:{minute:02d}:{second:02d}"
-                    
-                    result.fields.append(MetadataField(
-                        key="ModificationTime",
-                        value=time_str,
-                        group="PNG"
-                    ))
-                
+                    time_str = (
+                        f"{year:04d}-{month:02d}-{day:02d} {hour:02d}:{minute:02d}:{second:02d}"
+                    )
+
+                    result.fields.append(
+                        MetadataField(key="ModificationTime", value=time_str, group="PNG")
+                    )
+
                 # pHYs chunk - physical pixel dimensions
-                elif chunk_type == b'pHYs' and len(chunk_data) >= 9:
-                    x_pixels = struct.unpack('>I', chunk_data[0:4])[0]
-                    y_pixels = struct.unpack('>I', chunk_data[4:8])[0]
+                elif chunk_type == b"pHYs" and len(chunk_data) >= 9:
+                    x_pixels = struct.unpack(">I", chunk_data[0:4])[0]
+                    y_pixels = struct.unpack(">I", chunk_data[4:8])[0]
                     unit = chunk_data[8]
-                    
+
                     unit_str = "meters" if unit == 1 else "unknown"
-                    result.fields.append(MetadataField(
-                        key="PixelsPerUnit",
-                        value=f"{x_pixels}x{y_pixels} per {unit_str}",
-                        group="PNG"
-                    ))
-                
+                    result.fields.append(
+                        MetadataField(
+                            key="PixelsPerUnit",
+                            value=f"{x_pixels}x{y_pixels} per {unit_str}",
+                            group="PNG",
+                        )
+                    )
+
                 # IEND - end of PNG
-                elif chunk_type == b'IEND':
+                elif chunk_type == b"IEND":
                     break
-                
+
                 offset += 12 + chunk_len
-            
+
             except Exception as e:
                 logger.debug(f"Error parsing PNG chunk at offset {offset}: {e}")
                 break
-        
+
         return result
-    
+
     def _is_suspicious(self, text: str) -> bool:
         """Check if text contains suspicious patterns"""
         if not text:
             return False
-        
+
         import re
-        
+
         # Base64-like patterns - reduced threshold for CTF scenarios
-        if re.search(r'[A-Za-z0-9+/]{20,}={0,2}', text):
+        if re.search(r"[A-Za-z0-9+/]{20,}={0,2}", text):
             return True
-        
+
         # Steghide
-        if 'steghide' in text.lower():
+        if "steghide" in text.lower():
             return True
-        
+
         return False
 
 
 def extract_metadata(data: bytes, format_hint: Optional[str] = None) -> MetadataResult:
     """
     Extract metadata from file.
-    
+
     Args:
         data: File data or path
         format_hint: Optional format hint ('jpeg', 'png', etc.)
-    
+
     Returns:
         MetadataResult with extracted fields
     """
     # If data is a string, treat it as a file path
     if isinstance(data, str):
-        with open(data, 'rb') as f:
+        with open(data, "rb") as f:
             data = f.read()
-    
+
     # Auto-detect format
     if format_hint is None:
-        if data.startswith(b'\xff\xd8\xff'):
-            format_hint = 'jpeg'
-        elif data.startswith(b'\x89PNG'):
-            format_hint = 'png'
-    
+        if data.startswith(b"\xff\xd8\xff"):
+            format_hint = "jpeg"
+        elif data.startswith(b"\x89PNG"):
+            format_hint = "png"
+
     # Extract based on format
-    if format_hint == 'jpeg' or data.startswith(b'\xff\xd8\xff'):
+    if format_hint == "jpeg" or data.startswith(b"\xff\xd8\xff"):
         extractor = JPEGMetadataExtractor()
         return extractor.extract(data)
-    
-    elif format_hint == 'png' or data.startswith(b'\x89PNG'):
+
+    elif format_hint == "png" or data.startswith(b"\x89PNG"):
         extractor = PNGMetadataExtractor()
         return extractor.extract(data)
-    
+
     # Unsupported format
-    return MetadataResult(
-        format="unknown",
-        warnings=["Unsupported format for metadata extraction"]
-    )
+    return MetadataResult(format="unknown", warnings=["Unsupported format for metadata extraction"])

--- a/filo/metadata.py
+++ b/filo/metadata.py
@@ -317,7 +317,9 @@ class JPEGMetadataExtractor:
         # Parse IFD0
         self._parse_ifd(data, ifd0_offset, endian, result, "EXIF")
 
-    def _parse_ifd(self, data: bytes, offset: int, endian: str, result: MetadataResult, group: str) -> None:
+    def _parse_ifd(
+        self, data: bytes, offset: int, endian: str, result: MetadataResult, group: str
+    ) -> None:
         """Parse an Image File Directory (IFD)"""
         if offset + 2 > len(data):
             return

--- a/filo/metadata.py
+++ b/filo/metadata.py
@@ -274,7 +274,7 @@ class JPEGMetadataExtractor:
 
         return result
 
-    def _extract_jfif(self, data: bytes, result: MetadataResult):
+    def _extract_jfif(self, data: bytes, result: MetadataResult) -> None:
         """Extract JFIF metadata"""
         if len(data) < 14:
             return
@@ -290,7 +290,7 @@ class JPEGMetadataExtractor:
         result.fields.append(MetadataField(key="XResolution", value=x_density, group="JFIF"))
         result.fields.append(MetadataField(key="YResolution", value=y_density, group="JFIF"))
 
-    def _extract_exif(self, data: bytes, result: MetadataResult):
+    def _extract_exif(self, data: bytes, result: MetadataResult) -> None:
         """Extract EXIF metadata"""
         if len(data) < 8:
             return
@@ -317,7 +317,7 @@ class JPEGMetadataExtractor:
         # Parse IFD0
         self._parse_ifd(data, ifd0_offset, endian, result, "EXIF")
 
-    def _parse_ifd(self, data: bytes, offset: int, endian: str, result: MetadataResult, group: str):
+    def _parse_ifd(self, data: bytes, offset: int, endian: str, result: MetadataResult, group: str) -> None:
         """Parse an Image File Directory (IFD)"""
         if offset + 2 > len(data):
             return
@@ -440,7 +440,7 @@ class JPEGMetadataExtractor:
 
         return None
 
-    def _extract_xmp(self, data: bytes, result: MetadataResult):
+    def _extract_xmp(self, data: bytes, result: MetadataResult) -> None:
         """Extract XMP metadata (parse key fields from XML)"""
         try:
             xmp = data.decode("utf-8", errors="ignore")
@@ -510,7 +510,7 @@ class JPEGMetadataExtractor:
         except Exception as e:
             result.warnings.append(f"Failed to extract XMP: {e}")
 
-    def _extract_iptc(self, data: bytes, result: MetadataResult):
+    def _extract_iptc(self, data: bytes, result: MetadataResult) -> None:
         """Extract IPTC metadata"""
         try:
             # IPTC uses 8BIM resource blocks
@@ -561,7 +561,7 @@ class JPEGMetadataExtractor:
         except Exception as e:
             logger.debug(f"Failed to extract IPTC: {e}")
 
-    def _parse_iptc_records(self, data: bytes, result: MetadataResult):
+    def _parse_iptc_records(self, data: bytes, result: MetadataResult) -> None:
         """Parse IPTC records from data"""
         offset = 0
         while offset < len(data) - 5:
@@ -633,7 +633,7 @@ class JPEGMetadataExtractor:
 
             offset = value_start + length
 
-    def _extract_icc_profile(self, data: bytes, result: MetadataResult):
+    def _extract_icc_profile(self, data: bytes, result: MetadataResult) -> None:
         """Extract ICC color profile metadata"""
         if len(data) < 128:
             return
@@ -934,7 +934,7 @@ def extract_metadata(data: bytes, format_hint: Optional[str] = None) -> Metadata
 
     # Extract based on format
     if format_hint == "jpeg" or data.startswith(b"\xff\xd8\xff"):
-        extractor = JPEGMetadataExtractor()
+        extractor: JPEGMetadataExtractor | PNGMetadataExtractor = JPEGMetadataExtractor()
         return extractor.extract(data)
 
     elif format_hint == "png" or data.startswith(b"\x89PNG"):

--- a/filo/ml.py
+++ b/filo/ml.py
@@ -1,12 +1,10 @@
-import json
 import pickle
 import logging
 import zlib
 from pathlib import Path
-from typing import Optional, Dict, List, Tuple, Any
+from typing import Optional, Dict, List, Tuple
 from dataclasses import dataclass, field
 from collections import defaultdict, Counter
-import hashlib
 import math
 
 logger = logging.getLogger(__name__)
@@ -255,7 +253,7 @@ class MLDetector:
         try:
             compressed = zlib.compress(sample, level=6)
             features['compression_ratio'] = len(compressed) / len(sample)
-        except:
+        except Exception:
             features['compression_ratio'] = 1.0
         
         # Longest repeating byte sequence

--- a/filo/ml.py
+++ b/filo/ml.py
@@ -216,7 +216,7 @@ class MLDetector:
             if len(data) < n:
                 continue
 
-            ngrams = Counter()
+            ngrams: Counter[bytes] = Counter()
             for i in range(scan_len - n):
                 ngram = data[i : i + n]
                 # Skip uniform patterns (all same byte)
@@ -234,7 +234,7 @@ class MLDetector:
 
     def extract_features(self, data: bytes) -> Dict[str, float]:
         """Extract comprehensive statistical features from file data."""
-        features = {}
+        features: dict[str, float] = {}
         scan_len = min(8192, len(data))
         sample = data[:scan_len]
 
@@ -295,7 +295,7 @@ class MLDetector:
 
     def build_ngram_profile(self, data: bytes, n: int = 3) -> Dict[bytes, float]:
         """Build normalized n-gram frequency profile."""
-        ngrams = Counter()
+        ngrams: Counter[bytes] = Counter()
         scan_len = min(8192, len(data))
 
         if len(data) < n:

--- a/filo/ml.py
+++ b/filo/ml.py
@@ -34,23 +34,21 @@ class MLDetector:
     def __init__(self, model_path: Optional[Path] = None) -> None:
         if model_path is None:
             model_path = Path.home() / ".filo" / "learned_patterns.pkl"
-        
+
         self.model_path = Path(model_path)
         self.model_path.parent.mkdir(parents=True, exist_ok=True)
-        
+
         self.pattern_weights: Dict[Tuple[int, bytes, str], float] = {}
         self.negative_patterns: Dict[Tuple[int, bytes, str], float] = {}
         self.format_confidence_boost: Dict[str, float] = defaultdict(float)
-        self.format_stats: Dict[str, Dict[str, float]] = defaultdict(lambda: {
-            "count": 0,
-            "avg_entropy": 0.0,
-            "avg_size": 0.0
-        })
+        self.format_stats: Dict[str, Dict[str, float]] = defaultdict(
+            lambda: {"count": 0, "avg_entropy": 0.0, "avg_size": 0.0}
+        )
         self.format_features: Dict[str, Dict[str, float]] = defaultdict(dict)
         self.format_ngrams: Dict[str, Dict[bytes, float]] = defaultdict(dict)
-        
+
         self.load_model()
-    
+
     def load_model(self) -> None:
         if self.model_path.exists():
             try:
@@ -58,304 +56,318 @@ class MLDetector:
                     data = pickle.load(f)
                     self.pattern_weights = data.get("patterns", {})
                     self.negative_patterns = data.get("negative_patterns", {})
-                    self.format_confidence_boost = defaultdict(float, data.get("confidence_boost", {}))
+                    self.format_confidence_boost = defaultdict(
+                        float, data.get("confidence_boost", {})
+                    )
                     self.format_stats = defaultdict(
                         lambda: {"count": 0, "avg_entropy": 0.0, "avg_size": 0.0},
-                        data.get("stats", {})
+                        data.get("stats", {}),
                     )
                     self.format_features = defaultdict(dict, data.get("features", {}))
                     self.format_ngrams = defaultdict(dict, data.get("ngrams", {}))
-                logger.info(f"Loaded ML model with {len(self.pattern_weights)} patterns, {len(self.format_ngrams)} n-gram profiles")
+                logger.info(
+                    f"Loaded ML model with {len(self.pattern_weights)} patterns, {len(self.format_ngrams)} n-gram profiles"
+                )
             except Exception as e:
                 logger.warning(f"Failed to load ML model: {e}")
-    
+
     def save_model(self) -> None:
         try:
             with open(self.model_path, "wb") as f:
-                pickle.dump({
-                    "patterns": dict(self.pattern_weights),
-                    "negative_patterns": dict(self.negative_patterns),
-                    "confidence_boost": dict(self.format_confidence_boost),
-                    "stats": dict(self.format_stats),
-                    "features": dict(self.format_features),
-                    "ngrams": dict(self.format_ngrams)
-                }, f)
+                pickle.dump(
+                    {
+                        "patterns": dict(self.pattern_weights),
+                        "negative_patterns": dict(self.negative_patterns),
+                        "confidence_boost": dict(self.format_confidence_boost),
+                        "stats": dict(self.format_stats),
+                        "features": dict(self.format_features),
+                        "ngrams": dict(self.format_ngrams),
+                    },
+                    f,
+                )
             logger.info(f"Saved ML model to {self.model_path}")
         except Exception as e:
             logger.error(f"Failed to save ML model: {e}")
-    
+
     def learn(self, example: LearningExample) -> None:
         for pattern in example.patterns:
             key = (pattern.offset, pattern.pattern, example.correct_format)
             current_weight = self.pattern_weights.get(key, 0.0)
             self.pattern_weights[key] = min(1.0, current_weight + 0.15)
-        
+
         for incorrect_fmt in example.incorrect_formats:
             for pattern in example.patterns:
                 neg_key = (pattern.offset, pattern.pattern, incorrect_fmt)
                 self.negative_patterns[neg_key] = self.negative_patterns.get(neg_key, 0.0) + 0.1
-        
+
         self.format_confidence_boost[example.correct_format] += 0.05
-        
+
         stats = self.format_stats[example.correct_format]
         count = stats["count"]
         stats["avg_entropy"] = (stats["avg_entropy"] * count + example.entropy) / (count + 1)
         stats["avg_size"] = (stats["avg_size"] * count + example.file_size) / (count + 1)
         stats["count"] = count + 1
-        
+
         # Store rich features
         if example.features:
             fmt_features = self.format_features[example.correct_format]
             for feature_name, value in example.features.items():
                 current_avg = fmt_features.get(feature_name, 0.0)
                 fmt_features[feature_name] = (current_avg * count + value) / (count + 1)
-        
+
         # Store n-gram profile
         if example.ngram_profile:
             self.format_ngrams[example.correct_format] = example.ngram_profile
-        
+
         self.save_model()
-    
+
     def predict(self, data: bytes, entropy: float, file_size: int) -> List[Tuple[str, float]]:
         if not self.pattern_weights and not self.format_ngrams:
             return []
-        
+
         format_scores: Dict[str, float] = defaultdict(float)
-        
+
         scan_length = min(8192, len(data))
-        
+
         # Pattern matching
         for (offset, pattern, fmt), weight in self.pattern_weights.items():
             if offset >= scan_length:
                 continue
-            
+
             end_offset = offset + len(pattern)
             if end_offset <= len(data) and data[offset:end_offset] == pattern:
                 format_scores[fmt] += weight
-                
+
                 neg_key = (offset, pattern, fmt)
                 if neg_key in self.negative_patterns:
                     format_scores[fmt] -= self.negative_patterns[neg_key] * 0.5
-        
+
         # Statistical features matching
         for fmt, stats in self.format_stats.items():
             if stats["count"] < 3:
                 continue
-            
+
             entropy_diff = abs(entropy - stats["avg_entropy"])
             size_ratio = min(file_size, stats["avg_size"]) / max(file_size, stats["avg_size"], 1)
-            
+
             if entropy_diff < 2.0:
                 format_scores[fmt] += 0.2
             if size_ratio > 0.5:
                 format_scores[fmt] += 0.1
-        
+
         # Rich features matching
         if self.format_features:
             file_features = self.extract_features(data)
             for fmt, fmt_features in self.format_features.items():
                 feature_similarity = self._compare_features(file_features, fmt_features)
                 format_scores[fmt] += feature_similarity * 0.3
-        
+
         # N-gram profile matching
         if self.format_ngrams:
             file_ngrams = self.build_ngram_profile(data, n=3)
             for fmt, fmt_ngrams in self.format_ngrams.items():
                 ngram_similarity = self.ngram_similarity(file_ngrams, fmt_ngrams)
                 format_scores[fmt] += ngram_similarity * 0.4
-        
+
         for fmt in format_scores:
             format_scores[fmt] += self.format_confidence_boost.get(fmt, 0.0)
-        
+
         results = sorted(format_scores.items(), key=lambda x: x[1], reverse=True)
-        
+
         if results:
             max_score = results[0][1]
             if max_score > 0:
                 results = [(fmt, min(1.0, score / max_score)) for fmt, score in results]
-        
+
         return results[:3]
-    
+
     def extract_patterns(self, data: bytes, max_patterns: int = 10) -> List[bytes]:
         patterns = []
-        
+
         for size in [4, 8, 16]:
             for offset in range(0, min(1024, len(data) - size), size):
-                pattern = data[offset:offset + size]
+                pattern = data[offset : offset + size]
                 if len(set(pattern)) > 1:
                     patterns.append(pattern)
-        
+
         return patterns[:max_patterns]
-    
-    def extract_discriminative_patterns(self, data: bytes, max_patterns: int = 20) -> List[PatternMatch]:
+
+    def extract_discriminative_patterns(
+        self, data: bytes, max_patterns: int = 20
+    ) -> List[PatternMatch]:
         """Extract discriminative patterns automatically from file data."""
         patterns = []
-        
+
         # Header patterns (first 32 bytes in chunks)
         if len(data) >= 32:
             for size in [4, 8, 12, 16]:
                 if len(data) >= size:
                     patterns.append(PatternMatch(0, data[:size], "", 1.0))
-        
+
         # Footer patterns (last 16 bytes)
         if len(data) >= 64:
             patterns.append(PatternMatch(len(data) - 16, data[-16:], "", 0.7))
-        
+
         # Extract frequent n-grams (discriminative sequences)
         scan_len = min(8192, len(data))
         ngram_sizes = [4, 8, 12]
-        
+
         for n in ngram_sizes:
             if len(data) < n:
                 continue
-                
+
             ngrams = Counter()
             for i in range(scan_len - n):
-                ngram = data[i:i+n]
+                ngram = data[i : i + n]
                 # Skip uniform patterns (all same byte)
                 if len(set(ngram)) > 2:
                     ngrams[ngram] += 1
-            
+
             # Keep most frequent ngrams that appear multiple times
             for ngram, count in ngrams.most_common(5):
                 if count >= 2:
                     offset = data.find(ngram)
                     weight = min(0.9, 0.4 + (count * 0.1))
                     patterns.append(PatternMatch(offset, ngram, "", weight))
-        
+
         return patterns[:max_patterns]
-    
+
     def extract_features(self, data: bytes) -> Dict[str, float]:
         """Extract comprehensive statistical features from file data."""
         features = {}
         scan_len = min(8192, len(data))
         sample = data[:scan_len]
-        
+
         if not sample:
             return features
-        
+
         # Byte frequency distribution
         byte_counts = [0] * 256
         for byte in sample:
             byte_counts[byte] += 1
-        
+
         # Basic statistics
-        features['null_byte_ratio'] = byte_counts[0] / len(sample)
-        features['printable_ratio'] = sum(1 for b in sample if 32 <= b < 127) / len(sample)
-        features['high_byte_ratio'] = sum(1 for b in sample if b >= 128) / len(sample)
-        
+        features["null_byte_ratio"] = byte_counts[0] / len(sample)
+        features["printable_ratio"] = sum(1 for b in sample if 32 <= b < 127) / len(sample)
+        features["high_byte_ratio"] = sum(1 for b in sample if b >= 128) / len(sample)
+
         # Byte distribution variance (measure of randomness)
         mean_count = len(sample) / 256
         variance = sum((count - mean_count) ** 2 for count in byte_counts) / 256
-        features['byte_variance'] = variance
-        
+        features["byte_variance"] = variance
+
         # Compression ratio (compressed formats won't compress further)
         try:
             compressed = zlib.compress(sample, level=6)
-            features['compression_ratio'] = len(compressed) / len(sample)
+            features["compression_ratio"] = len(compressed) / len(sample)
         except Exception:
-            features['compression_ratio'] = 1.0
-        
+            features["compression_ratio"] = 1.0
+
         # Longest repeating byte sequence
-        features['max_repeat_length'] = self._find_longest_repeat(sample)
-        
+        features["max_repeat_length"] = self._find_longest_repeat(sample)
+
         # ASCII/text heuristic
-        features['likely_text'] = 1.0 if features['printable_ratio'] > 0.7 else 0.0
-        
+        features["likely_text"] = 1.0 if features["printable_ratio"] > 0.7 else 0.0
+
         # Entropy calculation (if not already provided)
         if len(sample) > 0:
             byte_probs = [count / len(sample) for count in byte_counts if count > 0]
-            features['entropy'] = -sum(p * math.log2(p) for p in byte_probs if p > 0)
-        
+            features["entropy"] = -sum(p * math.log2(p) for p in byte_probs if p > 0)
+
         return features
-    
+
     def _find_longest_repeat(self, data: bytes, max_len: int = 256) -> int:
         """Find the longest sequence of repeating bytes."""
         if not data:
             return 0
-        
+
         max_repeat = 0
         current_repeat = 1
-        
+
         for i in range(1, min(len(data), 1024)):
             if data[i] == data[i - 1]:
                 current_repeat += 1
                 max_repeat = max(max_repeat, current_repeat)
             else:
                 current_repeat = 1
-        
+
         return min(max_repeat, max_len)
-    
+
     def build_ngram_profile(self, data: bytes, n: int = 3) -> Dict[bytes, float]:
         """Build normalized n-gram frequency profile."""
         ngrams = Counter()
         scan_len = min(8192, len(data))
-        
+
         if len(data) < n:
             return {}
-        
+
         for i in range(scan_len - n):
-            ngrams[data[i:i+n]] += 1
-        
+            ngrams[data[i : i + n]] += 1
+
         total = sum(ngrams.values())
         if total == 0:
             return {}
-        
+
         # Keep top 100 most frequent n-grams
         return {ng: count / total for ng, count in ngrams.most_common(100)}
-    
+
     def ngram_similarity(self, profile1: Dict[bytes, float], profile2: Dict[bytes, float]) -> float:
         """Calculate cosine similarity between n-gram profiles."""
         if not profile1 or not profile2:
             return 0.0
-        
+
         common_keys = set(profile1.keys()) & set(profile2.keys())
         if not common_keys:
             return 0.0
-        
+
         dot_product = sum(profile1[k] * profile2[k] for k in common_keys)
-        
+
         mag1 = math.sqrt(sum(v * v for v in profile1.values()))
         mag2 = math.sqrt(sum(v * v for v in profile2.values()))
-        
+
         if mag1 == 0 or mag2 == 0:
             return 0.0
-        
+
         return dot_product / (mag1 * mag2)
-    
+
     def _compare_features(self, features1: Dict[str, float], features2: Dict[str, float]) -> float:
         """Compare feature dictionaries and return similarity score."""
         if not features1 or not features2:
             return 0.0
-        
+
         common_keys = set(features1.keys()) & set(features2.keys())
         if not common_keys:
             return 0.0
-        
+
         differences = []
         for key in common_keys:
             val1 = features1[key]
             val2 = features2[key]
-            
+
             # Normalize difference based on the scale
-            if key in ['compression_ratio', 'printable_ratio', 'null_byte_ratio', 'high_byte_ratio', 'likely_text']:
+            if key in [
+                "compression_ratio",
+                "printable_ratio",
+                "null_byte_ratio",
+                "high_byte_ratio",
+                "likely_text",
+            ]:
                 # These are 0-1 range
                 diff = abs(val1 - val2)
-            elif key == 'entropy':
+            elif key == "entropy":
                 # 0-8 range
                 diff = abs(val1 - val2) / 8.0
-            elif key == 'byte_variance':
+            elif key == "byte_variance":
                 # Normalize by max expected variance
                 diff = abs(val1 - val2) / 10000.0
-            elif key == 'max_repeat_length':
+            elif key == "max_repeat_length":
                 # Normalize by 256
                 diff = abs(val1 - val2) / 256.0
             else:
                 diff = abs(val1 - val2)
-            
+
             differences.append(diff)
-        
+
         # Average similarity (1 - average difference)
         avg_diff = sum(differences) / len(differences) if differences else 1.0
         return max(0.0, 1.0 - avg_diff)
-

--- a/filo/models.py
+++ b/filo/models.py
@@ -5,20 +5,28 @@ from pydantic import BaseModel, Field
 
 class YARAMatchInfo(BaseModel):
     """Result from YARA rule scanning"""
+
     rule: str = Field(description="YARA rule name")
     namespace: str = Field(default="default", description="Rule namespace")
     tags: list[str] = Field(default_factory=list, description="Rule tags")
     meta: dict[str, str] = Field(default_factory=dict, description="Rule metadata")
-    matched_strings: list[dict] = Field(default_factory=list, description="Matched string offsets and data")
+    matched_strings: list[dict] = Field(
+        default_factory=list, description="Matched string offsets and data"
+    )
     description: str = Field(default="", description="Description from meta if available")
 
 
 class OfficeMacroInfo(BaseModel):
     """Information about detected Office macros"""
+
     has_macros: bool = Field(default=False, description="Whether VBA macros were detected")
     macro_count: int = Field(default=0, description="Number of VBA macro modules")
-    auto_exec_macros: list[str] = Field(default_factory=list, description="Auto-executable macro names")
-    suspicious_keywords: list[str] = Field(default_factory=list, description="Suspicious VBA keywords detected")
+    auto_exec_macros: list[str] = Field(
+        default_factory=list, description="Auto-executable macro names"
+    )
+    suspicious_keywords: list[str] = Field(
+        default_factory=list, description="Suspicious VBA keywords detected"
+    )
     keyword_count: int = Field(default=0, description="Count of suspicious keywords")
     app_name: Optional[str] = Field(default=None, description="Detected Office application")
     is_encrypted: bool = Field(default=False, description="Whether document is encrypted")
@@ -27,6 +35,7 @@ class OfficeMacroInfo(BaseModel):
 
 class PolyglotMatch(BaseModel):
     """File valid as multiple formats simultaneously"""
+
     formats: List[str] = Field(description="List of valid formats")
     pattern: str = Field(description="Polyglot pattern name (e.g., 'gifar', 'png_zip')")
     confidence: float = Field(ge=0.0, le=1.0, description="Detection confidence")
@@ -37,17 +46,21 @@ class PolyglotMatch(BaseModel):
 
 class Fingerprint(BaseModel):
     """Tool/creator attribution fingerprint"""
+
     category: str = Field(description="Fingerprint category (e.g., 'zip_creator', 'pdf_producer')")
     tool: Optional[str] = Field(default=None, description="Tool/application name")
     version: Optional[str] = Field(default=None, description="Tool version")
     os_hint: Optional[str] = Field(default=None, description="Operating system hint")
-    timestamp: Optional[datetime] = Field(default=None, description="Creation/modification timestamp")
+    timestamp: Optional[datetime] = Field(
+        default=None, description="Creation/modification timestamp"
+    )
     confidence: float = Field(ge=0.0, le=1.0, description="Fingerprint confidence")
     evidence: str = Field(description="Technical evidence for this fingerprint")
 
 
 class EmbeddedObject(BaseModel):
     """File embedded within another file"""
+
     offset: int = Field(description="Byte offset where embedded object starts")
     format: str = Field(description="Detected format of embedded object")
     confidence: float = Field(ge=0.0, le=1.0, description="Detection confidence")
@@ -58,15 +71,19 @@ class EmbeddedObject(BaseModel):
 
 class Signature(BaseModel):
     """File signature specification"""
+
     offset: int = Field(description="Byte offset from file start")
     hex: str = Field(description="Hex string signature (e.g., '89504E47')")
     description: str = Field(description="Human-readable description")
     weight: float = Field(default=1.0, ge=0.0, le=1.0, description="Confidence weight")
-    offset_max: Optional[int] = Field(default=None, description="Maximum offset to scan (creates range from offset to offset_max)")
+    offset_max: Optional[int] = Field(
+        default=None, description="Maximum offset to scan (creates range from offset to offset_max)"
+    )
 
 
 class ChunkSpec(BaseModel):
     """Chunk/block specification for structured formats"""
+
     id: str = Field(description="Chunk identifier")
     required: bool = Field(default=False, description="Whether chunk is required")
     position: Optional[int] = Field(default=None, description="Expected position in file")
@@ -76,6 +93,7 @@ class ChunkSpec(BaseModel):
 
 class Structure(BaseModel):
     """File structure specification"""
+
     chunks: list[ChunkSpec] = Field(default_factory=list, description="Chunk specifications")
     endianness: Optional[str] = Field(default=None, description="big or little")
     header_size: Optional[int] = Field(default=None, description="Fixed header size in bytes")
@@ -83,12 +101,14 @@ class Structure(BaseModel):
 
 class Footer(BaseModel):
     """File footer signature"""
+
     hex: str = Field(description="Hex string signature")
     description: str = Field(description="Human-readable description")
 
 
 class Template(BaseModel):
     """Header generation template"""
+
     hex: str = Field(description="Template hex with {{variable}} placeholders")
     variables: dict[str, str] = Field(
         default_factory=dict, description="Variable types (e.g., uint32be)"
@@ -97,6 +117,7 @@ class Template(BaseModel):
 
 class RepairStrategy(BaseModel):
     """Repair strategy specification"""
+
     name: str = Field(description="Strategy function name")
     priority: int = Field(description="Priority order (lower = higher priority)")
     description: Optional[str] = Field(default=None, description="Strategy description")
@@ -104,6 +125,7 @@ class RepairStrategy(BaseModel):
 
 class ValidationCommand(BaseModel):
     """External validation command"""
+
     command: list[str] = Field(description="Command with {file} placeholder")
     success_codes: list[int] = Field(default_factory=lambda: [0], description="Success exit codes")
     description: str = Field(description="Validation description")
@@ -111,6 +133,7 @@ class ValidationCommand(BaseModel):
 
 class FormatSpec(BaseModel):
     """Complete file format specification"""
+
     format: str = Field(description="Format identifier (e.g., 'png')")
     version: str = Field(description="Format version")
     mime: list[str] = Field(description="MIME types")
@@ -119,29 +142,29 @@ class FormatSpec(BaseModel):
         default=0.9, ge=0.0, le=1.0, description="Overall format confidence weight"
     )
     extensions: list[str] = Field(default_factory=list, description="Common file extensions")
-    
+
     # Detection
     signatures: list[Signature] = Field(default_factory=list, description="File signatures")
     footers: list[Footer] = Field(default_factory=list, description="Footer signatures")
-    
+
     # Structure
     structure: Optional[Structure] = Field(default=None, description="File structure")
-    
+
     # Templates
     templates: dict[str, Template] = Field(
         default_factory=dict, description="Header generation templates"
     )
-    
+
     # Repair
     repair_strategies: list[RepairStrategy] = Field(
         default_factory=list, description="Repair strategies"
     )
-    
+
     # Validation
     validation: list[ValidationCommand] = Field(
         default_factory=list, description="External validation commands"
     )
-    
+
     # Metadata
     description: Optional[str] = Field(default=None, description="Format description")
     references: list[str] = Field(default_factory=list, description="Specification URLs")
@@ -150,15 +173,23 @@ class FormatSpec(BaseModel):
 
 class ConfidenceContribution(BaseModel):
     """Individual contribution to confidence score"""
-    source: str = Field(description="Source of contribution (e.g., 'signature', 'structure', 'container', 'ml')")
+
+    source: str = Field(
+        description="Source of contribution (e.g., 'signature', 'structure', 'container', 'ml')"
+    )
     value: float = Field(description="Contribution value (can be positive or negative)")
     description: str = Field(description="Human-readable description of what contributed")
-    is_penalty: bool = Field(default=False, description="Whether this is a penalty (negative contribution)")
+    is_penalty: bool = Field(
+        default=False, description="Whether this is a penalty (negative contribution)"
+    )
 
 
 class ArchitectureInfo(BaseModel):
     """CPU architecture information from executable file"""
-    architecture: str = Field(description="CPU architecture name (e.g., 'x86-64', 'ARM64', 'Xtensa')")
+
+    architecture: str = Field(
+        description="CPU architecture name (e.g., 'x86-64', 'ARM64', 'Xtensa')"
+    )
     bits: str = Field(description="Address width: '32-bit', '64-bit', etc.")
     endian: str = Field(description="Byte order: 'Little-endian' or 'Big-endian'")
     machine_code: int = Field(description="Machine type code from executable header")
@@ -167,6 +198,7 @@ class ArchitectureInfo(BaseModel):
 
 class Contradiction(BaseModel):
     """Detected format contradiction or structural anomaly"""
+
     severity: str = Field(description="Severity level: 'warning', 'error', 'critical'")
     claimed_format: str = Field(description="Format the file claims to be")
     issue: str = Field(description="What's wrong or contradictory")
@@ -176,18 +208,19 @@ class Contradiction(BaseModel):
 
 class DetectionResult(BaseModel):
     """Result of format detection"""
+
     format: str
     confidence: float = Field(ge=0.0, le=1.0)
     evidence: list[str] = Field(default_factory=list, description="Supporting evidence")
     contributions: list[ConfidenceContribution] = Field(
-        default_factory=list, 
-        description="Detailed breakdown of confidence contributions"
+        default_factory=list, description="Detailed breakdown of confidence contributions"
     )
     weight: float = Field(default=1.0, description="Module weight")
 
 
 class AnalysisResult(BaseModel):
     """Complete analysis result"""
+
     primary_format: str
     confidence: float = Field(ge=0.0, le=1.0)
     alternative_formats: list[tuple[str, float]] = Field(
@@ -214,9 +247,7 @@ class AnalysisResult(BaseModel):
     crypto_analysis: Optional[Dict[str, Any]] = Field(
         default=None, description="Cryptographic analysis results"
     )
-    yara_matches: list[YARAMatchInfo] = Field(
-        default_factory=list, description="YARA rule matches"
-    )
+    yara_matches: list[YARAMatchInfo] = Field(default_factory=list, description="YARA rule matches")
     office_macros: Optional[OfficeMacroInfo] = Field(
         default=None, description="Office VBA macro analysis"
     )

--- a/filo/models.py
+++ b/filo/models.py
@@ -10,7 +10,7 @@ class YARAMatchInfo(BaseModel):
     namespace: str = Field(default="default", description="Rule namespace")
     tags: list[str] = Field(default_factory=list, description="Rule tags")
     meta: dict[str, str] = Field(default_factory=dict, description="Rule metadata")
-    matched_strings: list[dict] = Field(
+    matched_strings: list[dict[str, Any]] = Field(
         default_factory=list, description="Matched string offsets and data"
     )
     description: str = Field(default="", description="Description from meta if available")

--- a/filo/office.py
+++ b/filo/office.py
@@ -174,7 +174,9 @@ def _parse_ole2_directory(data: bytes) -> list[tuple[str, int, int]]:
     return entries
 
 
-def _extract_ole_stream(data: bytes, start_sector: int, stream_size: int, fat: list[int], sector_size: int) -> bytes:
+def _extract_ole_stream(
+    data: bytes, start_sector: int, stream_size: int, fat: list[int], sector_size: int
+) -> bytes:
     if stream_size == 0:
         return b""
     result = bytearray()
@@ -198,7 +200,9 @@ def _extract_ole_stream(data: bytes, start_sector: int, stream_size: int, fat: l
     return bytes(result)
 
 
-def _detect_vba_in_entries(entries: list[tuple[str, int, int]], data: bytes, fat: list[int], sector_size: int) -> list[MacroStream]:
+def _detect_vba_in_entries(
+    entries: list[tuple[str, int, int]], data: bytes, fat: list[int], sector_size: int
+) -> list[MacroStream]:
     vba_streams = []
     for name, start, size in entries:
         if "VBA" in name or name.endswith("Module"):
@@ -263,13 +267,9 @@ def analyze_office_file(data: bytes) -> OfficeAnalysisResult:
         result.app_name = "OLE2 Storage"
 
     # Check for VBA project streams
-    has_vba = any(
-        "VBA" in n or n.endswith(("Module", "Class1"))
-        for n in vba_names
-    )
+    has_vba = any("VBA" in n or n.endswith(("Module", "Class1")) for n in vba_names)
     project_stream = any(
-        n in vba_names
-        for n in ["_VBA_PROJECT", "VBA/", "VBA/ThisDocument", "VBA/Module1"]
+        n in vba_names for n in ["_VBA_PROJECT", "VBA/", "VBA/ThisDocument", "VBA/Module1"]
     )
 
     result.has_macros = has_vba or project_stream
@@ -277,7 +277,8 @@ def analyze_office_file(data: bytes) -> OfficeAnalysisResult:
     if result.has_macros:
         # Count macro modules
         macro_modules = [
-            n for n in vba_names
+            n
+            for n in vba_names
             if n.startswith("VBA/Module") or n.startswith("Module") or n == "ThisDocument"
         ]
         result.macro_count = len(macro_modules)

--- a/filo/office.py
+++ b/filo/office.py
@@ -95,16 +95,16 @@ def _parse_ole2_directory(data: bytes) -> list[tuple[str, int, int]]:
         return []
 
     # Parse OLE2 header
-    minor_version = struct.unpack_from("<H", data, 24)[0]
-    major_version = struct.unpack_from("<H", data, 26)[0]
+    struct.unpack_from("<H", data, 24)[0]
+    struct.unpack_from("<H", data, 26)[0]
     sector_shift = struct.unpack_from("<H", data, 30)[0]
     mini_sector_shift = struct.unpack_from("<H", data, 32)[0]
-    num_dir_sectors = struct.unpack_from("<I", data, 40)[0]
-    num_fat_sectors = struct.unpack_from("<I", data, 44)[0]
+    struct.unpack_from("<I", data, 40)[0]
+    struct.unpack_from("<I", data, 44)[0]
     first_dir_sector = struct.unpack_from("<I", data, 48)[0]
 
     sector_size = 1 << sector_shift
-    mini_sector_size = 1 << mini_sector_shift
+    1 << mini_sector_shift
 
     # Read DIFAT (Double Indirect FAT)
     # For simplicity, read first 109 FAT sectors from header
@@ -142,21 +142,21 @@ def _parse_ole2_directory(data: bytes) -> list[tuple[str, int, int]]:
             name_buf = data[dir_offset : dir_offset + 64]
             name_len = struct.unpack_from("<H", data, dir_offset + 64)[0]
             obj_type = data[dir_offset + 66]
-            color = data[dir_offset + 67]
-            left_sibling = struct.unpack_from("<I", data, dir_offset + 68)[0]
-            right_sibling = struct.unpack_from("<I", data, dir_offset + 72)[0]
-            child = struct.unpack_from("<I", data, dir_offset + 76)[0]
-            clsid = data[dir_offset + 80 : dir_offset + 96]
-            state_bits = struct.unpack_from("<I", data, dir_offset + 96)[0]
-            creation = struct.unpack_from("<Q", data, dir_offset + 100)[0]
-            modified = struct.unpack_from("<Q", data, dir_offset + 108)[0]
+            data[dir_offset + 67]
+            struct.unpack_from("<I", data, dir_offset + 68)[0]
+            struct.unpack_from("<I", data, dir_offset + 72)[0]
+            struct.unpack_from("<I", data, dir_offset + 76)[0]
+            data[dir_offset + 80 : dir_offset + 96]
+            struct.unpack_from("<I", data, dir_offset + 96)[0]
+            struct.unpack_from("<Q", data, dir_offset + 100)[0]
+            struct.unpack_from("<Q", data, dir_offset + 108)[0]
             start_sector = struct.unpack_from("<I", data, dir_offset + 116)[0]
             stream_size = struct.unpack_from("<Q", data, dir_offset + 120)[0]
 
             if name_len > 0:
                 try:
                     name = name_buf[: name_len - 2].decode("utf-16-le", errors="replace")
-                except:
+                except Exception:
                     name = ""
             else:
                 name = ""
@@ -235,8 +235,8 @@ def analyze_office_file(data: bytes) -> OfficeAnalysisResult:
     result.is_ole2 = True
 
     # Parse basic OLE2 structure
-    minor_version = struct.unpack_from("<H", data, 24)[0]
-    major_version = struct.unpack_from("<H", data, 26)[0]
+    struct.unpack_from("<H", data, 24)[0]
+    struct.unpack_from("<H", data, 26)[0]
     sector_shift = struct.unpack_from("<H", data, 30)[0]
     sector_size = 1 << sector_shift
 
@@ -295,7 +295,7 @@ def analyze_office_file(data: bytes) -> OfficeAnalysisResult:
                         result.auto_exec_macros = _scan_for_auto_exec(source)
                         result.suspicious_keywords = _scan_for_keywords(source)
                         result.keyword_count = len(result.suspicious_keywords)
-                    except:
+                    except Exception:
                         pass
 
         # Scan additional module streams for patterns
@@ -318,7 +318,7 @@ def analyze_office_file(data: bytes) -> OfficeAnalysisResult:
                             if k not in result.suspicious_keywords:
                                 result.suspicious_keywords.append(k)
                                 result.keyword_count += 1
-                    except:
+                    except Exception:
                         pass
 
     return result

--- a/filo/office.py
+++ b/filo/office.py
@@ -120,7 +120,7 @@ def _parse_ole2_directory(data: bytes) -> list[tuple[str, int, int]]:
         fat_sectors.append(sec_id)
 
     # Read all FAT entries
-    fat = []
+    fat: list[int] = []
     for sec_id in fat_sectors:
         offset = sec_id * sector_size
         if offset + sector_size > len(data):
@@ -129,7 +129,7 @@ def _parse_ole2_directory(data: bytes) -> list[tuple[str, int, int]]:
         fat.extend(entries)
 
     # Read directory entries (128 bytes each)
-    entries = []
+    dir_entries: list[tuple[str, int, int]] = []
     current_sec = first_dir_sector
     while current_sec != 0xFFFFFFFF and current_sec != 0xFFFFFFFE:
         sec_offset = current_sec * sector_size
@@ -162,7 +162,7 @@ def _parse_ole2_directory(data: bytes) -> list[tuple[str, int, int]]:
                 name = ""
 
             if name and obj_type in (1, 2, 5):
-                entries.append((name, start_sector, stream_size))
+                dir_entries.append((name, start_sector, stream_size))
 
         # Move to next directory sector via FAT
         fat_idx = current_sec
@@ -171,7 +171,7 @@ def _parse_ole2_directory(data: bytes) -> list[tuple[str, int, int]]:
         else:
             break
 
-    return entries
+    return dir_entries
 
 
 def _extract_ole_stream(
@@ -330,7 +330,7 @@ def _build_fat(data: bytes, sector_size: int) -> list[int]:
     if len(data) < 512:
         return []
     difat = list(struct.unpack_from("<109I", data, 76))
-    fat = []
+    fat: list[int] = []
     for sec_id in difat:
         if sec_id == 0xFFFFFFFF or sec_id == 0:
             continue

--- a/filo/pcap.py
+++ b/filo/pcap.py
@@ -77,8 +77,8 @@ class PCAPAnalyzer:
                 # Packet header: ts_sec(4) ts_usec(4) incl_len(4) orig_len(4)
                 try:
                     incl_len = struct.unpack(f'{endian}I', data[offset+8:offset+12])[0]
-                    orig_len = struct.unpack(f'{endian}I', data[offset+12:offset+16])[0]
-                except:
+                    struct.unpack(f'{endian}I', data[offset+12:offset+16])[0]
+                except Exception:
                     break
                 
                 offset += 16
@@ -137,7 +137,7 @@ class PCAPAnalyzer:
                 self.protocols['ARP'] += 1
             elif ethertype == 0x86DD:  # IPv6
                 self.protocols['IPv6'] += 1
-        except:
+        except Exception:
             pass
     
     def _analyze_ipv4(self, ip_packet: bytes) -> None:
@@ -154,7 +154,7 @@ class PCAPAnalyzer:
                 self.protocols['UDP'] += 1
             elif protocol == 1:  # ICMP
                 self.protocols['ICMP'] += 1
-        except:
+        except Exception:
             pass
     
     def _extract_strings(self, data: bytes) -> None:
@@ -210,9 +210,9 @@ class PCAPAnalyzer:
                     if all(32 <= b <= 126 or b in (9, 10, 13) for b in decoded):
                         decoded_str = decoded.decode('utf-8', errors='ignore')
                         self.base64_data.append((b64_str[:50], decoded_str))
-                except:
+                except Exception:
                     pass
-        except:
+        except Exception:
             pass
     
     def _extract_flags(self, data: bytes) -> None:
@@ -231,7 +231,7 @@ class PCAPAnalyzer:
             for pattern in patterns:
                 matches = re.findall(pattern, text, re.IGNORECASE)
                 self.flags.extend(matches)
-        except:
+        except Exception:
             pass
     
     def _extract_http(self, data: bytes) -> None:
@@ -248,9 +248,9 @@ class PCAPAnalyzer:
             
             # Also look for Host headers to construct full URLs
             host_pattern = re.compile(r'Host: ([^\r\n]+)')
-            hosts = host_pattern.findall(text)
+            host_pattern.findall(text)
             
-        except:
+        except Exception:
             pass
 
 

--- a/filo/pcap.py
+++ b/filo/pcap.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 @dataclass
 class PCAPStats:
     """Statistics from PCAP analysis."""
+
     packet_count: int
     total_bytes: int
     protocols: Counter
@@ -30,7 +31,7 @@ class PCAPStats:
 
 class PCAPAnalyzer:
     """Analyze PCAP files for CTF challenges."""
-    
+
     def __init__(self):
         self.packet_count = 0
         self.total_bytes = 0
@@ -39,13 +40,13 @@ class PCAPAnalyzer:
         self.base64_data = []
         self.flags = []
         self.http_requests = []
-        
+
     def parse_pcap(self, data: bytes) -> Optional[PCAPStats]:
         """Parse PCAP file and extract relevant information.
-        
+
         Args:
             data: Raw PCAP file data
-            
+
         Returns:
             PCAPStats or None if parsing fails
         """
@@ -53,58 +54,58 @@ class PCAPAnalyzer:
             # Check PCAP magic number
             if len(data) < 24:
                 return None
-            
-            magic = struct.unpack('<I', data[0:4])[0]
-            
+
+            magic = struct.unpack("<I", data[0:4])[0]
+
             # pcap magic numbers (little-endian and big-endian)
-            if magic == 0xa1b2c3d4:
-                endian = '<'  # little-endian
-            elif magic == 0xd4c3b2a1:
-                endian = '>'  # big-endian
+            if magic == 0xA1B2C3D4:
+                endian = "<"  # little-endian
+            elif magic == 0xD4C3B2A1:
+                endian = ">"  # big-endian
             else:
                 return None
-            
+
             # Parse global header
             # magic(4) version_major(2) version_minor(2) thiszone(4) sigfigs(4) snaplen(4) network(4)
             offset = 24
-            
+
             # Parse packets
             payloads = []
             while offset < len(data):
                 if offset + 16 > len(data):
                     break
-                
+
                 # Packet header: ts_sec(4) ts_usec(4) incl_len(4) orig_len(4)
                 try:
-                    incl_len = struct.unpack(f'{endian}I', data[offset+8:offset+12])[0]
-                    struct.unpack(f'{endian}I', data[offset+12:offset+16])[0]
+                    incl_len = struct.unpack(f"{endian}I", data[offset + 8 : offset + 12])[0]
+                    struct.unpack(f"{endian}I", data[offset + 12 : offset + 16])[0]
                 except Exception:
                     break
-                
+
                 offset += 16
-                
+
                 if offset + incl_len > len(data):
                     break
-                
+
                 # Extract packet data
-                packet_data = data[offset:offset+incl_len]
+                packet_data = data[offset : offset + incl_len]
                 payloads.append(packet_data)
-                
+
                 self.packet_count += 1
                 self.total_bytes += incl_len
-                
+
                 # Try to identify protocol
                 self._analyze_packet(packet_data)
-                
+
                 offset += incl_len
-            
+
             # Extract strings from all payloads
-            all_payload = b''.join(payloads)
+            all_payload = b"".join(payloads)
             self._extract_strings(all_payload)
             self._extract_base64(all_payload)
             self._extract_flags(all_payload)
             self._extract_http(all_payload)
-            
+
             return PCAPStats(
                 packet_count=self.packet_count,
                 total_bytes=self.total_bytes,
@@ -113,72 +114,72 @@ class PCAPAnalyzer:
                 base64_data=self.base64_data[:20],
                 flags=self.flags,
                 http_requests=self.http_requests[:20],
-                file_size=len(data)
+                file_size=len(data),
             )
-            
+
         except Exception as e:
             logger.debug(f"PCAP parsing error: {e}")
             return None
-    
+
     def _analyze_packet(self, packet: bytes) -> None:
         """Analyze a single packet to identify protocols."""
         if len(packet) < 14:
             return
-        
+
         # Ethernet header is 14 bytes
         # We can check EtherType (bytes 12-13)
         try:
-            ethertype = struct.unpack('>H', packet[12:14])[0]
-            
+            ethertype = struct.unpack(">H", packet[12:14])[0]
+
             if ethertype == 0x0800:  # IPv4
-                self.protocols['IPv4'] += 1
+                self.protocols["IPv4"] += 1
                 self._analyze_ipv4(packet[14:])
             elif ethertype == 0x0806:  # ARP
-                self.protocols['ARP'] += 1
+                self.protocols["ARP"] += 1
             elif ethertype == 0x86DD:  # IPv6
-                self.protocols['IPv6'] += 1
+                self.protocols["IPv6"] += 1
         except Exception:
             pass
-    
+
     def _analyze_ipv4(self, ip_packet: bytes) -> None:
         """Analyze IPv4 packet."""
         if len(ip_packet) < 20:
             return
-        
+
         try:
             protocol = ip_packet[9]
-            
+
             if protocol == 6:  # TCP
-                self.protocols['TCP'] += 1
+                self.protocols["TCP"] += 1
             elif protocol == 17:  # UDP
-                self.protocols['UDP'] += 1
+                self.protocols["UDP"] += 1
             elif protocol == 1:  # ICMP
-                self.protocols['ICMP'] += 1
+                self.protocols["ICMP"] += 1
         except Exception:
             pass
-    
+
     def _extract_strings(self, data: bytes) -> None:
         """Extract printable ASCII strings."""
         current = []
         min_len = 8
-        
+
         for byte in data:
             if 32 <= byte <= 126:
                 current.append(chr(byte))
             else:
                 if len(current) >= min_len:
-                    s = ''.join(current)
+                    s = "".join(current)
                     # Filter out common noise
-                    if not all(c in '0123456789ABCDEFabcdef' for c in s):
+                    if not all(c in "0123456789ABCDEFabcdef" for c in s):
                         self.strings.append(s)
                 current = []
-        
+
         # Check final string
         if len(current) >= min_len:
-            s = ''.join(current)
-            if not all(c in '0123456789ABCDEFabcdef' for c in s):
+            s = "".join(current)
+            if not all(c in "0123456789ABCDEFabcdef" for c in s):
                 self.strings.append(s)
-        
+
         # Remove duplicates while preserving order
         seen = set()
         unique = []
@@ -187,86 +188,86 @@ class PCAPAnalyzer:
                 seen.add(s)
                 unique.append(s)
         self.strings = unique
-    
+
     def _extract_base64(self, data: bytes) -> None:
         """Extract and decode base64 patterns."""
         import base64
-        
+
         try:
-            text = data.decode('latin-1')
+            text = data.decode("latin-1")
             # Base64 pattern: at least 20 chars
-            pattern = re.compile(r'([A-Za-z0-9+/]{20,}={0,2})')
+            pattern = re.compile(r"([A-Za-z0-9+/]{20,}={0,2})")
             matches = pattern.findall(text)
-            
+
             for b64_str in matches[:20]:  # Limit to first 20
                 try:
                     # Pad if necessary
                     missing = len(b64_str) % 4
                     if missing:
-                        b64_str += '=' * (4 - missing)
-                    
+                        b64_str += "=" * (4 - missing)
+
                     decoded = base64.b64decode(b64_str)
                     # Only keep if it decodes to printable text
                     if all(32 <= b <= 126 or b in (9, 10, 13) for b in decoded):
-                        decoded_str = decoded.decode('utf-8', errors='ignore')
+                        decoded_str = decoded.decode("utf-8", errors="ignore")
                         self.base64_data.append((b64_str[:50], decoded_str))
                 except Exception:
                     pass
         except Exception:
             pass
-    
+
     def _extract_flags(self, data: bytes) -> None:
         """Extract common CTF flag patterns."""
         try:
-            text = data.decode('latin-1')
-            
+            text = data.decode("latin-1")
+
             patterns = [
-                r'picoCTF\{[^}]{5,}\}',
-                r'flag\{[^}]{5,}\}',
-                r'FLAG\{[^}]{5,}\}',
-                r'HTB\{[^}]{5,}\}',
-                r'CTF\{[^}]{5,}\}',
+                r"picoCTF\{[^}]{5,}\}",
+                r"flag\{[^}]{5,}\}",
+                r"FLAG\{[^}]{5,}\}",
+                r"HTB\{[^}]{5,}\}",
+                r"CTF\{[^}]{5,}\}",
             ]
-            
+
             for pattern in patterns:
                 matches = re.findall(pattern, text, re.IGNORECASE)
                 self.flags.extend(matches)
         except Exception:
             pass
-    
+
     def _extract_http(self, data: bytes) -> None:
         """Extract HTTP requests and interesting headers."""
         try:
-            text = data.decode('latin-1')
-            
+            text = data.decode("latin-1")
+
             # Find HTTP request lines
-            http_pattern = re.compile(r'(GET|POST|PUT|DELETE|HEAD|OPTIONS) ([^\s]+) HTTP/[\d.]+')
+            http_pattern = re.compile(r"(GET|POST|PUT|DELETE|HEAD|OPTIONS) ([^\s]+) HTTP/[\d.]+")
             matches = http_pattern.findall(text)
-            
+
             for method, path in matches:
                 self.http_requests.append(f"{method} {path}")
-            
+
             # Also look for Host headers to construct full URLs
-            host_pattern = re.compile(r'Host: ([^\r\n]+)')
+            host_pattern = re.compile(r"Host: ([^\r\n]+)")
             host_pattern.findall(text)
-            
+
         except Exception:
             pass
 
 
 def analyze_pcap(file_path: str) -> Optional[PCAPStats]:
     """Analyze a PCAP file.
-    
+
     Args:
         file_path: Path to PCAP file
-        
+
     Returns:
         PCAPStats or None if not a valid PCAP
     """
     try:
-        with open(file_path, 'rb') as f:
+        with open(file_path, "rb") as f:
             data = f.read()
-        
+
         analyzer = PCAPAnalyzer()
         return analyzer.parse_pcap(data)
     except Exception as e:

--- a/filo/pcap.py
+++ b/filo/pcap.py
@@ -21,7 +21,7 @@ class PCAPStats:
 
     packet_count: int
     total_bytes: int
-    protocols: Counter
+    protocols: Counter[str]
     strings: List[str]
     base64_data: List[Tuple[str, str]]  # (raw, decoded)
     flags: List[str]
@@ -32,14 +32,14 @@ class PCAPStats:
 class PCAPAnalyzer:
     """Analyze PCAP files for CTF challenges."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.packet_count = 0
         self.total_bytes = 0
-        self.protocols = Counter()
-        self.strings = []
-        self.base64_data = []
-        self.flags = []
-        self.http_requests = []
+        self.protocols: Counter[str] = Counter()
+        self.strings: list[str] = []
+        self.base64_data: list[tuple[str, str]] = []
+        self.flags: list[str] = []
+        self.http_requests: list[str] = []
 
     def parse_pcap(self, data: bytes) -> Optional[PCAPStats]:
         """Parse PCAP file and extract relevant information.

--- a/filo/polyglot.py
+++ b/filo/polyglot.py
@@ -9,7 +9,7 @@ from filo.models import PolyglotMatch
 
 class PolyglotDetector:
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.validators = {
             "png": self._validate_png,
             "gif": self._validate_gif,
@@ -111,9 +111,9 @@ class PolyglotDetector:
         if data[12:16] != b"IHDR":
             return False
 
-        ihdr_crc_expected = struct.unpack(">I", data[29:33])[0]
+        ihdr_crc_expected: int = struct.unpack(">I", data[29:33])[0]
         ihdr_data = data[12:29]
-        ihdr_crc_actual = zlib.crc32(ihdr_data) & 0xFFFFFFFF
+        ihdr_crc_actual: int = zlib.crc32(ihdr_data) & 0xFFFFFFFF
 
         return ihdr_crc_expected == ihdr_crc_actual
 

--- a/filo/polyglot.py
+++ b/filo/polyglot.py
@@ -2,7 +2,6 @@
 import struct
 import zlib
 from typing import List, Optional, Set
-from pathlib import Path
 
 from filo.models import PolyglotMatch
 
@@ -53,7 +52,7 @@ class PolyglotDetector:
                 confidence=0.92,
                 description="PDF with embedded JavaScript payload",
                 risk_level="high",
-                evidence=f"Valid PDF + JS payload detected"
+                evidence="Valid PDF + JS payload detected"
             ))
         
         if len(valid_formats) < 2:

--- a/filo/polyglot.py
+++ b/filo/polyglot.py
@@ -1,4 +1,5 @@
 """Polyglot file detection - identifies files valid as multiple formats."""
+
 import struct
 import zlib
 from typing import List, Optional, Set
@@ -7,334 +8,343 @@ from filo.models import PolyglotMatch
 
 
 class PolyglotDetector:
-    
+
     def __init__(self):
         self.validators = {
-            'png': self._validate_png,
-            'gif': self._validate_gif,
-            'jpeg': self._validate_jpeg,
-            'zip': self._validate_zip,
-            'jar': self._validate_jar,
-            'rar': self._validate_rar,
-            'pdf': self._validate_pdf,
-            'pe': self._validate_pe,
-            'elf': self._validate_elf,
+            "png": self._validate_png,
+            "gif": self._validate_gif,
+            "jpeg": self._validate_jpeg,
+            "zip": self._validate_zip,
+            "jar": self._validate_jar,
+            "rar": self._validate_rar,
+            "pdf": self._validate_pdf,
+            "pe": self._validate_pe,
+            "elf": self._validate_elf,
         }
-        
+
         self.polyglot_patterns = {
-            'gifar': ['gif', 'jar'],
-            'gifar_rar': ['gif', 'rar'],
-            'png_zip': ['png', 'zip'],
-            'jpeg_zip': ['jpeg', 'zip'],
-            'pdf_js': ['pdf'],
-            'pe_zip': ['pe', 'zip'],
+            "gifar": ["gif", "jar"],
+            "gifar_rar": ["gif", "rar"],
+            "png_zip": ["png", "zip"],
+            "jpeg_zip": ["jpeg", "zip"],
+            "pdf_js": ["pdf"],
+            "pe_zip": ["pe", "zip"],
         }
-    
-    def detect_polyglots(self, data: bytes, primary_format: Optional[str] = None) -> List[PolyglotMatch]:
+
+    def detect_polyglots(
+        self, data: bytes, primary_format: Optional[str] = None
+    ) -> List[PolyglotMatch]:
         """
         Detect all polyglot format combinations.
-        
+
         Args:
             data: File data to analyze
             primary_format: Optional hint for primary format
-        
+
         Returns:
             List of detected polyglot combinations
         """
         polyglots = []
-        
+
         valid_formats = self._get_valid_formats(data)
-        
-        if 'pdf' in valid_formats and self._has_js_payload(data):
-            polyglots.append(PolyglotMatch(
-                formats=sorted(['pdf', 'javascript']),
-                pattern='pdf_js',
-                confidence=0.92,
-                description="PDF with embedded JavaScript payload",
-                risk_level="high",
-                evidence="Valid PDF + JS payload detected"
-            ))
-        
+
+        if "pdf" in valid_formats and self._has_js_payload(data):
+            polyglots.append(
+                PolyglotMatch(
+                    formats=sorted(["pdf", "javascript"]),
+                    pattern="pdf_js",
+                    confidence=0.92,
+                    description="PDF with embedded JavaScript payload",
+                    risk_level="high",
+                    evidence="Valid PDF + JS payload detected",
+                )
+            )
+
         if len(valid_formats) < 2:
             return polyglots
-        
+
         for pattern_name, required_formats in self.polyglot_patterns.items():
-            if pattern_name == 'pdf_js':
+            if pattern_name == "pdf_js":
                 continue
-                
+
             if all(fmt in valid_formats for fmt in required_formats):
                 confidence = self._calculate_polyglot_confidence(data, required_formats)
                 risk = self._assess_risk(pattern_name, required_formats)
-                
-                polyglots.append(PolyglotMatch(
-                    formats=sorted(required_formats),
-                    pattern=pattern_name,
-                    confidence=confidence,
-                    description=self._get_pattern_description(pattern_name),
-                    risk_level=risk,
-                    evidence=f"Valid as: {', '.join(required_formats)}"
-                ))
-        
+
+                polyglots.append(
+                    PolyglotMatch(
+                        formats=sorted(required_formats),
+                        pattern=pattern_name,
+                        confidence=confidence,
+                        description=self._get_pattern_description(pattern_name),
+                        risk_level=risk,
+                        evidence=f"Valid as: {', '.join(required_formats)}",
+                    )
+                )
+
         other_combinations = self._find_other_combinations(valid_formats, polyglots)
         polyglots.extend(other_combinations)
-        
+
         return polyglots
-    
+
     def _get_valid_formats(self, data: bytes) -> Set[str]:
         """Run all validators and return set of valid formats."""
         valid = set()
-        
+
         for format_name, validator in self.validators.items():
             try:
                 if validator(data):
                     valid.add(format_name)
             except Exception:
                 pass
-        
+
         return valid
-    
+
     def _validate_png(self, data: bytes) -> bool:
         """Validate PNG format."""
         if len(data) < 33:
             return False
-        
-        if data[:8] != b'\x89PNG\r\n\x1a\n':
+
+        if data[:8] != b"\x89PNG\r\n\x1a\n":
             return False
-        
-        if data[12:16] != b'IHDR':
+
+        if data[12:16] != b"IHDR":
             return False
-        
-        ihdr_crc_expected = struct.unpack('>I', data[29:33])[0]
+
+        ihdr_crc_expected = struct.unpack(">I", data[29:33])[0]
         ihdr_data = data[12:29]
-        ihdr_crc_actual = zlib.crc32(ihdr_data) & 0xffffffff
-        
+        ihdr_crc_actual = zlib.crc32(ihdr_data) & 0xFFFFFFFF
+
         return ihdr_crc_expected == ihdr_crc_actual
-    
+
     def _validate_gif(self, data: bytes) -> bool:
         """Validate GIF format."""
         if len(data) < 13:
             return False
-        
-        if data[:3] not in (b'GIF', ):
+
+        if data[:3] not in (b"GIF",):
             return False
-        
-        if data[3:6] not in (b'87a', b'89a'):
+
+        if data[3:6] not in (b"87a", b"89a"):
             return False
-        
-        width = struct.unpack('<H', data[6:8])[0]
-        height = struct.unpack('<H', data[8:10])[0]
-        
+
+        width = struct.unpack("<H", data[6:8])[0]
+        height = struct.unpack("<H", data[8:10])[0]
+
         if width == 0 or height == 0 or width > 65535 or height > 65535:
             return False
-        
+
         return True
-    
+
     def _validate_jpeg(self, data: bytes) -> bool:
         """Validate JPEG format."""
         if len(data) < 4:
             return False
-        
-        if data[:2] != b'\xff\xd8':
+
+        if data[:2] != b"\xff\xd8":
             return False
-        
+
         pos = 2
         found_sos = False
-        
+
         while pos < len(data) - 1:
             if data[pos] != 0xFF:
                 break
-            
+
             marker = data[pos + 1]
-            
+
             if marker == 0xD9:
                 return True
-            
+
             if marker == 0xDA:
                 found_sos = True
-            
+
             if marker in (0xD0, 0xD1, 0xD2, 0xD3, 0xD4, 0xD5, 0xD6, 0xD7, 0xD8):
                 pos += 2
                 continue
-            
+
             if pos + 3 >= len(data):
                 break
-            
-            length = struct.unpack('>H', data[pos + 2:pos + 4])[0]
+
+            length = struct.unpack(">H", data[pos + 2 : pos + 4])[0]
             pos += 2 + length
-        
+
         return found_sos
-    
+
     def _validate_zip(self, data: bytes) -> bool:
         """Validate ZIP format."""
         if len(data) < 22:
             return False
-        
-        has_local_header = data[:4] == b'PK\x03\x04'
-        
-        eocd_pos = data.rfind(b'PK\x05\x06')
+
+        has_local_header = data[:4] == b"PK\x03\x04"
+
+        eocd_pos = data.rfind(b"PK\x05\x06")
         if eocd_pos == -1:
             return has_local_header
-        
+
         if len(data) - eocd_pos < 22:
             return has_local_header
-        
+
         return True
-    
+
     def _validate_jar(self, data: bytes) -> bool:
         """Validate JAR format (ZIP with manifest)."""
         if not self._validate_zip(data):
             return False
-        
-        if b'META-INF/MANIFEST.MF' in data:
+
+        if b"META-INF/MANIFEST.MF" in data:
             return True
-        
+
         return False
-    
+
     def _validate_rar(self, data: bytes) -> bool:
         """Validate RAR format."""
         if len(data) < 7:
             return False
-        
-        if data[:7] == b'Rar!\x1a\x07\x00':
+
+        if data[:7] == b"Rar!\x1a\x07\x00":
             return True
-        
-        if data[:8] == b'Rar!\x1a\x07\x01\x00':
+
+        if data[:8] == b"Rar!\x1a\x07\x01\x00":
             return True
-        
+
         return False
-    
+
     def _validate_pdf(self, data: bytes) -> bool:
         """Validate PDF format."""
         if len(data) < 8:
             return False
-        
-        if not data[:4] == b'%PDF':
+
+        if not data[:4] == b"%PDF":
             return False
-        
-        if b'%%EOF' in data[-1024:]:
+
+        if b"%%EOF" in data[-1024:]:
             return True
-        
-        return b'/Type' in data[:2048]
-    
+
+        return b"/Type" in data[:2048]
+
     def _validate_pe(self, data: bytes) -> bool:
         """Validate PE format."""
         if len(data) < 64:
             return False
-        
-        if data[:2] != b'MZ':
+
+        if data[:2] != b"MZ":
             return False
-        
+
         pe_offset_pos = 60
         if len(data) < pe_offset_pos + 4:
             return False
-        
-        pe_offset = struct.unpack('<I', data[pe_offset_pos:pe_offset_pos + 4])[0]
-        
+
+        pe_offset = struct.unpack("<I", data[pe_offset_pos : pe_offset_pos + 4])[0]
+
         if pe_offset == 0 or pe_offset > len(data) - 4:
-            return data[:2] == b'MZ'
-        
+            return data[:2] == b"MZ"
+
         if len(data) < pe_offset + 4:
-            return data[:2] == b'MZ'
-        
-        return data[pe_offset:pe_offset + 2] == b'PE'
-    
+            return data[:2] == b"MZ"
+
+        return data[pe_offset : pe_offset + 2] == b"PE"
+
     def _validate_elf(self, data: bytes) -> bool:
         """Validate ELF format."""
         if len(data) < 52:
             return False
-        
-        if data[:4] != b'\x7fELF':
+
+        if data[:4] != b"\x7fELF":
             return False
-        
+
         ei_class = data[4]
         if ei_class not in (1, 2):
             return False
-        
+
         ei_data = data[5]
         if ei_data not in (1, 2):
             return False
-        
+
         return True
-    
+
     def _has_js_payload(self, data: bytes) -> bool:
         """Check if PDF contains JavaScript payload."""
         if not self._validate_pdf(data):
             return False
-        
+
         js_indicators = [
-            b'/JavaScript',
-            b'/JS',
-            b'/AA',
-            b'/OpenAction',
-            b'eval(',
-            b'unescape(',
-            b'String.fromCharCode',
+            b"/JavaScript",
+            b"/JS",
+            b"/AA",
+            b"/OpenAction",
+            b"eval(",
+            b"unescape(",
+            b"String.fromCharCode",
         ]
-        
-        search_data = data[:min(len(data), 100000)]
-        
+
+        search_data = data[: min(len(data), 100000)]
+
         matches = sum(1 for indicator in js_indicators if indicator in search_data)
-        
+
         return matches >= 2
-    
+
     def _calculate_polyglot_confidence(self, data: bytes, formats: List[str]) -> float:
         """Calculate confidence score for polyglot detection."""
         base_confidence = 0.85
-        
+
         validations_passed = sum(
-            1 for fmt in formats 
-            if fmt in self.validators and self.validators[fmt](data)
+            1 for fmt in formats if fmt in self.validators and self.validators[fmt](data)
         )
-        
+
         confidence = base_confidence + (validations_passed * 0.03)
-        
+
         return min(confidence, 0.98)
-    
+
     def _assess_risk(self, pattern: str, formats: List[str]) -> str:
         """Assess security risk level of polyglot."""
-        high_risk_patterns = ['gifar', 'gifar_rar', 'pdf_js', 'pe_zip']
-        medium_risk_patterns = ['png_zip', 'jpeg_zip']
-        
+        high_risk_patterns = ["gifar", "gifar_rar", "pdf_js", "pe_zip"]
+        medium_risk_patterns = ["png_zip", "jpeg_zip"]
+
         if pattern in high_risk_patterns:
-            return 'high'
+            return "high"
         elif pattern in medium_risk_patterns:
-            return 'medium'
+            return "medium"
         else:
-            return 'low'
-    
+            return "low"
+
     def _get_pattern_description(self, pattern: str) -> str:
         """Get human-readable description of polyglot pattern."""
         descriptions = {
-            'gifar': 'GIF + JAR hybrid (GIFAR attack)',
-            'gifar_rar': 'GIF + RAR hybrid',
-            'png_zip': 'PNG + ZIP hybrid',
-            'jpeg_zip': 'JPEG + ZIP hybrid',
-            'pdf_js': 'PDF with JavaScript payload',
-            'pe_zip': 'PE executable + ZIP hybrid',
+            "gifar": "GIF + JAR hybrid (GIFAR attack)",
+            "gifar_rar": "GIF + RAR hybrid",
+            "png_zip": "PNG + ZIP hybrid",
+            "jpeg_zip": "JPEG + ZIP hybrid",
+            "pdf_js": "PDF with JavaScript payload",
+            "pe_zip": "PE executable + ZIP hybrid",
         }
         return descriptions.get(pattern, f"{pattern.upper()} polyglot")
-    
-    def _find_other_combinations(self, valid_formats: Set[str], existing: List[PolyglotMatch]) -> List[PolyglotMatch]:
+
+    def _find_other_combinations(
+        self, valid_formats: Set[str], existing: List[PolyglotMatch]
+    ) -> List[PolyglotMatch]:
         """Find polyglot combinations not covered by known patterns."""
         polyglots = []
         existing_combos = {tuple(sorted(p.formats)) for p in existing}
-        
+
         format_list = sorted(valid_formats)
-        
+
         for i, fmt1 in enumerate(format_list):
-            for fmt2 in format_list[i + 1:]:
+            for fmt2 in format_list[i + 1 :]:
                 combo = tuple(sorted([fmt1, fmt2]))
-                
+
                 if combo not in existing_combos:
-                    risk = 'medium' if any(f in ['pe', 'elf', 'pdf'] for f in combo) else 'low'
-                    
-                    polyglots.append(PolyglotMatch(
-                        formats=list(combo),
-                        pattern=f"{combo[0]}_{combo[1]}",
-                        confidence=0.82,
-                        description=f"Valid as {combo[0].upper()} and {combo[1].upper()}",
-                        risk_level=risk,
-                        evidence=f"Dual-format file: {combo[0]}, {combo[1]}"
-                    ))
-        
+                    risk = "medium" if any(f in ["pe", "elf", "pdf"] for f in combo) else "low"
+
+                    polyglots.append(
+                        PolyglotMatch(
+                            formats=list(combo),
+                            pattern=f"{combo[0]}_{combo[1]}",
+                            confidence=0.82,
+                            description=f"Valid as {combo[0].upper()} and {combo[1].upper()}",
+                            risk_level=risk,
+                            evidence=f"Dual-format file: {combo[0]}, {combo[1]}",
+                        )
+                    )
+
         return polyglots

--- a/filo/profiler.py
+++ b/filo/profiler.py
@@ -17,11 +17,12 @@ logger = logging.getLogger(__name__)
 @dataclass
 class TimingResult:
     """Result from timing a function."""
+
     name: str
     duration: float
     calls: int = 1
     avg_duration: float = 0.0
-    
+
     def __post_init__(self):
         self.avg_duration = self.duration / self.calls if self.calls > 0 else 0
 
@@ -29,10 +30,11 @@ class TimingResult:
 @dataclass
 class ProfileReport:
     """Performance profile report."""
+
     total_duration: float
     timings: Dict[str, TimingResult] = field(default_factory=dict)
     profile_data: Optional[str] = None
-    
+
     def add_timing(self, name: str, duration: float) -> None:
         """Add a timing measurement."""
         if name in self.timings:
@@ -42,11 +44,11 @@ class ProfileReport:
             existing.avg_duration = existing.duration / existing.calls
         else:
             self.timings[name] = TimingResult(name=name, duration=duration)
-    
+
     def get_sorted_timings(self) -> List[TimingResult]:
         """Get timings sorted by duration (descending)."""
         return sorted(self.timings.values(), key=lambda x: x.duration, reverse=True)
-    
+
     def format_report(self) -> str:
         """Format report as string."""
         lines = [
@@ -58,34 +60,34 @@ class ProfileReport:
             "Top Operations by Time:",
             "-" * 70,
             f"{'Operation':<30} {'Time (s)':<12} {'Calls':<8} {'Avg (s)':<12}",
-            "-" * 70
+            "-" * 70,
         ]
-        
+
         for timing in self.get_sorted_timings()[:20]:  # Top 20
             lines.append(
                 f"{timing.name:<30} {timing.duration:<12.4f} {timing.calls:<8} {timing.avg_duration:<12.6f}"
             )
-        
+
         lines.append("=" * 70)
-        
+
         return "\n".join(lines)
 
 
 class Profiler:
     """
     Performance profiler for analyzing bottlenecks.
-    
+
     Features:
     - Function timing
     - Context manager for easy timing
     - cProfile integration
     - Detailed reports
     """
-    
+
     def __init__(self, enabled: bool = True) -> None:
         """
         Initialize profiler.
-        
+
         Args:
             enabled: Enable profiling (can disable for production)
         """
@@ -93,51 +95,51 @@ class Profiler:
         self.report = ProfileReport(total_duration=0.0)
         self._start_time: Optional[float] = None
         self._profiler: Optional[cProfile.Profile] = None
-    
+
     def start(self) -> None:
         """Start profiling session."""
         if not self.enabled:
             return
-        
+
         self._start_time = time.time()
         self._profiler = cProfile.Profile()
         self._profiler.enable()
         logger.info("Profiling started")
-    
+
     def stop(self) -> ProfileReport:
         """
         Stop profiling and generate report.
-        
+
         Returns:
             ProfileReport with results
         """
         if not self.enabled or not self._start_time:
             return self.report
-        
+
         if self._profiler:
             self._profiler.disable()
-            
+
             # Capture cProfile output
             s = StringIO()
             ps = pstats.Stats(self._profiler, stream=s)
-            ps.sort_stats('cumulative')
+            ps.sort_stats("cumulative")
             ps.print_stats(30)  # Top 30 functions
-            
+
             self.report.profile_data = s.getvalue()
-        
+
         self.report.total_duration = time.time() - self._start_time
         logger.info(f"Profiling stopped. Duration: {self.report.total_duration:.4f}s")
-        
+
         return self.report
-    
+
     @contextmanager
     def time_operation(self, name: str):
         """
         Context manager for timing an operation.
-        
+
         Args:
             name: Operation name
-            
+
         Example:
             with profiler.time_operation("analyze_file"):
                 result = analyzer.analyze(data)
@@ -145,38 +147,39 @@ class Profiler:
         if not self.enabled:
             yield
             return
-        
+
         start = time.time()
         try:
             yield
         finally:
             duration = time.time() - start
             self.report.add_timing(name, duration)
-    
+
     def time_function(self, name: Optional[str] = None):
         """
         Decorator for timing a function.
-        
+
         Args:
             name: Optional custom name (defaults to function name)
-            
+
         Example:
             @profiler.time_function()
             def analyze_file(data):
                 ...
         """
+
         def decorator(func: Callable) -> Callable:
             timing_name = name or func.__name__
-            
+
             def wrapper(*args, **kwargs):
                 if not self.enabled:
                     return func(*args, **kwargs)
-                
+
                 with self.time_operation(timing_name):
                     return func(*args, **kwargs)
-            
+
             return wrapper
-        
+
         return decorator
 
 
@@ -187,17 +190,17 @@ _global_profiler: Optional[Profiler] = None
 def get_profiler(enabled: bool = True) -> Profiler:
     """Get or create global profiler instance."""
     global _global_profiler
-    
+
     if _global_profiler is None:
         _global_profiler = Profiler(enabled=enabled)
-    
+
     return _global_profiler
 
 
 def profile_analysis(func: Callable) -> Callable:
     """
     Decorator to profile an analysis function.
-    
+
     Example:
         @profile_analysis
         def my_analysis(data):
@@ -211,17 +214,17 @@ def profile_analysis(func: Callable) -> Callable:
 def profile_session():
     """
     Context manager for a profiling session.
-    
+
     Example:
         with profile_session() as profiler:
             # ... do work ...
             pass
-        
+
         print(profiler.report.format_report())
     """
     profiler = get_profiler()
     profiler.start()
-    
+
     try:
         yield profiler
     finally:

--- a/filo/profiler.py
+++ b/filo/profiler.py
@@ -155,7 +155,9 @@ class Profiler:
             duration = time.time() - start
             self.report.add_timing(name, duration)
 
-    def time_function(self, name: Optional[str] = None) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    def time_function(
+        self, name: Optional[str] = None
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
         """
         Decorator for timing a function.
 

--- a/filo/profiler.py
+++ b/filo/profiler.py
@@ -9,7 +9,7 @@ import time
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from io import StringIO
-from typing import Dict, List, Optional, Callable
+from typing import Any, Callable, Dict, Iterator, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +23,7 @@ class TimingResult:
     calls: int = 1
     avg_duration: float = 0.0
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         self.avg_duration = self.duration / self.calls if self.calls > 0 else 0
 
 
@@ -133,7 +133,7 @@ class Profiler:
         return self.report
 
     @contextmanager
-    def time_operation(self, name: str):
+    def time_operation(self, name: str) -> Iterator[None]:
         """
         Context manager for timing an operation.
 
@@ -155,7 +155,7 @@ class Profiler:
             duration = time.time() - start
             self.report.add_timing(name, duration)
 
-    def time_function(self, name: Optional[str] = None):
+    def time_function(self, name: Optional[str] = None) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
         """
         Decorator for timing a function.
 
@@ -168,10 +168,10 @@ class Profiler:
                 ...
         """
 
-        def decorator(func: Callable) -> Callable:
+        def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
             timing_name = name or func.__name__
 
-            def wrapper(*args, **kwargs):
+            def wrapper(*args: Any, **kwargs: Any) -> Any:
                 if not self.enabled:
                     return func(*args, **kwargs)
 
@@ -197,7 +197,7 @@ def get_profiler(enabled: bool = True) -> Profiler:
     return _global_profiler
 
 
-def profile_analysis(func: Callable) -> Callable:
+def profile_analysis(func: Callable[..., Any]) -> Callable[..., Any]:
     """
     Decorator to profile an analysis function.
 
@@ -211,7 +211,7 @@ def profile_analysis(func: Callable) -> Callable:
 
 
 @contextmanager
-def profile_session():
+def profile_session() -> Iterator[Profiler]:
     """
     Context manager for a profiling session.
 

--- a/filo/profiler.py
+++ b/filo/profiler.py
@@ -9,8 +9,7 @@ import time
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from io import StringIO
-from pathlib import Path
-from typing import Dict, List, Optional, Callable, Any
+from typing import Dict, List, Optional, Callable
 
 logger = logging.getLogger(__name__)
 

--- a/filo/repair.py
+++ b/filo/repair.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 @dataclass
 class RepairReport:
     """Report of repair operation."""
+
     success: bool
     strategy_used: str
     original_size: int
@@ -29,14 +30,18 @@ class RepairReport:
 class RepairEngine:
     """
     File repair and header reconstruction engine.
-    
+
     Implements multiple strategies for repairing corrupted files.
     """
-    
-    def __init__(self, database: Optional[FormatDatabase] = None, lineage_tracker: Optional[LineageTracker] = None) -> None:
+
+    def __init__(
+        self,
+        database: Optional[FormatDatabase] = None,
+        lineage_tracker: Optional[LineageTracker] = None,
+    ) -> None:
         """
         Initialize repair engine.
-        
+
         Args:
             database: Optional format database
             lineage_tracker: Optional lineage tracker for chain-of-custody
@@ -45,7 +50,7 @@ class RepairEngine:
         self.lineage_tracker = lineage_tracker
         self._register_advanced_strategies()
         logger.info(f"RepairEngine initialized with {self.database.count()} formats")
-    
+
     def _register_advanced_strategies(self) -> None:
         """Register format-specific advanced repair strategies."""
         self.advanced_strategies = {
@@ -77,7 +82,7 @@ class RepairEngine:
                 self._repair_ole2_header,
             ],
         }
-    
+
     def repair(
         self,
         data: bytes,
@@ -87,20 +92,20 @@ class RepairEngine:
     ) -> tuple[bytes, RepairReport]:
         """
         Repair corrupted file data.
-        
+
         Args:
             data: Corrupted file data
             format_name: Target format for repair
             strategy: Repair strategy ('auto', 'advanced', or specific strategy name)
             original_path: Path to original file (for lineage tracking)
-        
+
         Returns:
             Tuple of (repaired_data, repair_report)
         """
         spec = self.database.get_format(format_name)
         if not spec:
             raise ValueError(f"Unknown format: {format_name}")
-        
+
         # Try advanced strategies first if available
         if strategy == "auto" or strategy == "advanced":
             if format_name in self.advanced_strategies:
@@ -118,12 +123,12 @@ class RepairEngine:
                                     original_path=original_path,
                                     format=format_name,
                                     strategy=report.strategy_used,
-                                    changes=report.changes_made
+                                    changes=report.changes_made,
                                 )
                             return repaired, report
                     except Exception as e:
                         logger.debug(f"Advanced strategy {repair_func.__name__} failed: {e}")
-        
+
         if strategy == "advanced":
             return data, RepairReport(
                 success=False,
@@ -133,14 +138,12 @@ class RepairEngine:
                 changes_made=[],
                 warnings=["No advanced strategies succeeded"],
             )
-        
+
         if strategy == "auto":
             # Try standard strategies in priority order
             for repair_strategy in sorted(spec.repair_strategies, key=lambda s: s.priority):
                 try:
-                    repaired, report = self._apply_strategy(
-                        data, spec, repair_strategy.name
-                    )
+                    repaired, report = self._apply_strategy(data, spec, repair_strategy.name)
                     if report.success:
                         # Record lineage if tracker available
                         if self.lineage_tracker and repaired != data:
@@ -151,12 +154,12 @@ class RepairEngine:
                                 original_path=original_path,
                                 format=format_name,
                                 strategy=report.strategy_used,
-                                changes=report.changes_made
+                                changes=report.changes_made,
                             )
                         return repaired, report
                 except Exception as e:
                     logger.warning(f"Strategy {repair_strategy.name} failed: {e}")
-            
+
             # No strategy succeeded
             return data, RepairReport(
                 success=False,
@@ -168,7 +171,7 @@ class RepairEngine:
             )
         else:
             return self._apply_strategy(data, spec, strategy)
-    
+
     def _apply_strategy(
         self, data: bytes, spec: FormatSpec, strategy_name: str
     ) -> tuple[bytes, RepairReport]:
@@ -178,7 +181,7 @@ class RepairEngine:
         if hasattr(self, method_name):
             method = getattr(self, method_name)
             return method(data, spec)
-        
+
         # Generic strategies
         if strategy_name == "generate_minimal_header":
             return self._strategy_generate_minimal_header(data, spec)
@@ -188,14 +191,14 @@ class RepairEngine:
             return self._strategy_add_zip_header(data, spec)
         else:
             raise ValueError(f"Unknown repair strategy: {strategy_name}")
-    
+
     def _strategy_generate_minimal_header(
         self, data: bytes, spec: FormatSpec
     ) -> tuple[bytes, RepairReport]:
         """Generate minimal valid header for file."""
         changes = []
         warnings = []
-        
+
         # Get default template
         if "default" not in spec.templates:
             warnings.append("No default template available")
@@ -207,15 +210,15 @@ class RepairEngine:
                 changes_made=changes,
                 warnings=warnings,
             )
-        
+
         template = spec.templates["default"]
-        
+
         # Use template as-is (without variable substitution)
         header_hex = template.hex.split("{{")[0]  # Take part before first variable
         header_bytes = bytes.fromhex(header_hex)
-        
+
         # Check if header is already present
-        if data.startswith(header_bytes[:len(header_hex)//2]):
+        if data.startswith(header_bytes[: len(header_hex) // 2]):
             warnings.append("Header already present")
             return data, RepairReport(
                 success=False,
@@ -225,11 +228,11 @@ class RepairEngine:
                 changes_made=changes,
                 warnings=warnings,
             )
-        
+
         # Prepend header
         repaired = header_bytes + data
         changes.append(f"Added {len(header_bytes)} byte header")
-        
+
         return repaired, RepairReport(
             success=True,
             strategy_used="generate_minimal_header",
@@ -238,14 +241,12 @@ class RepairEngine:
             changes_made=changes,
             warnings=warnings,
         )
-    
-    def _strategy_add_pdf_header(
-        self, data: bytes, spec: FormatSpec
-    ) -> tuple[bytes, RepairReport]:
+
+    def _strategy_add_pdf_header(self, data: bytes, spec: FormatSpec) -> tuple[bytes, RepairReport]:
         """Add PDF header to file."""
         pdf_header = b"%PDF-1.7\r\n"
         changes = []
-        
+
         if data.startswith(b"%PDF"):
             return data, RepairReport(
                 success=False,
@@ -255,10 +256,10 @@ class RepairEngine:
                 changes_made=changes,
                 warnings=["PDF header already present"],
             )
-        
+
         repaired = pdf_header + data
         changes.append("Added PDF-1.7 header")
-        
+
         return repaired, RepairReport(
             success=True,
             strategy_used="add_pdf_header",
@@ -267,14 +268,12 @@ class RepairEngine:
             changes_made=changes,
             warnings=[],
         )
-    
-    def _strategy_add_zip_header(
-        self, data: bytes, spec: FormatSpec
-    ) -> tuple[bytes, RepairReport]:
+
+    def _strategy_add_zip_header(self, data: bytes, spec: FormatSpec) -> tuple[bytes, RepairReport]:
         """Add ZIP local file header."""
         zip_header = bytes.fromhex("504B0304")
         changes = []
-        
+
         if data.startswith(zip_header):
             return data, RepairReport(
                 success=False,
@@ -284,10 +283,10 @@ class RepairEngine:
                 changes_made=changes,
                 warnings=["ZIP header already present"],
             )
-        
+
         repaired = zip_header + data
         changes.append("Added ZIP local file header")
-        
+
         return repaired, RepairReport(
             success=True,
             strategy_used="add_zip_header",
@@ -296,19 +295,19 @@ class RepairEngine:
             changes_made=changes,
             warnings=[],
         )
-    
+
     def _strategy_reconstruct_from_chunks(
         self, data: bytes, spec: FormatSpec
     ) -> tuple[bytes, RepairReport]:
         """
         Reconstruct file header from existing chunk data.
-        
+
         This is specifically designed for chunk-based formats like PNG
         where the header might be corrupted but chunks are intact.
         """
         changes = []
         warnings = []
-        
+
         # Currently only supports PNG format
         if spec.format != "png":
             return data, RepairReport(
@@ -319,7 +318,7 @@ class RepairEngine:
                 changes_made=changes,
                 warnings=["reconstruct_from_chunks only supports PNG format"],
             )
-        
+
         # Check if PNG signature is correct
         png_sig = b"\x89PNG\r\n\x1a\n"
         if data[:8] != png_sig:
@@ -330,7 +329,7 @@ class RepairEngine:
                 repaired = bytearray(png_sig)
                 repaired.extend(data[8:])  # Keep everything after signature
                 changes.append("Reconstructed PNG signature")
-                
+
                 return bytes(repaired), RepairReport(
                     success=True,
                     strategy_used="reconstruct_from_chunks",
@@ -349,7 +348,7 @@ class RepairEngine:
                     changes_made=changes,
                     warnings=warnings,
                 )
-        
+
         # Signature is fine, check if file is already valid
         return data, RepairReport(
             success=False,
@@ -359,7 +358,7 @@ class RepairEngine:
             changes_made=changes,
             warnings=["PNG signature already valid"],
         )
-    
+
     def repair_file(
         self,
         file_path: Union[str, Path],
@@ -370,50 +369,50 @@ class RepairEngine:
     ) -> tuple[bytes, RepairReport]:
         """
         Repair a file from disk.
-        
+
         Args:
             file_path: Path to corrupted file
             format_name: Target format for repair
             strategy: Repair strategy to use
             output_path: Where to write repaired file (None = overwrite original)
             create_backup: Whether to create .bak backup
-        
+
         Returns:
             Tuple of (repaired_data, repair_report)
         """
         path = Path(file_path)
-        
+
         if not path.exists():
             raise FileNotFoundError(f"File not found: {file_path}")
-        
+
         # Read original data
         with open(path, "rb") as f:
             data = f.read()
-        
+
         # Repair
         repaired_data, report = self.repair(data, format_name, strategy)
-        
+
         # Write output
         if report.success:
             if output_path is None:
                 output_path = path
-            
+
             output_path = Path(output_path)
-            
+
             # Create backup if requested
             if create_backup and output_path == path:
                 backup_path = path.with_suffix(path.suffix + ".bak")
                 backup_path.write_bytes(data)
                 logger.info(f"Created backup: {backup_path}")
-            
+
             # Write repaired file
             output_path.write_bytes(repaired_data)
             logger.info(f"Wrote repaired file: {output_path}")
-        
+
         return repaired_data, report
-    
+
     # Advanced PNG Repair Strategies
-    
+
     def _repair_png_chunks(self, data: bytes) -> Tuple[bytes, RepairReport]:
         """Repair PNG chunk structure and CRCs."""
         if not data.startswith(b"\x89PNG\r\n\x1a\n"):
@@ -425,53 +424,55 @@ class RepairEngine:
                 changes_made=[],
                 warnings=["Not a PNG file"],
             )
-        
+
         changes = []
         warnings = []
         repaired = bytearray(data[:8])  # Keep PNG signature
         pos = 8
         chunks_repaired = 0
-        
+
         while pos < len(data) - 12:
             try:
                 # Read chunk length
                 if pos + 4 > len(data):
                     break
-                chunk_len = struct.unpack(">I", data[pos:pos+4])[0]
-                
+                chunk_len = struct.unpack(">I", data[pos : pos + 4])[0]
+
                 if pos + 12 + chunk_len > len(data):
                     warnings.append(f"Truncated chunk at offset {pos}")
                     break
-                
+
                 # Read chunk type and data
-                chunk_type = data[pos+4:pos+8]
-                chunk_data = data[pos+8:pos+8+chunk_len]
-                chunk_crc = struct.unpack(">I", data[pos+8+chunk_len:pos+12+chunk_len])[0]
-                
+                chunk_type = data[pos + 4 : pos + 8]
+                chunk_data = data[pos + 8 : pos + 8 + chunk_len]
+                chunk_crc = struct.unpack(">I", data[pos + 8 + chunk_len : pos + 12 + chunk_len])[0]
+
                 # Recalculate CRC
-                calc_crc = zlib.crc32(chunk_type + chunk_data) & 0xffffffff
-                
+                calc_crc = zlib.crc32(chunk_type + chunk_data) & 0xFFFFFFFF
+
                 if calc_crc != chunk_crc:
-                    changes.append(f"Fixed CRC for {chunk_type.decode('ascii', errors='ignore')} chunk")
+                    changes.append(
+                        f"Fixed CRC for {chunk_type.decode('ascii', errors='ignore')} chunk"
+                    )
                     chunks_repaired += 1
                     chunk_crc = calc_crc
-                
+
                 # Write chunk
                 repaired.extend(struct.pack(">I", chunk_len))
                 repaired.extend(chunk_type)
                 repaired.extend(chunk_data)
                 repaired.extend(struct.pack(">I", chunk_crc))
-                
+
                 pos += 12 + chunk_len
-                
+
                 # Stop at IEND
                 if chunk_type == b"IEND":
                     break
-                    
+
             except Exception as e:
                 warnings.append(f"Error at offset {pos}: {e}")
                 break
-        
+
         if not changes and not chunks_repaired:
             return data, RepairReport(
                 success=False,
@@ -481,7 +482,7 @@ class RepairEngine:
                 changes_made=[],
                 warnings=["No repairs needed"],
             )
-        
+
         return bytes(repaired), RepairReport(
             success=True,
             strategy_used="repair_png_chunks",
@@ -492,37 +493,37 @@ class RepairEngine:
             chunks_repaired=chunks_repaired,
             confidence=0.9,
         )
-    
+
     def _repair_png_crc(self, data: bytes) -> Tuple[bytes, RepairReport]:
         """Fix all PNG chunk CRCs."""
         return self._repair_png_chunks(data)
-    
+
     def _reconstruct_png_ihdr(self, data: bytes) -> Tuple[bytes, RepairReport]:
         """Reconstruct missing or corrupted PNG IHDR chunk."""
         if not data.startswith(b"\x89PNG\r\n\x1a\n"):
             # Add PNG signature if missing
             data = b"\x89PNG\r\n\x1a\n" + data
-        
+
         changes = []
-        
+
         # Check if IHDR exists at position 8
         if len(data) < 33 or data[12:16] != b"IHDR":
             # Reconstruct minimal IHDR
             # Try to infer dimensions from IDAT chunks
             width, height = 800, 600  # Default fallback
-            
+
             ihdr_data = struct.pack(">II", width, height)  # Width, Height
             ihdr_data += b"\x08\x02\x00\x00\x00"  # bit_depth=8, color_type=2 (RGB), compression=0, filter=0, interlace=0
-            
+
             ihdr_chunk = struct.pack(">I", 13)  # Length
             ihdr_chunk += b"IHDR"
             ihdr_chunk += ihdr_data
-            ihdr_chunk += struct.pack(">I", zlib.crc32(b"IHDR" + ihdr_data) & 0xffffffff)
-            
+            ihdr_chunk += struct.pack(">I", zlib.crc32(b"IHDR" + ihdr_data) & 0xFFFFFFFF)
+
             # Insert after PNG signature
             repaired = data[:8] + ihdr_chunk + data[8:]
             changes.append("Reconstructed IHDR chunk with default dimensions")
-            
+
             return repaired, RepairReport(
                 success=True,
                 strategy_used="reconstruct_png_ihdr",
@@ -532,7 +533,7 @@ class RepairEngine:
                 warnings=["Used default dimensions 800x600"],
                 confidence=0.6,
             )
-        
+
         return data, RepairReport(
             success=False,
             strategy_used="reconstruct_png_ihdr",
@@ -541,9 +542,9 @@ class RepairEngine:
             changes_made=[],
             warnings=["IHDR already present"],
         )
-    
+
     # Advanced JPEG Repair Strategies
-    
+
     def _repair_jpeg_markers(self, data: bytes) -> Tuple[bytes, RepairReport]:
         """Repair JPEG markers and structure."""
         if not data.startswith(b"\xff\xd8"):
@@ -552,12 +553,12 @@ class RepairEngine:
             changes = ["Added JPEG SOI and JFIF markers"]
         else:
             changes = []
-        
+
         # Check for EOI marker
         if not data.endswith(b"\xff\xd9"):
             data += b"\xff\xd9"
             changes.append("Added JPEG EOI marker")
-        
+
         if changes:
             return data, RepairReport(
                 success=True,
@@ -568,7 +569,7 @@ class RepairEngine:
                 warnings=[],
                 confidence=0.85,
             )
-        
+
         return data, RepairReport(
             success=False,
             strategy_used="repair_jpeg_markers",
@@ -577,7 +578,7 @@ class RepairEngine:
             changes_made=[],
             warnings=["No repairs needed"],
         )
-    
+
     def _add_jpeg_eoi(self, data: bytes) -> Tuple[bytes, RepairReport]:
         """Add JPEG end-of-image marker."""
         if data.endswith(b"\xff\xd9"):
@@ -589,7 +590,7 @@ class RepairEngine:
                 changes_made=[],
                 warnings=["EOI marker already present"],
             )
-        
+
         repaired = data + b"\xff\xd9"
         return repaired, RepairReport(
             success=True,
@@ -600,9 +601,9 @@ class RepairEngine:
             warnings=[],
             confidence=0.95,
         )
-    
+
     # Advanced ZIP Repair Strategies
-    
+
     def _repair_zip_directory(self, data: bytes) -> Tuple[bytes, RepairReport]:
         """Repair ZIP central directory."""
         if not data.startswith(b"PK\x03\x04"):
@@ -614,20 +615,20 @@ class RepairEngine:
                 changes_made=[],
                 warnings=["Not a ZIP file"],
             )
-        
+
         changes = []
-        
+
         # Look for end of central directory
         eocd_sig = b"PK\x05\x06"
         eocd_pos = data.rfind(eocd_sig)
-        
+
         if eocd_pos == -1:
             # Reconstruct EOCD
             eocd = eocd_sig
             eocd += b"\x00" * 18  # Minimal EOCD structure
             repaired = data + eocd
             changes.append("Reconstructed End of Central Directory")
-            
+
             return repaired, RepairReport(
                 success=True,
                 strategy_used="repair_zip_directory",
@@ -637,7 +638,7 @@ class RepairEngine:
                 warnings=["Reconstructed minimal EOCD - file may not be fully accessible"],
                 confidence=0.5,
             )
-        
+
         return data, RepairReport(
             success=False,
             strategy_used="repair_zip_directory",
@@ -646,7 +647,7 @@ class RepairEngine:
             changes_made=[],
             warnings=["Central directory appears intact"],
         )
-    
+
     def _reconstruct_zip_headers(self, data: bytes) -> Tuple[bytes, RepairReport]:
         """Reconstruct ZIP local file headers."""
         if data.startswith(b"PK\x03\x04"):
@@ -658,19 +659,19 @@ class RepairEngine:
                 changes_made=[],
                 warnings=["ZIP header already present"],
             )
-        
+
         # Add minimal ZIP local file header
         header = b"PK\x03\x04"  # Local file header signature
-        header += b"\x14\x00"    # Version needed
-        header += b"\x00\x00"    # General purpose bit flag
-        header += b"\x00\x00"    # Compression method (stored)
-        header += b"\x00" * 8    # Modification time/date
-        header += b"\x00" * 12   # CRC-32, sizes
-        header += b"\x00\x00"    # File name length
-        header += b"\x00\x00"    # Extra field length
-        
+        header += b"\x14\x00"  # Version needed
+        header += b"\x00\x00"  # General purpose bit flag
+        header += b"\x00\x00"  # Compression method (stored)
+        header += b"\x00" * 8  # Modification time/date
+        header += b"\x00" * 12  # CRC-32, sizes
+        header += b"\x00\x00"  # File name length
+        header += b"\x00\x00"  # Extra field length
+
         repaired = header + data
-        
+
         return repaired, RepairReport(
             success=True,
             strategy_used="reconstruct_zip_headers",
@@ -680,9 +681,9 @@ class RepairEngine:
             warnings=["File may require additional repair"],
             confidence=0.6,
         )
-    
+
     # Advanced PDF Repair Strategies
-    
+
     def _repair_pdf_xref(self, data: bytes) -> Tuple[bytes, RepairReport]:
         """Repair or reconstruct PDF cross-reference table."""
         if not data.startswith(b"%PDF"):
@@ -694,9 +695,9 @@ class RepairEngine:
                 changes_made=[],
                 warnings=["Not a PDF file"],
             )
-        
+
         changes = []
-        
+
         # Check for xref table
         if b"xref" not in data:
             # Add minimal xref and trailer
@@ -704,7 +705,7 @@ class RepairEngine:
             xref += str(len(data)).encode() + b"\n%%EOF"
             repaired = data + xref
             changes.append("Added minimal cross-reference table")
-            
+
             return repaired, RepairReport(
                 success=True,
                 strategy_used="repair_pdf_xref",
@@ -714,7 +715,7 @@ class RepairEngine:
                 warnings=["Reconstructed minimal xref - PDF may have limited functionality"],
                 confidence=0.5,
             )
-        
+
         return data, RepairReport(
             success=False,
             strategy_used="repair_pdf_xref",
@@ -723,11 +724,11 @@ class RepairEngine:
             changes_made=[],
             warnings=["xref table appears present"],
         )
-    
+
     def _repair_png_header(self, data: bytes) -> Tuple[bytes, RepairReport]:
         """Repair corrupted PNG signature and chunk names."""
         import struct
-        
+
         if len(data) < 33:
             return data, RepairReport(
                 success=False,
@@ -737,15 +738,15 @@ class RepairEngine:
                 changes_made=[],
                 warnings=["File too small to be a valid PNG"],
             )
-        
+
         changes = []
         warnings = []
         repaired = bytearray(data)
-        
+
         # PNG signature: 89 50 4E 47 0D 0A 1A 0A
-        correct_sig = b'\x89PNG\r\n\x1a\n'
+        correct_sig = b"\x89PNG\r\n\x1a\n"
         actual_sig = data[0:8]
-        
+
         # Fix signature if corrupted
         if actual_sig != correct_sig:
             repaired[0:8] = correct_sig
@@ -754,113 +755,125 @@ class RepairEngine:
                 if actual != expected:
                     sig_changes.append(f"byte {i}: 0x{actual:02X} → 0x{expected:02X}")
             changes.append(f"Fixed PNG signature: {', '.join(sig_changes)}")
-        
+
         # Fix IHDR chunk name (should be first chunk after signature)
         if len(data) >= 16:
             ihdr_type = data[12:16]
-            if ihdr_type != b'IHDR':
-                repaired[12:16] = b'IHDR'
+            if ihdr_type != b"IHDR":
+                repaired[12:16] = b"IHDR"
                 chunk_changes = []
-                for i, (actual, expected) in enumerate(zip(ihdr_type, b'IHDR')):
+                for i, (actual, expected) in enumerate(zip(ihdr_type, b"IHDR")):
                     if actual != expected:
-                        actual_char = chr(actual) if 32 <= actual < 127 else '?'
-                        chunk_changes.append(f"'{actual_char}' (0x{actual:02X}) → '{chr(expected)}' (0x{expected:02X})")
+                        actual_char = chr(actual) if 32 <= actual < 127 else "?"
+                        chunk_changes.append(
+                            f"'{actual_char}' (0x{actual:02X}) → '{chr(expected)}' (0x{expected:02X})"
+                        )
                 changes.append(f"Fixed IHDR chunk name: {', '.join(chunk_changes)}")
-                
+
                 # Recalculate CRC for IHDR chunk
                 ihdr_length = struct.unpack(">I", data[8:12])[0]
                 if ihdr_length == 13:  # Standard IHDR length
                     import zlib
-                    chunk_data = repaired[12:12+4+ihdr_length]  # type + data
-                    crc = zlib.crc32(chunk_data) & 0xffffffff
-                    struct.pack_into(">I", repaired, 12+4+ihdr_length, crc)
+
+                    chunk_data = repaired[12 : 12 + 4 + ihdr_length]  # type + data
+                    crc = zlib.crc32(chunk_data) & 0xFFFFFFFF
+                    struct.pack_into(">I", repaired, 12 + 4 + ihdr_length, crc)
                     changes.append("Recalculated IHDR CRC")
-        
+
         # Scan through all chunks and fix common corruptions
         pos = 33
         idat_found = False
-        
+
         while pos < len(data) - 12:  # Need at least 12 bytes for chunk header
             try:
                 if pos + 8 > len(data):
                     break
-                
-                chunk_length = struct.unpack(">I", repaired[pos:pos+4])[0]
-                chunk_type = repaired[pos+4:pos+8]
-                
+
+                chunk_length = struct.unpack(">I", repaired[pos : pos + 4])[0]
+                chunk_type = repaired[pos + 4 : pos + 8]
+
                 # Fix pHYs chunk corruption (0xAA in X-axis pixels per unit)
-                if chunk_type == b'pHYs' and chunk_length == 9:
+                if chunk_type == b"pHYs" and chunk_length == 9:
                     # Check if X-axis has 0xAA corruption
-                    if repaired[pos+8] == 0xAA:
-                        old_val = bytes(repaired[pos+8:pos+12])
-                        repaired[pos+8] = 0x00  # Fix X-axis first byte
-                        new_val = bytes(repaired[pos+8:pos+12])
+                    if repaired[pos + 8] == 0xAA:
+                        old_val = bytes(repaired[pos + 8 : pos + 12])
+                        repaired[pos + 8] = 0x00  # Fix X-axis first byte
+                        new_val = bytes(repaired[pos + 8 : pos + 12])
                         changes.append(f"Fixed pHYs X-axis: 0x{old_val.hex()} → 0x{new_val.hex()}")
-                        
+
                         # Recalculate CRC
                         import zlib
-                        chunk_data = repaired[pos+4:pos+8+chunk_length]
-                        crc = zlib.crc32(chunk_data) & 0xffffffff
-                        struct.pack_into(">I", repaired, pos+8+chunk_length, crc)
+
+                        chunk_data = repaired[pos + 4 : pos + 8 + chunk_length]
+                        crc = zlib.crc32(chunk_data) & 0xFFFFFFFF
+                        struct.pack_into(">I", repaired, pos + 8 + chunk_length, crc)
                         changes.append("Recalculated pHYs CRC")
-                
+
                 # Fix corrupted IDAT chunk
                 # Check for IDAT-like corruptions: length has 0xAAAA prefix or type is corrupted
                 if not idat_found:
                     # Check if this looks like a corrupted IDAT
                     # Common pattern: length = 0xAAAAFFxx, type = 0xABDET or similar
-                    length_bytes = repaired[pos:pos+4]
-                    type_bytes = repaired[pos+4:pos+8]
-                    
+                    length_bytes = repaired[pos : pos + 4]
+                    type_bytes = repaired[pos + 4 : pos + 8]
+
                     # Check if length has 0xAAAA prefix (corrupted)
-                    if length_bytes[0:2] == b'\xAA\xAA':
+                    if length_bytes[0:2] == b"\xaa\xaa":
                         old_length = struct.unpack(">I", length_bytes)[0]
                         # Replace AAAA with 0000
                         repaired[pos] = 0x00
-                        repaired[pos+1] = 0x00
-                        new_length = struct.unpack(">I", repaired[pos:pos+4])[0]
-                        changes.append(f"Fixed IDAT length at 0x{pos:X}: 0x{old_length:08X} → 0x{new_length:08X}")
+                        repaired[pos + 1] = 0x00
+                        new_length = struct.unpack(">I", repaired[pos : pos + 4])[0]
+                        changes.append(
+                            f"Fixed IDAT length at 0x{pos:X}: 0x{old_length:08X} → 0x{new_length:08X}"
+                        )
                         chunk_length = new_length
-                    
+
                     # Check if chunk type looks like corrupted IDAT
                     # Pattern: 0xABDET (ab 44 45 54) should be IDAT (49 44 41 54)
-                    if (type_bytes[0] == 0xAB and type_bytes[1:4] == b'DET') or \
-                       (all(65 <= b <= 90 or 97 <= b <= 122 for b in type_bytes) and 
-                        type_bytes != b'IDAT' and
-                        abs(type_bytes[1] - ord('D')) <= 10 and
-                        abs(type_bytes[2] - ord('A')) <= 10):
-                        
+                    if (type_bytes[0] == 0xAB and type_bytes[1:4] == b"DET") or (
+                        all(65 <= b <= 90 or 97 <= b <= 122 for b in type_bytes)
+                        and type_bytes != b"IDAT"
+                        and abs(type_bytes[1] - ord("D")) <= 10
+                        and abs(type_bytes[2] - ord("A")) <= 10
+                    ):
+
                         old_type = bytes(type_bytes)
-                        repaired[pos+4:pos+8] = b'IDAT'
-                        
+                        repaired[pos + 4 : pos + 8] = b"IDAT"
+
                         chunk_changes = []
-                        for i, (actual, expected) in enumerate(zip(old_type, b'IDAT')):
+                        for i, (actual, expected) in enumerate(zip(old_type, b"IDAT")):
                             if actual != expected:
-                                actual_char = chr(actual) if 32 <= actual < 127 else '?'
-                                chunk_changes.append(f"'{actual_char}' (0x{actual:02X}) → '{chr(expected)}' (0x{expected:02X})")
-                        changes.append(f"Fixed IDAT chunk type at 0x{pos:X}: {', '.join(chunk_changes)}")
-                        
+                                actual_char = chr(actual) if 32 <= actual < 127 else "?"
+                                chunk_changes.append(
+                                    f"'{actual_char}' (0x{actual:02X}) → '{chr(expected)}' (0x{expected:02X})"
+                                )
+                        changes.append(
+                            f"Fixed IDAT chunk type at 0x{pos:X}: {', '.join(chunk_changes)}"
+                        )
+
                         # Recalculate CRC for IDAT
                         if pos + 8 + chunk_length + 4 <= len(data):
                             import zlib
-                            chunk_data = repaired[pos+4:pos+8+chunk_length]
-                            crc = zlib.crc32(chunk_data) & 0xffffffff
-                            struct.pack_into(">I", repaired, pos+8+chunk_length, crc)
+
+                            chunk_data = repaired[pos + 4 : pos + 8 + chunk_length]
+                            crc = zlib.crc32(chunk_data) & 0xFFFFFFFF
+                            struct.pack_into(">I", repaired, pos + 8 + chunk_length, crc)
                             changes.append(f"Recalculated IDAT CRC at 0x{pos:X}")
-                        
+
                         idat_found = True
-                
+
                 # Move to next chunk (with sanity check on length)
                 if chunk_length < 10 * 1024 * 1024:  # Max 10MB per chunk
                     pos += 8 + chunk_length + 4
                 else:
                     # Corrupted length, try to find next chunk signature
                     break
-                    
+
             except Exception as e:
                 logger.debug(f"Error processing chunk at 0x{pos:X}: {e}")
                 break
-        
+
         # Validate the repair
         if not changes:
             return data, RepairReport(
@@ -871,7 +884,7 @@ class RepairEngine:
                 changes_made=[],
                 warnings=["Header appears valid, no changes needed"],
             )
-        
+
         return bytes(repaired), RepairReport(
             success=True,
             strategy_used="repair_png_header",
@@ -880,19 +893,19 @@ class RepairEngine:
             changes_made=changes,
             warnings=warnings,
             confidence=0.95,
-            validation_result="Repaired PNG signature and chunk structure"
+            validation_result="Repaired PNG signature and chunk structure",
         )
-    
+
     def _repair_bmp_header(self, data: bytes) -> Tuple[bytes, RepairReport]:
         """
         Repair corrupted BMP header.
-        
+
         Common issues:
         - Wrong DIB header size (offset 0x0E)
         - Wrong pixel data offset (offset 0x0A)
         - Wrong image height (need to calculate from file size)
         """
-        if len(data) < 54 or not data.startswith(b'BM'):
+        if len(data) < 54 or not data.startswith(b"BM"):
             return data, RepairReport(
                 success=False,
                 strategy_used="repair_bmp_header",
@@ -901,11 +914,11 @@ class RepairEngine:
                 changes_made=[],
                 warnings=["Not a BMP file or too small"],
             )
-        
+
         changes = []
         warnings = []
         repaired = bytearray(data)
-        
+
         # Read current header values
         file_size = struct.unpack("<I", data[2:6])[0]
         pixel_offset_orig = struct.unpack("<I", data[10:14])[0]
@@ -913,30 +926,34 @@ class RepairEngine:
         width = struct.unpack("<I", data[18:22])[0]
         height_orig = struct.unpack("<I", data[22:26])[0]
         bits_per_pixel = struct.unpack("<H", data[28:30])[0]
-        
+
         # Fix DIB header size if wrong (should be 40 for BITMAPINFOHEADER)
         if dib_size_orig != 40:
             struct.pack_into("<I", repaired, 14, 40)
             changes.append(f"Fixed DIB header size: 0x{dib_size_orig:X} → 0x28 (40)")
-        
+
         # Fix pixel data offset (should be 14 + DIB header size = 54 for standard BMP)
         standard_offset = 54
         if pixel_offset_orig != standard_offset:
             struct.pack_into("<I", repaired, 10, standard_offset)
-            changes.append(f"Fixed pixel data offset: 0x{pixel_offset_orig:X} → 0x{standard_offset:X}")
-        
+            changes.append(
+                f"Fixed pixel data offset: 0x{pixel_offset_orig:X} → 0x{standard_offset:X}"
+            )
+
         # Calculate correct height from file size
         # Formula: height = (file_size - header_size) / (width * bytes_per_pixel)
         bits_per_pixel // 8
         row_size = ((width * bits_per_pixel + 31) // 32) * 4  # Row size aligned to 4 bytes
         pixel_data_size = file_size - standard_offset
         calculated_height = pixel_data_size // row_size
-        
+
         if calculated_height != height_orig and calculated_height > 0:
             struct.pack_into("<I", repaired, 22, calculated_height)
-            changes.append(f"Fixed height: {height_orig} → {calculated_height} (calculated from file size)")
+            changes.append(
+                f"Fixed height: {height_orig} → {calculated_height} (calculated from file size)"
+            )
             warnings.append(f"Original height ({height_orig}) didn't match file size")
-        
+
         # Validate the repair
         if not changes:
             return data, RepairReport(
@@ -947,7 +964,7 @@ class RepairEngine:
                 changes_made=[],
                 warnings=["Header appears valid, no changes needed"],
             )
-        
+
         return bytes(repaired), RepairReport(
             success=True,
             strategy_used="repair_bmp_header",
@@ -956,7 +973,7 @@ class RepairEngine:
             changes_made=changes,
             warnings=warnings,
             confidence=0.95,
-            validation_result=f"Repaired BMP: {width}x{calculated_height}, {bits_per_pixel}bpp"
+            validation_result=f"Repaired BMP: {width}x{calculated_height}, {bits_per_pixel}bpp",
         )
 
     def _repair_elf_header(self, data: bytes) -> Tuple[bytes, RepairReport]:
@@ -1045,7 +1062,7 @@ class RepairEngine:
             changes_made=changes,
             warnings=warnings,
             confidence=0.7,
-            validation_result=f"Reconstructed ELF header: {'64' if ei_class == 2 else '32'}-bit, {'big' if ei_data == 2 else 'little'}-endian"
+            validation_result=f"Reconstructed ELF header: {'64' if ei_class == 2 else '32'}-bit, {'big' if ei_data == 2 else 'little'}-endian",
         )
 
     def _repair_ole2_header(self, data: bytes) -> Tuple[bytes, RepairReport]:
@@ -1088,7 +1105,7 @@ class RepairEngine:
             tail = data[512:]
             reconstructed = bytes(header) + tail
         else:
-            reconstructed = bytes(header[:len(data)])
+            reconstructed = bytes(header[: len(data)])
 
         changes.append("Reconstructed OLE2 compound document header")
 
@@ -1100,7 +1117,7 @@ class RepairEngine:
             changes_made=changes,
             warnings=warnings,
             confidence=0.6,
-            validation_result="Reconstructed OLE2 header with default block allocation table"
+            validation_result="Reconstructed OLE2 header with default block allocation table",
         )
 
     def _add_pdf_eof(self, data: bytes) -> Tuple[bytes, RepairReport]:
@@ -1114,7 +1131,7 @@ class RepairEngine:
                 changes_made=[],
                 warnings=["EOF marker already present"],
             )
-        
+
         repaired = data.rstrip() + b"\n%%EOF"
         return repaired, RepairReport(
             success=True,

--- a/filo/repair.py
+++ b/filo/repair.py
@@ -180,7 +180,7 @@ class RepairEngine:
         method_name = f"_strategy_{strategy_name}"
         if hasattr(self, method_name):
             method = getattr(self, method_name)
-            return method(data, spec)
+            return method(data, spec)  # type: ignore[no-any-return]
 
         # Generic strategies
         if strategy_name == "generate_minimal_header":
@@ -196,8 +196,8 @@ class RepairEngine:
         self, data: bytes, spec: FormatSpec
     ) -> tuple[bytes, RepairReport]:
         """Generate minimal valid header for file."""
-        changes = []
-        warnings = []
+        changes: list[str] = []
+        warnings: list[str] = []
 
         # Get default template
         if "default" not in spec.templates:
@@ -245,7 +245,7 @@ class RepairEngine:
     def _strategy_add_pdf_header(self, data: bytes, spec: FormatSpec) -> tuple[bytes, RepairReport]:
         """Add PDF header to file."""
         pdf_header = b"%PDF-1.7\r\n"
-        changes = []
+        changes: list[str] = []
 
         if data.startswith(b"%PDF"):
             return data, RepairReport(
@@ -272,7 +272,7 @@ class RepairEngine:
     def _strategy_add_zip_header(self, data: bytes, spec: FormatSpec) -> tuple[bytes, RepairReport]:
         """Add ZIP local file header."""
         zip_header = bytes.fromhex("504B0304")
-        changes = []
+        changes: list[str] = []
 
         if data.startswith(zip_header):
             return data, RepairReport(
@@ -305,8 +305,8 @@ class RepairEngine:
         This is specifically designed for chunk-based formats like PNG
         where the header might be corrupted but chunks are intact.
         """
-        changes = []
-        warnings = []
+        changes: list[str] = []
+        warnings: list[str] = []
 
         # Currently only supports PNG format
         if spec.format != "png":
@@ -739,8 +739,8 @@ class RepairEngine:
                 warnings=["File too small to be a valid PNG"],
             )
 
-        changes = []
-        warnings = []
+        changes: list[str] = []
+        warnings: list[str] = []
         repaired = bytearray(data)
 
         # PNG signature: 89 50 4E 47 0D 0A 1A 0A
@@ -1068,8 +1068,8 @@ class RepairEngine:
     def _repair_ole2_header(self, data: bytes) -> Tuple[bytes, RepairReport]:
         """Repair or reconstruct corrupted OLE2 (Compound Document) header."""
         ole2_magic = b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1"
-        changes = []
-        warnings = []
+        changes: list[str] = []
+        warnings: list[str] = []
 
         if len(data) >= 8 and data[:8] == ole2_magic:
             return data, RepairReport(

--- a/filo/repair.py
+++ b/filo/repair.py
@@ -1,9 +1,9 @@
 import logging
 import struct
 import zlib
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, Union, List, Tuple
+from typing import Optional, Union, Tuple
 
 from filo.formats import FormatDatabase
 from filo.models import FormatSpec
@@ -616,7 +616,6 @@ class RepairEngine:
             )
         
         changes = []
-        warnings = []
         
         # Look for end of central directory
         eocd_sig = b"PK\x05\x06"
@@ -803,7 +802,7 @@ class RepairEngine:
                         chunk_data = repaired[pos+4:pos+8+chunk_length]
                         crc = zlib.crc32(chunk_data) & 0xffffffff
                         struct.pack_into(">I", repaired, pos+8+chunk_length, crc)
-                        changes.append(f"Recalculated pHYs CRC")
+                        changes.append("Recalculated pHYs CRC")
                 
                 # Fix corrupted IDAT chunk
                 # Check for IDAT-like corruptions: length has 0xAAAA prefix or type is corrupted
@@ -928,7 +927,7 @@ class RepairEngine:
         
         # Calculate correct height from file size
         # Formula: height = (file_size - header_size) / (width * bytes_per_pixel)
-        bytes_per_pixel = bits_per_pixel // 8
+        bits_per_pixel // 8
         row_size = ((width * bits_per_pixel + 31) // 32) * 4  # Row size aligned to 4 bytes
         pixel_data_size = file_size - standard_offset
         calculated_height = pixel_data_size // row_size

--- a/filo/stego.py
+++ b/filo/stego.py
@@ -12,9 +12,8 @@ import zlib
 import re
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
-from typing import Optional, Iterator
+from typing import Optional
 from enum import Enum
-from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -164,7 +163,7 @@ class LSBExtractor:
                 if match:
                     return match.group()
             
-        except:
+        except Exception:
             pass
         
         return None
@@ -206,7 +205,7 @@ class LSBExtractor:
                 # Add more details for Targa images (like zsteg does)
                 if 'Targa' in desc and len(data) >= 18:
                     try:
-                        id_length = data[0]
+                        data[0]
                         color_map_type = data[1]
                         image_type = data[2]
                         width = struct.unpack('<H', data[12:14])[0]
@@ -216,7 +215,7 @@ class LSBExtractor:
                         alpha_bits = descriptor & 0x0F
                         
                         # Build detailed description like zsteg
-                        details = f"Targa image data"
+                        details = "Targa image data"
                         if image_type == 1:
                             details += " - Map"
                         elif image_type == 2:
@@ -252,7 +251,7 @@ class LSBExtractor:
                             details += f" - {alpha_bits}-bit alpha"
                         
                         return details
-                    except:
+                    except Exception:
                         pass
                 
                 return desc
@@ -414,13 +413,13 @@ class PNGStegoDetector:
                         
                         if len(remaining) >= 2:
                             compression_flag = remaining[0]
-                            compression_method = remaining[1]
+                            remaining[1]
                             
                             # Find language and text
                             remaining = remaining[2:]
                             null_pos2 = remaining.find(b'\0')
                             if null_pos2 >= 0:
-                                language = remaining[:null_pos2].decode('utf-8', errors='ignore')
+                                remaining[:null_pos2].decode('utf-8', errors='ignore')
                                 remaining = remaining[null_pos2+1:]
                                 
                                 # Skip translated keyword
@@ -432,7 +431,7 @@ class PNGStegoDetector:
                                     if compression_flag == 1:
                                         try:
                                             text_data = zlib.decompress(text_data)
-                                        except:
+                                        except Exception:
                                             pass
                                     
                                     text = text_data.decode('utf-8', errors='ignore')
@@ -461,7 +460,7 @@ class PNGStegoDetector:
                         keyword = chunk_data[:null_pos].decode('latin1', errors='ignore')
                         
                         if len(chunk_data) > null_pos + 2:
-                            compression_method = chunk_data[null_pos+1]
+                            chunk_data[null_pos+1]
                             compressed_text = chunk_data[null_pos+2:]
                             
                             try:
@@ -549,13 +548,13 @@ class PNGStegoDetector:
                         break
                     
                     offset += 12 + chunk_len
-                except:
+                except Exception:
                     break
             
             if idat_compressed:
                 try:
                     raw_idat_decompressed = zlib.decompress(idat_compressed)
-                except:
+                except Exception:
                     pass
         
         try:
@@ -818,7 +817,6 @@ class PNGStegoDetector:
         while i < len(analyze_data):
             # Start collecting printable characters
             printable_chars = []
-            start_pos = i
             
             while i < len(analyze_data):
                 byte = analyze_data[i]
@@ -974,7 +972,7 @@ class PNGStegoDetector:
             file_type = self.extractor.detect_file_type(extracted)
             if file_type:
                 # Show first bytes as preview
-                preview = ' '.join(f'\\{ord(c):03o}' if c < ' ' or c > '~' else c for c in extracted[:50].decode('latin-1', errors='ignore'))
+                ' '.join(f'\\{ord(c):03o}' if c < ' ' or c > '~' else c for c in extracted[:50].decode('latin-1', errors='ignore'))
                 results.append(StegoResult(
                     method=f"b{bits},{channels},{bit_order},{px_order}",
                     channel=channels,
@@ -1023,7 +1021,7 @@ class PNGStegoDetector:
             zlib_data = self.extractor.detect_zlib(extracted)
             if zlib_data:
                 # Detect what the decompressed data is
-                desc = f"zlib compressed data"
+                desc = "zlib compressed data"
                 if zlib_data.startswith(b'%PDF'):
                     desc = "zlib: PDF document"
                 elif zlib_data.startswith(b'\x89PNG'):
@@ -1219,7 +1217,7 @@ class PDFMetadataDetector:
                         value = data[value_start+1:value_end]
                         try:
                             metadata[field_name] = value.decode('utf-8', errors='ignore')
-                        except:
+                        except Exception:
                             metadata[field_name] = value.decode('latin-1', errors='ignore')
                         break
                 elif data[value_start:value_start+1] == b'<':
@@ -1231,7 +1229,7 @@ class PDFMetadataDetector:
                             # Decode hex
                             value = bytes.fromhex(hex_value.decode('ascii'))
                             metadata[field_name] = value.decode('utf-8', errors='ignore')
-                        except:
+                        except Exception:
                             pass
                         break
                 

--- a/filo/stego.py
+++ b/filo/stego.py
@@ -12,7 +12,7 @@ import zlib
 import re
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any, Optional
 from enum import Enum
 
 logger = logging.getLogger(__name__)
@@ -53,7 +53,7 @@ class StegoResult:
 class LSBExtractor:
     """Extract data from LSB of image pixels."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.min_string_len = 8
         self.max_extract_bytes = 1024 * 1024  # 1MB limit
 
@@ -86,7 +86,7 @@ class LSBExtractor:
         if not data or bits < 1 or bits > 8:
             return b""
 
-        result_bits = []
+        result_bits: list[int] = []
         max_bits = min(len(data) * bits, self.max_extract_bytes * 8)
 
         for i, byte_val in enumerate(data):
@@ -352,7 +352,7 @@ class LSBExtractor:
 class PNGStegoDetector:
     """Detect steganography in PNG files."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.extractor = LSBExtractor()
 
     def extract_png_metadata(self, data: bytes) -> list[StegoResult]:
@@ -360,7 +360,7 @@ class PNGStegoDetector:
 
         This mimics zsteg's metadata extraction behavior.
         """
-        results = []
+        results: list[Any] = []
 
         if not data.startswith(b"\x89PNG\r\n\x1a\n"):
             return results
@@ -542,7 +542,7 @@ class PNGStegoDetector:
 
         return results
 
-    def parse_png(self, data: bytes) -> Optional[dict]:
+    def parse_png(self, data: bytes) -> Optional[dict[str, Any]]:
         """Parse PNG using PIL for reliable pixel extraction.
 
         Returns pixels in RGBA format, row by row (xy order),
@@ -582,7 +582,7 @@ class PNGStegoDetector:
             from PIL import Image
             import io
 
-            img = Image.open(io.BytesIO(data))
+            img: Any = Image.open(io.BytesIO(data))
 
             # Convert to RGBA if needed (same as zsteg)
             if img.mode != "RGBA":
@@ -608,12 +608,12 @@ class PNGStegoDetector:
             logger.debug(f"Failed to load PNG with PIL: {e}")
             return None
 
-    def _manual_png_parse(self, data: bytes) -> Optional[dict]:
+    def _manual_png_parse(self, data: bytes) -> Optional[dict[str, Any]]:
         """Fallback manual PNG parser."""
         if not data.startswith(b"\x89PNG\r\n\x1a\n"):
             return None
 
-        info = {
+        info: dict[str, Any] = {
             "width": 0,
             "height": 0,
             "bit_depth": 0,
@@ -819,7 +819,7 @@ class PNGStegoDetector:
             return bytes(result)
 
     def analyze_imagedata(
-        self, data: bytes, raw_idat_decompressed: bytes = None
+        self, data: bytes, raw_idat_decompressed: Optional[bytes] = None
     ) -> Optional[StegoResult]:
         """Analyze raw pixel data for patterns (like zsteg's imagedata).
 
@@ -1100,10 +1100,10 @@ class PNGStegoDetector:
 class BMPStegoDetector:
     """Detect steganography in BMP files."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.extractor = LSBExtractor()
 
-    def parse_bmp(self, data: bytes) -> Optional[dict]:
+    def parse_bmp(self, data: bytes) -> Optional[dict[str, Any]]:
         """Parse BMP structure."""
         if not data.startswith(b"BM"):
             return None
@@ -1128,7 +1128,7 @@ class BMPStegoDetector:
 
     def detect(self, data: bytes) -> list[StegoResult]:
         """Detect LSB steganography in BMP file."""
-        results = []
+        results: list[Any] = []
 
         bmp_info = self.parse_bmp(data)
         if not bmp_info or not bmp_info["image_data"]:
@@ -1199,12 +1199,12 @@ class BMPStegoDetector:
 class PDFMetadataDetector:
     """Detect steganography in PDF metadata."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.extractor = LSBExtractor()
 
-    def extract_metadata(self, data: bytes) -> dict:
+    def extract_metadata(self, data: bytes) -> dict[str, Any]:
         """Extract PDF metadata fields."""
-        metadata = {}
+        metadata: dict[str, Any] = {}
 
         if not data.startswith(b"%PDF"):
             return metadata
@@ -1270,7 +1270,7 @@ class PDFMetadataDetector:
 
     def detect(self, data: bytes) -> list[StegoResult]:
         """Detect steganography in PDF metadata."""
-        results = []
+        results: list[Any] = []
 
         metadata = self.extract_metadata(data)
 
@@ -1329,7 +1329,7 @@ class PDFMetadataDetector:
 class TrailingDataDetector:
     """Detect data appended after file end markers."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.extractor = LSBExtractor()
 
     def find_file_end(self, data: bytes, format_hint: Optional[str] = None) -> Optional[int]:
@@ -1368,7 +1368,7 @@ class TrailingDataDetector:
 
     def detect(self, data: bytes, format_hint: Optional[str] = None) -> list[StegoResult]:
         """Detect trailing data after file end marker."""
-        results = []
+        results: list[Any] = []
 
         # Auto-detect format
         if format_hint is None:
@@ -1404,7 +1404,7 @@ class TrailingDataDetector:
                     order="trailing",
                     data=printable.encode(),
                     data_type="trailing",
-                    description=f'Trailing data after {format_hint.upper()} end: "{display_str}"',
+                    description=f"Trailing data after {(format_hint or '').upper()} end: \"{display_str}\"",
                     confidence=0.95,
                     offset=end_pos,
                     size=len(printable),
@@ -1414,7 +1414,7 @@ class TrailingDataDetector:
         # Check for base64 in trailing data
         base64_data = self.extractor.detect_base64(trailing)
         if base64_data:
-            desc = f"Trailing data ({format_hint.upper()})"
+            desc = f"Trailing data ({(format_hint or '').upper()})"
             printable_b64 = self.extractor.detect_printable_strings(base64_data)
             if printable_b64:
                 desc += f': "{printable_b64[:50]}"'
@@ -1440,12 +1440,12 @@ class TrailingDataDetector:
 class SVGStegoDetector:
     """Detect hidden text and steganography in SVG files."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.extractor = LSBExtractor()
 
     def detect(self, data: bytes) -> list[StegoResult]:
         """Detect hidden text in SVG files."""
-        results = []
+        results: list[Any] = []
 
         try:
             # Parse as text
@@ -1531,7 +1531,7 @@ class SVGStegoDetector:
             # Process found hidden texts
             if hidden_texts:
                 # Combine all text
-                all_text = " ".join([ht["text"] for ht in hidden_texts])
+                all_text = " ".join([str(ht["text"]) for ht in hidden_texts])
 
                 # Clean up - remove extra spaces between single characters (common in SVG stego)
                 cleaned_text = re.sub(r"(?<=[a-zA-Z0-9_{}])\s+(?=[a-zA-Z0-9_{}])", "", all_text)
@@ -1598,7 +1598,7 @@ class SVGStegoDetector:
         return results
 
 
-def detect_steganography(data, format_hint: Optional[str] = None) -> list[StegoResult]:
+def detect_steganography(data: Any, format_hint: Optional[str] = None) -> list[StegoResult]:
     """
     Detect steganography in various file formats.
 
@@ -1638,7 +1638,7 @@ def detect_steganography(data, format_hint: Optional[str] = None) -> list[StegoR
 
     # LSB analysis for images
     if format_hint == "png" or data.startswith(b"\x89PNG"):
-        detector = PNGStegoDetector()
+        detector: Any = PNGStegoDetector()
         results.extend(detector.detect(data))
 
     if format_hint == "bmp" or data.startswith(b"BM"):

--- a/filo/stego.py
+++ b/filo/stego.py
@@ -20,12 +20,14 @@ logger = logging.getLogger(__name__)
 
 class BitOrder(Enum):
     """Bit extraction order."""
+
     LSB = "lsb"  # Least significant bit first
     MSB = "msb"  # Most significant bit first
 
 
 class PixelOrder(Enum):
     """Pixel iteration order."""
+
     XY = "xy"  # Left to right, top to bottom
     YX = "yx"  # Top to bottom, left to right
     XY_REV = "XY"  # Right to left, top to bottom
@@ -35,6 +37,7 @@ class PixelOrder(Enum):
 @dataclass
 class StegoResult:
     """Result from steganography detection."""
+
     method: str
     channel: str
     bit_plane: int
@@ -49,47 +52,47 @@ class StegoResult:
 
 class LSBExtractor:
     """Extract data from LSB of image pixels."""
-    
+
     def __init__(self):
         self.min_string_len = 8
         self.max_extract_bytes = 1024 * 1024  # 1MB limit
-    
+
     def extract_bits(
         self,
         data: bytes,
         bits: int = 1,
         order: BitOrder = BitOrder.LSB,
         channels: str = "rgba",
-        pixel_order: PixelOrder = PixelOrder.XY
+        pixel_order: PixelOrder = PixelOrder.XY,
     ) -> bytes:
         """
         Extract bits from image data using zsteg-compatible algorithm.
-        
+
         This matches zsteg's exact behavior:
         - LSB order: extract bit 0 from each byte
-        - MSB order: extract bit 7 from each byte  
+        - MSB order: extract bit 7 from each byte
         - Bits are packed MSB-first into output bytes
-        
+
         Args:
             data: Raw pixel data (RGBA format)
             bits: Number of bits to extract per byte (1-8)
             order: LSB or MSB first
             channels: Which channels to use (r, g, b, a, rgb, rgba, etc.)
             pixel_order: Order to traverse pixels
-            
+
         Returns:
             Extracted bytes
         """
         if not data or bits < 1 or bits > 8:
             return b""
-        
+
         result_bits = []
         max_bits = min(len(data) * bits, self.max_extract_bytes * 8)
-        
+
         for i, byte_val in enumerate(data):
             if len(result_bits) >= max_bits:
                 break
-            
+
             # Extract specified number of bits
             if order == BitOrder.LSB:
                 # Extract from LSB (bit 0, 1, 2, ...)
@@ -101,119 +104,119 @@ class LSBExtractor:
                 for bit_idx in range(bits):
                     bit = (byte_val >> (7 - bit_idx)) & 1
                     result_bits.append(bit)
-        
+
         # Convert bits to bytes using MSB-first packing (zsteg's method)
         # In zsteg: when bit_order is :lsb, it does: byte |= (a.shift<<(7-i))
         # This means first extracted bit goes to position 7 (MSB), second to position 6, etc.
         result_bytes = bytearray()
         for i in range(0, len(result_bits), 8):
             if i + 8 <= len(result_bits):
-                byte_bits = result_bits[i:i+8]
+                byte_bits = result_bits[i : i + 8]
                 byte_val = 0
                 # Pack MSB-first: first bit at position 7, last bit at position 0
                 for bit_pos, bit in enumerate(byte_bits):
-                    byte_val |= (bit << (7 - bit_pos))
+                    byte_val |= bit << (7 - bit_pos)
                 result_bytes.append(byte_val)
-        
+
         return bytes(result_bytes)
-    
+
     def pack_bits(self, bits: list[int]) -> bytes:
         """Pack a list of bits into bytes using MSB-first packing.
-        
+
         Args:
             bits: List of bits (0 or 1)
-            
+
         Returns:
             Packed bytes
         """
         result_bytes = bytearray()
         for i in range(0, len(bits), 8):
             if i + 8 <= len(bits):
-                byte_bits = bits[i:i+8]
+                byte_bits = bits[i : i + 8]
                 byte_val = 0
                 # Pack MSB-first: first bit at position 7, last bit at position 0
                 for bit_pos, bit in enumerate(byte_bits):
-                    byte_val |= (bit << (7 - bit_pos))
+                    byte_val |= bit << (7 - bit_pos)
                 result_bytes.append(byte_val)
-        
+
         return bytes(result_bytes)
-    
+
     def detect_flag_patterns(self, data: bytes) -> Optional[str]:
         """Detect common CTF flag patterns in data.
-        
+
         Searches for patterns like picoCTF{...}, flag{...}, HTB{...}, etc.
         """
         import re
-        
+
         try:
             # Decode as much as possible, ignoring errors
-            text = data.decode('latin-1')
-            
+            text = data.decode("latin-1")
+
             # Common flag patterns
             patterns = [
-                r'picoCTF\{[^}]{5,}\}',
-                r'flag\{[^}]{5,}\}',
-                r'FLAG\{[^}]{5,}\}',
-                r'HTB\{[^}]{5,}\}',
-                r'CTF\{[^}]{5,}\}',
+                r"picoCTF\{[^}]{5,}\}",
+                r"flag\{[^}]{5,}\}",
+                r"FLAG\{[^}]{5,}\}",
+                r"HTB\{[^}]{5,}\}",
+                r"CTF\{[^}]{5,}\}",
             ]
-            
+
             for pattern in patterns:
                 match = re.search(pattern, text, re.IGNORECASE)
                 if match:
                     return match.group()
-            
+
         except Exception:
             pass
-        
+
         return None
-    
+
     def detect_file_type(self, data: bytes) -> Optional[str]:
         """Detect file type from magic bytes (like zsteg does)."""
         if not data or len(data) < 4:
             return None
-        
+
         # Common file signatures
         signatures = [
-            (b'\x89PNG\r\n\x1a\n', 'PNG image data'),
-            (b'\xff\xd8\xff', 'JPEG image data'),
-            (b'GIF87a', 'GIF image data, version 87a'),
-            (b'GIF89a', 'GIF image data, version 89a'),
-            (b'BM', 'PC bitmap'),
-            (b'%PDF', 'PDF document'),
-            (b'PK\x03\x04', 'Zip archive data'),
-            (b'\x1f\x8b', 'gzip compressed data'),
-            (b'\x50\x4b\x03\x04', 'Zip archive data'),
-            (b'Rar!', 'RAR archive data'),
-            (b'\x7fELF', 'ELF'),
-            (b'MZ', 'DOS/MBR boot sector'),
-            (b'\x00\x00\x01\x00', 'MS Windows icon resource'),
+            (b"\x89PNG\r\n\x1a\n", "PNG image data"),
+            (b"\xff\xd8\xff", "JPEG image data"),
+            (b"GIF87a", "GIF image data, version 87a"),
+            (b"GIF89a", "GIF image data, version 89a"),
+            (b"BM", "PC bitmap"),
+            (b"%PDF", "PDF document"),
+            (b"PK\x03\x04", "Zip archive data"),
+            (b"\x1f\x8b", "gzip compressed data"),
+            (b"\x50\x4b\x03\x04", "Zip archive data"),
+            (b"Rar!", "RAR archive data"),
+            (b"\x7fELF", "ELF"),
+            (b"MZ", "DOS/MBR boot sector"),
+            (b"\x00\x00\x01\x00", "MS Windows icon resource"),
             # OpenPGP signatures (common in stego)
-            (b'\x99\x01', 'OpenPGP Public Key'),
-            (b'\x95\x01', 'OpenPGP Secret Key'),
-            (b'\x99\x00', 'OpenPGP Public Key'),
-            (b'\x95\x00', 'OpenPGP Secret Key'),
+            (b"\x99\x01", "OpenPGP Public Key"),
+            (b"\x95\x01", "OpenPGP Secret Key"),
+            (b"\x99\x00", "OpenPGP Public Key"),
+            (b"\x95\x00", "OpenPGP Secret Key"),
             # Targa image patterns (zsteg detects these)
-            (b'\x00\x00\x02\x00', 'Targa image data'),
-            (b'\x00\x00\x03\x00', 'Targa image data'),
-            (b'\x00\x00\x0a\x00', 'Targa image data'),
-            (b'\x00\x00\x0b\x00', 'Targa image data'),
+            (b"\x00\x00\x02\x00", "Targa image data"),
+            (b"\x00\x00\x03\x00", "Targa image data"),
+            (b"\x00\x00\x0a\x00", "Targa image data"),
+            (b"\x00\x00\x0b\x00", "Targa image data"),
         ]
-        
+
         for sig, desc in signatures:
             if data.startswith(sig):
                 # Add more details for Targa images (like zsteg does)
-                if 'Targa' in desc and len(data) >= 18:
+                if "Targa" in desc and len(data) >= 18:
                     try:
                         data[0]
                         color_map_type = data[1]
                         image_type = data[2]
-                        width = struct.unpack('<H', data[12:14])[0]
-                        height = struct.unpack('<H', data[14:16])[0]
+                        width = struct.unpack("<H", data[12:14])[0]
+                        height = struct.unpack("<H", data[14:16])[0]
                         pixel_depth = data[16]
                         descriptor = data[17]
                         alpha_bits = descriptor & 0x0F
-                        
+
                         # Build detailed description like zsteg
                         details = "Targa image data"
                         if image_type == 1:
@@ -222,20 +225,20 @@ class LSBExtractor:
                             details += " - RGB"
                         elif image_type == 3:
                             details += " - Mono"
-                        
+
                         if color_map_type:
                             details += f" {width} x {height}"
                         else:
                             details += f" ({width}-{height})"
-                        
+
                         details += f" {width} x {height}"
-                        
+
                         if pixel_depth:
                             details += f" x {pixel_depth}"
-                        
+
                         if alpha_bits:
                             details += f" +{alpha_bits}"
-                        
+
                         # Direction flags
                         direction_flags = (descriptor >> 4) & 0x03
                         if direction_flags == 0:
@@ -246,64 +249,64 @@ class LSBExtractor:
                             details += " - right/bottom"
                         elif direction_flags == 3:
                             details += " - left/bottom"
-                        
+
                         if alpha_bits:
                             details += f" - {alpha_bits}-bit alpha"
-                        
+
                         return details
                     except Exception:
                         pass
-                
+
                 return desc
-        
+
         # Check for Alliant virtual executable (zsteg detects this)
         if len(data) >= 8:
             # Alliant virtual executable pattern
-            if data[0:2] == b'\x01\x03' or data[0:2] == b'\x01\x07':
+            if data[0:2] == b"\x01\x03" or data[0:2] == b"\x01\x07":
                 return "0420 Alliant virtual executable not stripped"
-        
+
         # Check for Applesoft BASIC (zsteg detects this)
         if len(data) >= 4:
             if data[0] in (0x00, 0x01) and data[2] in range(0x00, 0x20):
                 # Could be Applesoft BASIC
-                first_line = struct.unpack('<H', data[0:2])[0]
+                first_line = struct.unpack("<H", data[0:2])[0]
                 if 1 <= first_line <= 65535:
                     return f"Applesoft BASIC program data, first line number {first_line}"
-        
+
         return None
-    
+
     def detect_printable_strings(self, data: bytes) -> Optional[str]:
         """Detect ASCII printable strings in data."""
         if not data:
             return None
-        
+
         # Look for printable ASCII strings
         current_string = []
         longest_string = ""
-        
+
         for byte in data[:1024]:  # Check first 1KB
             if 32 <= byte <= 126:  # Printable ASCII
                 current_string.append(chr(byte))
             else:
                 if len(current_string) >= self.min_string_len:
-                    s = ''.join(current_string)
+                    s = "".join(current_string)
                     if len(s) > len(longest_string):
                         longest_string = s
                 current_string = []
-        
+
         # Check final string
         if len(current_string) >= self.min_string_len:
-            s = ''.join(current_string)
+            s = "".join(current_string)
             if len(s) > len(longest_string):
                 longest_string = s
-        
+
         return longest_string if longest_string else None
-    
+
     def detect_zlib(self, data: bytes) -> Optional[bytes]:
         """Try to decompress data as zlib."""
         if not data or len(data) < 2:
             return None
-        
+
         # Try different offsets for zlib header
         for offset in range(min(16, len(data) - 2)):
             try:
@@ -312,28 +315,28 @@ class LSBExtractor:
                     return decompressed
             except zlib.error:
                 continue
-        
+
         return None
-    
+
     def detect_base64(self, data: bytes) -> Optional[bytes]:
         """Detect and decode base64 data."""
         import base64
         import re
-        
+
         try:
             # Look for base64 pattern - check first 500 bytes
-            text = data[:500].decode('ascii', errors='ignore')
+            text = data[:500].decode("ascii", errors="ignore")
             # Base64 pattern: only A-Za-z0-9+/= chars, at least 20 chars
-            base64_pattern = re.compile(r'([A-Za-z0-9+/]{20,}={0,2})')
+            base64_pattern = re.compile(r"([A-Za-z0-9+/]{20,}={0,2})")
             matches = base64_pattern.findall(text)
-            
+
             for b64_str in matches:
                 try:
                     # Pad if necessary
                     missing_padding = len(b64_str) % 4
                     if missing_padding:
-                        b64_str += '=' * (4 - missing_padding)
-                    
+                        b64_str += "=" * (4 - missing_padding)
+
                     decoded = base64.b64decode(b64_str)
                     # Only return if decoded data looks meaningful (at least 10 bytes)
                     if len(decoded) >= 10:
@@ -342,243 +345,261 @@ class LSBExtractor:
                     continue
         except Exception:
             pass
-        
+
         return None
 
 
 class PNGStegoDetector:
     """Detect steganography in PNG files."""
-    
+
     def __init__(self):
         self.extractor = LSBExtractor()
-    
+
     def extract_png_metadata(self, data: bytes) -> list[StegoResult]:
         """Extract metadata from PNG text chunks (tEXt, iTXt, zTXt).
-        
+
         This mimics zsteg's metadata extraction behavior.
         """
         results = []
-        
-        if not data.startswith(b'\x89PNG\r\n\x1a\n'):
+
+        if not data.startswith(b"\x89PNG\r\n\x1a\n"):
             return results
-        
+
         offset = 8  # Skip PNG signature
-        
+
         while offset < len(data):
             if offset + 8 > len(data):
                 break
-            
+
             try:
                 # Read chunk length and type
-                chunk_len = struct.unpack('>I', data[offset:offset+4])[0]
-                chunk_type = data[offset+4:offset+8]
+                chunk_len = struct.unpack(">I", data[offset : offset + 4])[0]
+                chunk_type = data[offset + 4 : offset + 8]
                 chunk_data_start = offset + 8
                 chunk_data_end = chunk_data_start + chunk_len
-                
+
                 if chunk_data_end > len(data):
                     break
-                
+
                 chunk_data = data[chunk_data_start:chunk_data_end]
-                
+
                 # tEXt chunk: keyword\0text
-                if chunk_type == b'tEXt':
-                    null_pos = chunk_data.find(b'\0')
+                if chunk_type == b"tEXt":
+                    null_pos = chunk_data.find(b"\0")
                     if null_pos > 0:
-                        keyword = chunk_data[:null_pos].decode('latin1', errors='ignore')
-                        text = chunk_data[null_pos+1:].decode('latin1', errors='ignore')
-                        
+                        keyword = chunk_data[:null_pos].decode("latin1", errors="ignore")
+                        text = chunk_data[null_pos + 1 :].decode("latin1", errors="ignore")
+
                         # Check for flags
-                        flag = self.extractor.detect_flag_patterns(text.encode('utf-8'))
+                        flag = self.extractor.detect_flag_patterns(text.encode("utf-8"))
                         confidence = 1.0 if flag else 0.7
-                        
-                        results.append(StegoResult(
-                            method=f"meta {keyword}",
-                            channel="tEXt",
-                            bit_plane=0,
-                            order="metadata",
-                            data=text.encode('utf-8'),
-                            data_type="text",
-                            description=f"text: \"{text}\"" if not flag else f"FLAG: {flag}",
-                            confidence=confidence,
-                            offset=chunk_data_start,
-                            size=len(text)
-                        ))
-                
+
+                        results.append(
+                            StegoResult(
+                                method=f"meta {keyword}",
+                                channel="tEXt",
+                                bit_plane=0,
+                                order="metadata",
+                                data=text.encode("utf-8"),
+                                data_type="text",
+                                description=f'text: "{text}"' if not flag else f"FLAG: {flag}",
+                                confidence=confidence,
+                                offset=chunk_data_start,
+                                size=len(text),
+                            )
+                        )
+
                 # iTXt chunk: keyword\0compression\0language\0translated_keyword\0text
-                elif chunk_type == b'iTXt':
-                    null_pos = chunk_data.find(b'\0')
+                elif chunk_type == b"iTXt":
+                    null_pos = chunk_data.find(b"\0")
                     if null_pos > 0:
-                        keyword = chunk_data[:null_pos].decode('utf-8', errors='ignore')
-                        remaining = chunk_data[null_pos+1:]
-                        
+                        keyword = chunk_data[:null_pos].decode("utf-8", errors="ignore")
+                        remaining = chunk_data[null_pos + 1 :]
+
                         if len(remaining) >= 2:
                             compression_flag = remaining[0]
                             remaining[1]
-                            
+
                             # Find language and text
                             remaining = remaining[2:]
-                            null_pos2 = remaining.find(b'\0')
+                            null_pos2 = remaining.find(b"\0")
                             if null_pos2 >= 0:
-                                remaining[:null_pos2].decode('utf-8', errors='ignore')
-                                remaining = remaining[null_pos2+1:]
-                                
+                                remaining[:null_pos2].decode("utf-8", errors="ignore")
+                                remaining = remaining[null_pos2 + 1 :]
+
                                 # Skip translated keyword
-                                null_pos3 = remaining.find(b'\0')
+                                null_pos3 = remaining.find(b"\0")
                                 if null_pos3 >= 0:
-                                    text_data = remaining[null_pos3+1:]
-                                    
+                                    text_data = remaining[null_pos3 + 1 :]
+
                                     # Decompress if needed
                                     if compression_flag == 1:
                                         try:
                                             text_data = zlib.decompress(text_data)
                                         except Exception:
                                             pass
-                                    
-                                    text = text_data.decode('utf-8', errors='ignore')
-                                    
+
+                                    text = text_data.decode("utf-8", errors="ignore")
+
                                     # Check for flags
-                                    flag = self.extractor.detect_flag_patterns(text.encode('utf-8'))
+                                    flag = self.extractor.detect_flag_patterns(text.encode("utf-8"))
                                     confidence = 1.0 if flag else 0.75
-                                    
-                                    results.append(StegoResult(
+
+                                    results.append(
+                                        StegoResult(
+                                            method=f"meta {keyword}",
+                                            channel="iTXt",
+                                            bit_plane=0,
+                                            order="metadata",
+                                            data=text.encode("utf-8"),
+                                            data_type="text",
+                                            description=(
+                                                f"file: {text[:100]}"
+                                                if len(text) > 100
+                                                else f'text: "{text}"'
+                                            ),
+                                            confidence=confidence,
+                                            offset=chunk_data_start,
+                                            size=len(text),
+                                        )
+                                    )
+
+                # zTXt chunk: keyword\0compression_method\compressed_text
+                elif chunk_type == b"zTXt":
+                    null_pos = chunk_data.find(b"\0")
+                    if null_pos > 0:
+                        keyword = chunk_data[:null_pos].decode("latin1", errors="ignore")
+
+                        if len(chunk_data) > null_pos + 2:
+                            chunk_data[null_pos + 1]
+                            compressed_text = chunk_data[null_pos + 2 :]
+
+                            try:
+                                text = zlib.decompress(compressed_text).decode(
+                                    "latin1", errors="ignore"
+                                )
+
+                                # Check for flags
+                                flag = self.extractor.detect_flag_patterns(text.encode("utf-8"))
+                                confidence = 1.0 if flag else 0.7
+
+                                results.append(
+                                    StegoResult(
                                         method=f"meta {keyword}",
-                                        channel="iTXt",
+                                        channel="zTXt",
                                         bit_plane=0,
                                         order="metadata",
-                                        data=text.encode('utf-8'),
+                                        data=text.encode("utf-8"),
                                         data_type="text",
-                                        description=f"file: {text[:100]}" if len(text) > 100 else f"text: \"{text}\"",
+                                        description=(
+                                            f'text: "{text}"' if not flag else f"FLAG: {flag}"
+                                        ),
                                         confidence=confidence,
                                         offset=chunk_data_start,
-                                        size=len(text)
-                                    ))
-                
-                # zTXt chunk: keyword\0compression_method\compressed_text
-                elif chunk_type == b'zTXt':
-                    null_pos = chunk_data.find(b'\0')
-                    if null_pos > 0:
-                        keyword = chunk_data[:null_pos].decode('latin1', errors='ignore')
-                        
-                        if len(chunk_data) > null_pos + 2:
-                            chunk_data[null_pos+1]
-                            compressed_text = chunk_data[null_pos+2:]
-                            
-                            try:
-                                text = zlib.decompress(compressed_text).decode('latin1', errors='ignore')
-                                
-                                # Check for flags
-                                flag = self.extractor.detect_flag_patterns(text.encode('utf-8'))
-                                confidence = 1.0 if flag else 0.7
-                                
-                                results.append(StegoResult(
-                                    method=f"meta {keyword}",
-                                    channel="zTXt",
-                                    bit_plane=0,
-                                    order="metadata",
-                                    data=text.encode('utf-8'),
-                                    data_type="text",
-                                    description=f"text: \"{text}\"" if not flag else f"FLAG: {flag}",
-                                    confidence=confidence,
-                                    offset=chunk_data_start,
-                                    size=len(text)
-                                ))
+                                        size=len(text),
+                                    )
+                                )
                             except Exception as e:
                                 logger.debug(f"Failed to decompress zTXt chunk: {e}")
-                
+
                 # tIME chunk: last modification time
-                elif chunk_type == b'tIME' and len(chunk_data) >= 7:
-                    year = struct.unpack('>H', chunk_data[0:2])[0]
+                elif chunk_type == b"tIME" and len(chunk_data) >= 7:
+                    year = struct.unpack(">H", chunk_data[0:2])[0]
                     month = chunk_data[2]
                     day = chunk_data[3]
                     hour = chunk_data[4]
                     minute = chunk_data[5]
                     second = chunk_data[6]
-                    
-                    time_str = f"{year:04d}-{month:02d}-{day:02d} {hour:02d}:{minute:02d}:{second:02d}"
-                    
-                    results.append(StegoResult(
-                        method="meta,tIME",
-                        channel="tIME",
-                        bit_plane=0,
-                        order="metadata",
-                        data=time_str.encode('utf-8'),
-                        data_type="timestamp",
-                        description=f"PNG modification time: {time_str}",
-                        confidence=0.5,
-                        offset=chunk_data_start,
-                        size=7
-                    ))
-                
+
+                    time_str = (
+                        f"{year:04d}-{month:02d}-{day:02d} {hour:02d}:{minute:02d}:{second:02d}"
+                    )
+
+                    results.append(
+                        StegoResult(
+                            method="meta,tIME",
+                            channel="tIME",
+                            bit_plane=0,
+                            order="metadata",
+                            data=time_str.encode("utf-8"),
+                            data_type="timestamp",
+                            description=f"PNG modification time: {time_str}",
+                            confidence=0.5,
+                            offset=chunk_data_start,
+                            size=7,
+                        )
+                    )
+
                 # Move to next chunk
-                if chunk_type == b'IEND':
+                if chunk_type == b"IEND":
                     break
-                
+
                 offset += 12 + chunk_len  # length(4) + type(4) + data(chunk_len) + CRC(4)
-                
+
             except Exception as e:
                 logger.debug(f"Error parsing PNG chunk at offset {offset}: {e}")
                 break
-        
+
         return results
-    
+
     def parse_png(self, data: bytes) -> Optional[dict]:
         """Parse PNG using PIL for reliable pixel extraction.
-        
+
         Returns pixels in RGBA format, row by row (xy order),
         which matches zsteg's zpng behavior.
         """
         # First, extract raw IDAT data manually (needed for imagedata analysis)
-        raw_idat_decompressed = b''
-        if data.startswith(b'\x89PNG\r\n\x1a\n'):
+        raw_idat_decompressed = b""
+        if data.startswith(b"\x89PNG\r\n\x1a\n"):
             offset = 8
-            idat_compressed = b''
-            
+            idat_compressed = b""
+
             while offset < len(data):
                 if offset + 8 > len(data):
                     break
-                
+
                 try:
-                    chunk_len = struct.unpack('>I', data[offset:offset+4])[0]
-                    chunk_type = data[offset+4:offset+8]
-                    chunk_data = data[offset+8:offset+8+chunk_len]
-                    
-                    if chunk_type == b'IDAT':
+                    chunk_len = struct.unpack(">I", data[offset : offset + 4])[0]
+                    chunk_type = data[offset + 4 : offset + 8]
+                    chunk_data = data[offset + 8 : offset + 8 + chunk_len]
+
+                    if chunk_type == b"IDAT":
                         idat_compressed += chunk_data
-                    elif chunk_type == b'IEND':
+                    elif chunk_type == b"IEND":
                         break
-                    
+
                     offset += 12 + chunk_len
                 except Exception:
                     break
-            
+
             if idat_compressed:
                 try:
                     raw_idat_decompressed = zlib.decompress(idat_compressed)
                 except Exception:
                     pass
-        
+
         try:
             from PIL import Image
             import io
-            
+
             img = Image.open(io.BytesIO(data))
-            
+
             # Convert to RGBA if needed (same as zsteg)
-            if img.mode != 'RGBA':
-                img = img.convert('RGBA')
-            
+            if img.mode != "RGBA":
+                img = img.convert("RGBA")
+
             # Get pixel data as flat array
             # PIL returns pixels in row-major order (left-to-right, top-to-bottom)
             # Each pixel is 4 bytes: R, G, B, A
             # This matches zpng's pixel iteration order
             pixels = bytearray(img.tobytes())
-            
+
             return {
-                'width': img.width,
-                'height': img.height,
-                'mode': img.mode,
-                'clean_pixels': bytes(pixels),
-                'raw_idat_decompressed': raw_idat_decompressed
+                "width": img.width,
+                "height": img.height,
+                "mode": img.mode,
+                "clean_pixels": bytes(pixels),
+                "raw_idat_decompressed": raw_idat_decompressed,
             }
         except ImportError:
             logger.warning("PIL not available, falling back to manual PNG parsing")
@@ -586,75 +607,75 @@ class PNGStegoDetector:
         except Exception as e:
             logger.debug(f"Failed to load PNG with PIL: {e}")
             return None
-    
+
     def _manual_png_parse(self, data: bytes) -> Optional[dict]:
         """Fallback manual PNG parser."""
-        if not data.startswith(b'\x89PNG\r\n\x1a\n'):
+        if not data.startswith(b"\x89PNG\r\n\x1a\n"):
             return None
-        
+
         info = {
-            'width': 0,
-            'height': 0,
-            'bit_depth': 0,
-            'color_type': 0,
-            'image_data': b'',
-            'chunks': [],
-            'clean_pixels': b'',
-            'raw_idat_decompressed': b''  # Store raw decompressed data
+            "width": 0,
+            "height": 0,
+            "bit_depth": 0,
+            "color_type": 0,
+            "image_data": b"",
+            "chunks": [],
+            "clean_pixels": b"",
+            "raw_idat_decompressed": b"",  # Store raw decompressed data
         }
-        
+
         offset = 8  # Skip PNG signature
-        
+
         while offset < len(data):
             if offset + 8 > len(data):
                 break
-            
+
             # Read chunk length and type
-            chunk_len = struct.unpack('>I', data[offset:offset+4])[0]
-            chunk_type = data[offset+4:offset+8]
-            chunk_data = data[offset+8:offset+8+chunk_len]
-            
-            info['chunks'].append((chunk_type.decode('latin1', errors='ignore'), chunk_len))
-            
-            if chunk_type == b'IHDR' and len(chunk_data) >= 13:
-                info['width'] = struct.unpack('>I', chunk_data[0:4])[0]
-                info['height'] = struct.unpack('>I', chunk_data[4:8])[0]
-                info['bit_depth'] = chunk_data[8]
-                info['color_type'] = chunk_data[9]
-            elif chunk_type == b'IDAT':
-                info['image_data'] += chunk_data
-            elif chunk_type == b'IEND':
+            chunk_len = struct.unpack(">I", data[offset : offset + 4])[0]
+            chunk_type = data[offset + 4 : offset + 8]
+            chunk_data = data[offset + 8 : offset + 8 + chunk_len]
+
+            info["chunks"].append((chunk_type.decode("latin1", errors="ignore"), chunk_len))
+
+            if chunk_type == b"IHDR" and len(chunk_data) >= 13:
+                info["width"] = struct.unpack(">I", chunk_data[0:4])[0]
+                info["height"] = struct.unpack(">I", chunk_data[4:8])[0]
+                info["bit_depth"] = chunk_data[8]
+                info["color_type"] = chunk_data[9]
+            elif chunk_type == b"IDAT":
+                info["image_data"] += chunk_data
+            elif chunk_type == b"IEND":
                 break
-            
+
             offset += 12 + chunk_len  # length + type + data + CRC
-        
+
         # Decompress and remove filter bytes
-        if info['image_data']:
+        if info["image_data"]:
             try:
-                decompressed = zlib.decompress(info['image_data'])
-                info['raw_idat_decompressed'] = decompressed  # Store raw decompressed data
-                
+                decompressed = zlib.decompress(info["image_data"])
+                info["raw_idat_decompressed"] = decompressed  # Store raw decompressed data
+
                 # Remove PNG filter bytes (first byte of each scanline)
-                bytes_per_pixel = 4 if info['color_type'] == 6 else 3  # RGBA or RGB
-                bytes_per_row = info['width'] * bytes_per_pixel + 1  # +1 for filter byte
-                
+                bytes_per_pixel = 4 if info["color_type"] == 6 else 3  # RGBA or RGB
+                bytes_per_row = info["width"] * bytes_per_pixel + 1  # +1 for filter byte
+
                 clean_pixels = bytearray()
-                for y in range(info['height']):
+                for y in range(info["height"]):
                     row_start = y * bytes_per_row
                     if row_start + bytes_per_row <= len(decompressed):
                         # Skip filter byte (first byte of row)
-                        row_data = decompressed[row_start + 1:row_start + bytes_per_row]
+                        row_data = decompressed[row_start + 1 : row_start + bytes_per_row]
                         clean_pixels.extend(row_data)
-                
-                info['clean_pixels'] = bytes(clean_pixels)
+
+                info["clean_pixels"] = bytes(clean_pixels)
             except Exception as e:
                 logger.debug(f"Failed to process PNG pixels: {e}")
-        
+
         return info
-    
+
     def reorder_pixels(self, pixels: bytes, width: int, height: int, pixel_order: str) -> bytes:
         """Reorder pixels according to traversal order.
-        
+
         Args:
             pixels: Raw pixel data in RGBA format (row-major, left-to-right, top-to-bottom)
             width: Image width
@@ -664,85 +685,87 @@ class PNGStegoDetector:
                 yx: top-to-bottom, left-to-right
                 XY: right-to-left, top-to-bottom
                 YX: bottom-to-top, left-to-right
-        
+
         Returns:
             Reordered pixel data
         """
         bytes_per_pixel = 4  # RGBA
-        
+
         # xy order is already the native format
         if pixel_order == "xy":
             return pixels
-        
+
         result = bytearray()
-        
+
         if pixel_order == "yx":
             # Top-to-bottom, left-to-right (column-major)
             for x in range(width):
                 for y in range(height):
                     pixel_offset = (y * width + x) * bytes_per_pixel
-                    result.extend(pixels[pixel_offset:pixel_offset + bytes_per_pixel])
-        
+                    result.extend(pixels[pixel_offset : pixel_offset + bytes_per_pixel])
+
         elif pixel_order == "XY":
             # Right-to-left, top-to-bottom
             for y in range(height):
                 for x in range(width - 1, -1, -1):
                     pixel_offset = (y * width + x) * bytes_per_pixel
-                    result.extend(pixels[pixel_offset:pixel_offset + bytes_per_pixel])
-        
+                    result.extend(pixels[pixel_offset : pixel_offset + bytes_per_pixel])
+
         elif pixel_order == "YX":
             # Bottom-to-top, left-to-right
             for x in range(width):
                 for y in range(height - 1, -1, -1):
                     pixel_offset = (y * width + x) * bytes_per_pixel
-                    result.extend(pixels[pixel_offset:pixel_offset + bytes_per_pixel])
-        
+                    result.extend(pixels[pixel_offset : pixel_offset + bytes_per_pixel])
+
         else:
             # Unknown order, return original
             return pixels
-        
+
         return bytes(result)
-    
-    def extract_channel_data(self, pixels: bytes, channels: str, bits_per_channel: int = 1, bit_order: str = "lsb") -> bytes:
+
+    def extract_channel_data(
+        self, pixels: bytes, channels: str, bits_per_channel: int = 1, bit_order: str = "lsb"
+    ) -> bytes:
         """Extract data from specific color channels (zsteg-compatible).
-        
+
         This properly handles multi-bit extraction by directly packing nibbles/bytes.
-        
+
         Args:
             pixels: Raw pixel data in RGBA format (4 bytes per pixel)
             channels: Which channels to extract ('rgb', 'rgba', 'r', 'g', 'b', 'a', 'bgr', 'abgr', etc.)
             bits_per_channel: Number of bits to extract per channel (1-8)
             bit_order: 'lsb' for least significant bits first, 'msb' for most significant bits first
-            
+
         Returns:
             Extracted bytes
         """
         bytes_per_pixel = 4  # RGBA
         num_pixels = len(pixels) // bytes_per_pixel
-        
+
         # Collect extracted nibbles/bytes as integer values
         extracted_values = []
-        
+
         for i in range(num_pixels):
             pixel_start = i * bytes_per_pixel
             r = pixels[pixel_start]
             g = pixels[pixel_start + 1]
             b = pixels[pixel_start + 2]
             a = pixels[pixel_start + 3]
-            
+
             # Extract values from requested channels in order
             for channel in channels:
-                if channel == 'r':
+                if channel == "r":
                     value = r
-                elif channel == 'g':
+                elif channel == "g":
                     value = g
-                elif channel == 'b':
+                elif channel == "b":
                     value = b
-                elif channel == 'a':
+                elif channel == "a":
                     value = a
                 else:
                     continue
-                
+
                 # Extract N bits from this channel value
                 if bit_order == "lsb":
                     # Extract LSBs: mask to get lowest N bits
@@ -754,9 +777,9 @@ class PNGStegoDetector:
                     # e.g., for 4 bits from 0xAB, shift right 4 to get 0x0A
                     shift = 8 - bits_per_channel
                     extracted_val = value >> shift
-                
+
                 extracted_values.append(extracted_val)
-        
+
         # Now pack the extracted values into bytes
         # Each value contains bits_per_channel bits
         if bits_per_channel == 8:
@@ -794,30 +817,32 @@ class PNGStegoDetector:
                         byte_val = (byte_val << 1) | extracted_values[i + j]
                 result.append(byte_val)
             return bytes(result)
-    
-    def analyze_imagedata(self, data: bytes, raw_idat_decompressed: bytes = None) -> Optional[StegoResult]:
+
+    def analyze_imagedata(
+        self, data: bytes, raw_idat_decompressed: bytes = None
+    ) -> Optional[StegoResult]:
         """Analyze raw pixel data for patterns (like zsteg's imagedata).
-        
+
         This looks at the decompressed IDAT data (before filter byte removal)
         to find readable patterns or text.
-        
+
         Args:
             data: Clean pixel data (for fallback)
             raw_idat_decompressed: Raw decompressed IDAT data (with filter bytes)
         """
         # Prefer raw IDAT data if available
         analyze_data = raw_idat_decompressed if raw_idat_decompressed else data
-        
+
         # Look through the entire data for printable sequences
         best_text = None
         best_length = 0
-        
+
         # Scan through data looking for printable sequences
         i = 0
         while i < len(analyze_data):
             # Start collecting printable characters
             printable_chars = []
-            
+
             while i < len(analyze_data):
                 byte = analyze_data[i]
                 if 32 <= byte <= 126 or byte in (9, 10, 13):  # Printable or whitespace
@@ -825,67 +850,67 @@ class PNGStegoDetector:
                     i += 1
                 else:
                     break
-            
+
             # If we found a good sequence, keep track of it
             if len(printable_chars) >= 8:
-                text = ''.join(printable_chars)
+                text = "".join(printable_chars)
                 if len(text) > best_length:
                     best_text = text
                     best_length = len(text)
-            
+
             i += 1
-        
+
         if best_text and len(best_text) >= 8:
             # Limit display to reasonable length
             display_text = best_text[:100] if len(best_text) > 100 else best_text
-            
+
             # Use repr to properly escape special characters
             display_text = repr(display_text)[1:-1]  # Remove outer quotes
-            
+
             return StegoResult(
                 method="imagedata",
                 channel="pixels",
                 bit_plane=0,
                 order="raw",
-                data=best_text.encode('utf-8'),
+                data=best_text.encode("utf-8"),
                 data_type="text",
                 description=f'text: "{display_text}"',
                 confidence=0.6,
                 offset=0,
-                size=len(best_text)
+                size=len(best_text),
             )
-        
+
         return None
-    
+
     def detect(self, data: bytes) -> list[StegoResult]:
         """
         Detect LSB steganography in PNG file.
-        
+
         Args:
             data: PNG file data
-            
+
         Returns:
             List of steganography results found
         """
         results = []
-        
+
         # First, extract PNG metadata chunks (tEXt, iTXt, zTXt) - like zsteg does
         metadata_results = self.extract_png_metadata(data)
         results.extend(metadata_results)
-        
+
         png_info = self.parse_png(data)
-        if not png_info or not png_info['clean_pixels']:
+        if not png_info or not png_info["clean_pixels"]:
             return results
-        
+
         # Use clean pixel data (RGBA format)
-        image_data = png_info['clean_pixels']
-        
+        image_data = png_info["clean_pixels"]
+
         # Analyze raw imagedata (decompressed IDAT with filter bytes) - like zsteg
-        raw_idat = png_info.get('raw_idat_decompressed', b'')
+        raw_idat = png_info.get("raw_idat_decompressed", b"")
         imagedata_result = self.analyze_imagedata(image_data, raw_idat)
         if imagedata_result:
             results.append(imagedata_result)
-        
+
         # Test different bit planes and channels (matching zsteg's comprehensive scan)
         test_configs = [
             # b1 (1-bit) LSB tests - xy order (standard: left-to-right, top-to-bottom)
@@ -897,7 +922,6 @@ class PNGStegoDetector:
             (1, "a", "lsb", "xy"),
             (1, "bgr", "lsb", "xy"),
             (1, "abgr", "lsb", "xy"),
-            
             # b2 (2-bit) LSB tests
             (2, "rgba", "lsb", "xy"),
             (2, "rgb", "lsb", "xy"),
@@ -905,7 +929,6 @@ class PNGStegoDetector:
             (2, "g", "lsb", "xy"),
             (2, "b", "lsb", "xy"),
             (2, "a", "lsb", "xy"),
-            
             # b4 (4-bit) LSB tests
             (4, "rgba", "lsb", "xy"),
             (4, "rgb", "lsb", "xy"),
@@ -913,20 +936,16 @@ class PNGStegoDetector:
             (4, "r", "lsb", "xy"),
             (4, "g", "lsb", "xy"),
             (4, "b", "lsb", "xy"),
-            
             # b1 (1-bit) LSB tests - yx order (column-major)
             (1, "rgba", "lsb", "yx"),
             (1, "rgb", "lsb", "yx"),
             (1, "b", "lsb", "yx"),
-            
             # b1 (1-bit) LSB tests - XY order (reversed horizontal)
             (1, "rgba", "lsb", "XY"),
             (1, "rgb", "lsb", "XY"),
-            
             # b1 (1-bit) LSB tests - YX order (reversed vertical)
             (1, "rgba", "lsb", "YX"),
             (1, "rgb", "lsb", "YX"),
-            
             # b1 (1-bit) MSB tests - xy order
             (1, "rgba", "msb", "xy"),
             (1, "rgb", "msb", "xy"),
@@ -935,115 +954,123 @@ class PNGStegoDetector:
             (1, "b", "msb", "xy"),
             (1, "a", "msb", "xy"),
             (1, "abgr", "msb", "xy"),
-            
             # b2 (2-bit) MSB tests
             (2, "rgba", "msb", "xy"),
             (2, "rgb", "msb", "xy"),
             (2, "r", "msb", "xy"),
             (2, "g", "msb", "xy"),
             (2, "b", "msb", "xy"),
-            
             # b4 (4-bit) MSB tests
             (4, "rgba", "msb", "xy"),
             (4, "rgb", "msb", "xy"),
             (4, "r", "msb", "xy"),
             (4, "g", "msb", "xy"),
             (4, "b", "msb", "xy"),
-            
             # b1 MSB tests - yx order
             (1, "rgba", "msb", "yx"),
             (1, "rgb", "msb", "yx"),
         ]
-        
-        width = png_info.get('width', 0)
-        height = png_info.get('height', 0)
-        
+
+        width = png_info.get("width", 0)
+        height = png_info.get("height", 0)
+
         for bits, channels, bit_order, px_order in test_configs:
             # Reorder pixels according to pixel order
             reordered_pixels = self.reorder_pixels(image_data, width, height, px_order)
-            
+
             # Extract data from specific color channels
             extracted = self.extract_channel_data(reordered_pixels, channels, bits, bit_order)
-            
+
             if not extracted:
                 continue
-            
+
             # First, check for file type (like zsteg does)
             file_type = self.extractor.detect_file_type(extracted)
             if file_type:
                 # Show first bytes as preview
-                ' '.join(f'\\{ord(c):03o}' if c < ' ' or c > '~' else c for c in extracted[:50].decode('latin-1', errors='ignore'))
-                results.append(StegoResult(
-                    method=f"b{bits},{channels},{bit_order},{px_order}",
-                    channel=channels,
-                    bit_plane=bits,
-                    order=px_order,
-                    data=extracted,
-                    data_type="file",
-                    description=f'file: {file_type}',
-                    confidence=0.95,
-                    size=len(extracted)
-                ))
-            
+                " ".join(
+                    f"\\{ord(c):03o}" if c < " " or c > "~" else c
+                    for c in extracted[:50].decode("latin-1", errors="ignore")
+                )
+                results.append(
+                    StegoResult(
+                        method=f"b{bits},{channels},{bit_order},{px_order}",
+                        channel=channels,
+                        bit_plane=bits,
+                        order=px_order,
+                        data=extracted,
+                        data_type="file",
+                        description=f"file: {file_type}",
+                        confidence=0.95,
+                        size=len(extracted),
+                    )
+                )
+
             # Check for flag patterns (highest priority for text)
             flag = self.extractor.detect_flag_patterns(extracted)
             if flag:
-                results.append(StegoResult(
-                    method=f"b{bits},{channels},{bit_order},{px_order}",
-                    channel=channels,
-                    bit_plane=bits,
-                    order=px_order,
-                    data=flag.encode(),
-                    data_type="flag",
-                    description=f'text: "{flag}"',
-                    confidence=1.0,
-                    size=len(flag)
-                ))
-            
+                results.append(
+                    StegoResult(
+                        method=f"b{bits},{channels},{bit_order},{px_order}",
+                        channel=channels,
+                        bit_plane=bits,
+                        order=px_order,
+                        data=flag.encode(),
+                        data_type="flag",
+                        description=f'text: "{flag}"',
+                        confidence=1.0,
+                        size=len(flag),
+                    )
+                )
+
             # Check for printable strings
             printable_str = self.extractor.detect_printable_strings(extracted)
             if printable_str and not flag:  # Don't duplicate if we already found a flag
                 # Truncate long strings to match zsteg's output style (max ~250 chars)
                 display_str = printable_str[:250] if len(printable_str) > 250 else printable_str
-                results.append(StegoResult(
-                    method=f"b{bits},{channels},{bit_order},{px_order}",
-                    channel=channels,
-                    bit_plane=bits,
-                    order=px_order,
-                    data=printable_str.encode(),
-                    data_type="text",
-                    description=f'text: "{display_str}"',
-                    confidence=0.75,
-                    size=len(printable_str)
-                ))
-            
+                results.append(
+                    StegoResult(
+                        method=f"b{bits},{channels},{bit_order},{px_order}",
+                        channel=channels,
+                        bit_plane=bits,
+                        order=px_order,
+                        data=printable_str.encode(),
+                        data_type="text",
+                        description=f'text: "{display_str}"',
+                        confidence=0.75,
+                        size=len(printable_str),
+                    )
+                )
+
             # Check for zlib compressed data
             zlib_data = self.extractor.detect_zlib(extracted)
             if zlib_data:
                 # Detect what the decompressed data is
                 desc = "zlib compressed data"
-                if zlib_data.startswith(b'%PDF'):
+                if zlib_data.startswith(b"%PDF"):
                     desc = "zlib: PDF document"
-                elif zlib_data.startswith(b'\x89PNG'):
+                elif zlib_data.startswith(b"\x89PNG"):
                     desc = "zlib: PNG image"
-                
+
                 # Try to find printable content
                 printable = self.extractor.detect_printable_strings(zlib_data)
                 if printable:
                     desc += f', contains: "{printable[:50]}"'
-                
-                results.append(StegoResult(
-                    method=f"b{bits},{channels},{bit_order},{px_order}",
-                    channel=channels,
-                    bit_plane=bits,
-                    order=px_order,
-                    data=zlib_data,
-                    data_type="zlib",
-                    description=desc,
-                    confidence=0.95,
-                    size=len(zlib_data)
-                ))
-            
+
+                results.append(
+                    StegoResult(
+                        method=f"b{bits},{channels},{bit_order},{px_order}",
+                        channel=channels,
+                        bit_plane=bits,
+                        order=px_order,
+                        data=zlib_data,
+                        data_type="zlib",
+                        description=desc,
+                        confidence=0.95,
+                        size=len(zlib_data),
+                    )
+                )
+
             # Check for base64 encoded data
             base64_data = self.extractor.detect_base64(extracted)
             if base64_data:
@@ -1052,61 +1079,63 @@ class PNGStegoDetector:
                 printable = self.extractor.detect_printable_strings(base64_data)
                 if printable:
                     desc += f': "{printable[:50]}"'
-                
-                results.append(StegoResult(
-                    method=f"b{bits},{channels},{bit_order},{px_order}",
-                    channel=channels,
-                    bit_plane=bits,
-                    order=px_order,
-                    data=base64_data,
-                    data_type="base64",
-                    description=desc,
-                    confidence=0.85,
-                    size=len(base64_data)
-                ))
-        
+
+                results.append(
+                    StegoResult(
+                        method=f"b{bits},{channels},{bit_order},{px_order}",
+                        channel=channels,
+                        bit_plane=bits,
+                        order=px_order,
+                        data=base64_data,
+                        data_type="base64",
+                        description=desc,
+                        confidence=0.85,
+                        size=len(base64_data),
+                    )
+                )
+
         return results
 
 
 class BMPStegoDetector:
     """Detect steganography in BMP files."""
-    
+
     def __init__(self):
         self.extractor = LSBExtractor()
-    
+
     def parse_bmp(self, data: bytes) -> Optional[dict]:
         """Parse BMP structure."""
-        if not data.startswith(b'BM'):
+        if not data.startswith(b"BM"):
             return None
-        
+
         if len(data) < 54:  # Minimum BMP header size
             return None
-        
+
         info = {
-            'file_size': struct.unpack('<I', data[2:6])[0],
-            'pixel_offset': struct.unpack('<I', data[10:14])[0],
-            'width': struct.unpack('<I', data[18:22])[0],
-            'height': struct.unpack('<I', data[22:26])[0],
-            'bit_depth': struct.unpack('<H', data[28:30])[0],
+            "file_size": struct.unpack("<I", data[2:6])[0],
+            "pixel_offset": struct.unpack("<I", data[10:14])[0],
+            "width": struct.unpack("<I", data[18:22])[0],
+            "height": struct.unpack("<I", data[22:26])[0],
+            "bit_depth": struct.unpack("<H", data[28:30])[0],
         }
-        
-        if info['pixel_offset'] < len(data):
-            info['image_data'] = data[info['pixel_offset']:]
+
+        if info["pixel_offset"] < len(data):
+            info["image_data"] = data[info["pixel_offset"] :]
         else:
-            info['image_data'] = b''
-        
+            info["image_data"] = b""
+
         return info
-    
+
     def detect(self, data: bytes) -> list[StegoResult]:
         """Detect LSB steganography in BMP file."""
         results = []
-        
+
         bmp_info = self.parse_bmp(data)
-        if not bmp_info or not bmp_info['image_data']:
+        if not bmp_info or not bmp_info["image_data"]:
             return results
-        
-        image_data = bmp_info['image_data']
-        
+
+        image_data = bmp_info["image_data"]
+
         # Test configurations similar to PNG
         test_configs = [
             (1, "bgr", "lsb", "xy"),
@@ -1116,32 +1145,32 @@ class BMPStegoDetector:
             (1, "r", "lsb", "xy"),
             (2, "bgr", "lsb", "xy"),
         ]
-        
+
         for bits, channels, bit_order, px_order in test_configs:
             extracted = self.extractor.extract_bits(
-                image_data,
-                bits=bits,
-                order=BitOrder.LSB if bit_order == "lsb" else BitOrder.MSB
+                image_data, bits=bits, order=BitOrder.LSB if bit_order == "lsb" else BitOrder.MSB
             )
-            
+
             if not extracted:
                 continue
-            
+
             # Check for strings
             printable_str = self.extractor.detect_printable_strings(extracted)
             if printable_str:
-                results.append(StegoResult(
-                    method=f"b{bits},{channels},{bit_order},{px_order}",
-                    channel=channels,
-                    bit_plane=bits,
-                    order=px_order,
-                    data=printable_str.encode(),
-                    data_type="text",
-                    description=f'text: "{printable_str}"',
-                    confidence=0.9,
-                    size=len(printable_str)
-                ))
-            
+                results.append(
+                    StegoResult(
+                        method=f"b{bits},{channels},{bit_order},{px_order}",
+                        channel=channels,
+                        bit_plane=bits,
+                        order=px_order,
+                        data=printable_str.encode(),
+                        data_type="text",
+                        description=f'text: "{printable_str}"',
+                        confidence=0.9,
+                        size=len(printable_str),
+                    )
+                )
+
             # Check for zlib
             zlib_data = self.extractor.detect_zlib(extracted)
             if zlib_data:
@@ -1149,108 +1178,110 @@ class BMPStegoDetector:
                 printable = self.extractor.detect_printable_strings(zlib_data)
                 if printable:
                     desc += f', contains: "{printable[:50]}"'
-                
-                results.append(StegoResult(
-                    method=f"b{bits},{channels},{bit_order},{px_order}",
-                    channel=channels,
-                    bit_plane=bits,
-                    order=px_order,
-                    data=zlib_data,
-                    data_type="zlib",
-                    description=desc,
-                    confidence=0.95,
-                    size=len(zlib_data)
-                ))
-        
+
+                results.append(
+                    StegoResult(
+                        method=f"b{bits},{channels},{bit_order},{px_order}",
+                        channel=channels,
+                        bit_plane=bits,
+                        order=px_order,
+                        data=zlib_data,
+                        data_type="zlib",
+                        description=desc,
+                        confidence=0.95,
+                        size=len(zlib_data),
+                    )
+                )
+
         return results
 
 
 class PDFMetadataDetector:
     """Detect steganography in PDF metadata."""
-    
+
     def __init__(self):
         self.extractor = LSBExtractor()
-    
+
     def extract_metadata(self, data: bytes) -> dict:
         """Extract PDF metadata fields."""
         metadata = {}
-        
-        if not data.startswith(b'%PDF'):
+
+        if not data.startswith(b"%PDF"):
             return metadata
-        
+
         # Find the Info dictionary
         # Look for /Info reference in trailer
-        trailer_match = data.rfind(b'trailer')
+        trailer_match = data.rfind(b"trailer")
         if trailer_match == -1:
             return metadata
-        
+
         # Search for metadata fields in the PDF
         # Common fields: /Author, /Title, /Subject, /Keywords, /Creator, /Producer
-        fields = [b'/Author', b'/Title', b'/Subject', b'/Keywords', b'/Creator', b'/Producer']
-        
+        fields = [b"/Author", b"/Title", b"/Subject", b"/Keywords", b"/Creator", b"/Producer"]
+
         for field in fields:
-            field_name = field.decode('ascii').lstrip('/')
-            
+            field_name = field.decode("ascii").lstrip("/")
+
             # Find field in PDF
             pos = 0
             while True:
                 pos = data.find(field, pos)
                 if pos == -1:
                     break
-                
+
                 # Extract the value (usually in parentheses or angle brackets)
                 # Format: /Author (value) or /Author <hex>
                 value_start = pos + len(field)
-                
+
                 # Skip whitespace
-                while value_start < len(data) and data[value_start:value_start+1] in b' \t\n\r':
+                while value_start < len(data) and data[value_start : value_start + 1] in b" \t\n\r":
                     value_start += 1
-                
+
                 if value_start >= len(data):
                     break
-                
+
                 # Extract based on delimiter
-                if data[value_start:value_start+1] == b'(':
+                if data[value_start : value_start + 1] == b"(":
                     # Parentheses format: (value)
-                    value_end = data.find(b')', value_start)
+                    value_end = data.find(b")", value_start)
                     if value_end != -1:
-                        value = data[value_start+1:value_end]
+                        value = data[value_start + 1 : value_end]
                         try:
-                            metadata[field_name] = value.decode('utf-8', errors='ignore')
+                            metadata[field_name] = value.decode("utf-8", errors="ignore")
                         except Exception:
-                            metadata[field_name] = value.decode('latin-1', errors='ignore')
+                            metadata[field_name] = value.decode("latin-1", errors="ignore")
                         break
-                elif data[value_start:value_start+1] == b'<':
+                elif data[value_start : value_start + 1] == b"<":
                     # Hex format: <hex>
-                    value_end = data.find(b'>', value_start)
+                    value_end = data.find(b">", value_start)
                     if value_end != -1:
-                        hex_value = data[value_start+1:value_end]
+                        hex_value = data[value_start + 1 : value_end]
                         try:
                             # Decode hex
-                            value = bytes.fromhex(hex_value.decode('ascii'))
-                            metadata[field_name] = value.decode('utf-8', errors='ignore')
+                            value = bytes.fromhex(hex_value.decode("ascii"))
+                            metadata[field_name] = value.decode("utf-8", errors="ignore")
                         except Exception:
                             pass
                         break
-                
+
                 pos = value_start
-        
+
         return metadata
-    
+
     def detect(self, data: bytes) -> list[StegoResult]:
         """Detect steganography in PDF metadata."""
         results = []
-        
+
         metadata = self.extract_metadata(data)
-        
+
         if not metadata:
             return results
-        
+
         # Check each metadata field for hidden data
         for field_name, field_value in metadata.items():
             if not field_value or len(field_value) < 10:
                 continue
-            
+
             # Check for base64
             base64_data = self.extractor.detect_base64(field_value.encode())
             if base64_data:
@@ -1258,122 +1289,128 @@ class PDFMetadataDetector:
                 printable = self.extractor.detect_printable_strings(base64_data)
                 if printable:
                     desc += f': "{printable[:50]}"'
-                
-                results.append(StegoResult(
-                    method=f"metadata,{field_name.lower()}",
-                    channel=field_name,
-                    bit_plane=0,
-                    order="metadata",
-                    data=base64_data,
-                    data_type="metadata",
-                    description=desc,
-                    confidence=0.95,
-                    size=len(base64_data)
-                ))
-            
-            # Also show raw metadata if it contains printable strings
-            elif len(field_value) > 20:
-                printable = self.extractor.detect_printable_strings(field_value.encode())
-                if printable and printable != field_value[:len(printable)]:
-                    # Found something different from the raw value
-                    results.append(StegoResult(
+
+                results.append(
+                    StegoResult(
                         method=f"metadata,{field_name.lower()}",
                         channel=field_name,
                         bit_plane=0,
                         order="metadata",
-                        data=printable.encode(),
+                        data=base64_data,
                         data_type="metadata",
-                        description=f'PDF metadata ({field_name}): "{field_value[:100]}"',
-                        confidence=0.7,
-                        size=len(printable)
-                    ))
-        
+                        description=desc,
+                        confidence=0.95,
+                        size=len(base64_data),
+                    )
+                )
+
+            # Also show raw metadata if it contains printable strings
+            elif len(field_value) > 20:
+                printable = self.extractor.detect_printable_strings(field_value.encode())
+                if printable and printable != field_value[: len(printable)]:
+                    # Found something different from the raw value
+                    results.append(
+                        StegoResult(
+                            method=f"metadata,{field_name.lower()}",
+                            channel=field_name,
+                            bit_plane=0,
+                            order="metadata",
+                            data=printable.encode(),
+                            data_type="metadata",
+                            description=f'PDF metadata ({field_name}): "{field_value[:100]}"',
+                            confidence=0.7,
+                            size=len(printable),
+                        )
+                    )
+
         return results
 
 
 class TrailingDataDetector:
     """Detect data appended after file end markers."""
-    
+
     def __init__(self):
         self.extractor = LSBExtractor()
-    
+
     def find_file_end(self, data: bytes, format_hint: Optional[str] = None) -> Optional[int]:
         """Find the logical end of a file based on its format."""
-        
+
         # JPEG: Find last FF D9 (EOI marker)
-        if format_hint == 'jpeg' or data.startswith(b'\xff\xd8\xff'):
-            pos = data.rfind(b'\xff\xd9')
+        if format_hint == "jpeg" or data.startswith(b"\xff\xd8\xff"):
+            pos = data.rfind(b"\xff\xd9")
             if pos != -1:
                 return pos + 2  # After the EOI marker
-        
+
         # PNG: Find IEND chunk
-        elif format_hint == 'png' or data.startswith(b'\x89PNG'):
-            pos = data.find(b'IEND')
+        elif format_hint == "png" or data.startswith(b"\x89PNG"):
+            pos = data.find(b"IEND")
             if pos != -1:
                 # IEND is followed by 4-byte CRC
                 return pos + 8
-        
+
         # PDF: Find %%EOF
-        elif format_hint == 'pdf' or data.startswith(b'%PDF'):
-            pos = data.rfind(b'%%EOF')
+        elif format_hint == "pdf" or data.startswith(b"%PDF"):
+            pos = data.rfind(b"%%EOF")
             if pos != -1:
                 # Skip any whitespace after EOF
                 end_pos = pos + 5
-                while end_pos < len(data) and data[end_pos:end_pos+1] in b'\r\n\t ':
+                while end_pos < len(data) and data[end_pos : end_pos + 1] in b"\r\n\t ":
                     end_pos += 1
                 return end_pos
-        
+
         # GIF: Find trailer (0x3B)
-        elif format_hint == 'gif' or data.startswith(b'GIF8'):
-            pos = data.rfind(b'\x3b')
+        elif format_hint == "gif" or data.startswith(b"GIF8"):
+            pos = data.rfind(b"\x3b")
             if pos != -1:
                 return pos + 1
-        
+
         return None
-    
+
     def detect(self, data: bytes, format_hint: Optional[str] = None) -> list[StegoResult]:
         """Detect trailing data after file end marker."""
         results = []
-        
+
         # Auto-detect format
         if format_hint is None:
-            if data.startswith(b'\xff\xd8\xff'):
-                format_hint = 'jpeg'
-            elif data.startswith(b'\x89PNG'):
-                format_hint = 'png'
-            elif data.startswith(b'%PDF'):
-                format_hint = 'pdf'
-            elif data.startswith(b'GIF8'):
-                format_hint = 'gif'
-        
+            if data.startswith(b"\xff\xd8\xff"):
+                format_hint = "jpeg"
+            elif data.startswith(b"\x89PNG"):
+                format_hint = "png"
+            elif data.startswith(b"%PDF"):
+                format_hint = "pdf"
+            elif data.startswith(b"GIF8"):
+                format_hint = "gif"
+
         end_pos = self.find_file_end(data, format_hint)
-        
+
         if end_pos is None or end_pos >= len(data):
             return results
-        
+
         # Extract trailing data
         trailing = data[end_pos:]
-        
+
         if len(trailing) < 4:  # Ignore very small trailing data
             return results
-        
+
         # Check for printable text
         printable = self.extractor.detect_printable_strings(trailing)
         if printable:
             display_str = printable[:100] if len(printable) > 100 else printable
-            results.append(StegoResult(
-                method=f"trailing,{format_hint or 'unknown'}",
-                channel="EOI",
-                bit_plane=0,
-                order="trailing",
-                data=printable.encode(),
-                data_type="trailing",
-                description=f'Trailing data after {format_hint.upper()} end: "{display_str}"',
-                confidence=0.95,
-                offset=end_pos,
-                size=len(printable)
-            ))
-        
+            results.append(
+                StegoResult(
+                    method=f"trailing,{format_hint or 'unknown'}",
+                    channel="EOI",
+                    bit_plane=0,
+                    order="trailing",
+                    data=printable.encode(),
+                    data_type="trailing",
+                    description=f'Trailing data after {format_hint.upper()} end: "{display_str}"',
+                    confidence=0.95,
+                    offset=end_pos,
+                    size=len(printable),
+                )
+            )
+
         # Check for base64 in trailing data
         base64_data = self.extractor.detect_base64(trailing)
         if base64_data:
@@ -1381,117 +1418,129 @@ class TrailingDataDetector:
             printable_b64 = self.extractor.detect_printable_strings(base64_data)
             if printable_b64:
                 desc += f': "{printable_b64[:50]}"'
-            
-            results.append(StegoResult(
-                method=f"trailing,{format_hint or 'unknown'},base64",
-                channel="EOI",
-                bit_plane=0,
-                order="trailing",
-                data=base64_data,
-                data_type="trailing",
-                description=desc,
-                confidence=0.9,
-                offset=end_pos,
-                size=len(base64_data)
-            ))
-        
+
+            results.append(
+                StegoResult(
+                    method=f"trailing,{format_hint or 'unknown'},base64",
+                    channel="EOI",
+                    bit_plane=0,
+                    order="trailing",
+                    data=base64_data,
+                    data_type="trailing",
+                    description=desc,
+                    confidence=0.9,
+                    offset=end_pos,
+                    size=len(base64_data),
+                )
+            )
+
         return results
 
 
 class SVGStegoDetector:
     """Detect hidden text and steganography in SVG files."""
-    
+
     def __init__(self):
         self.extractor = LSBExtractor()
-    
+
     def detect(self, data: bytes) -> list[StegoResult]:
         """Detect hidden text in SVG files."""
         results = []
-        
+
         try:
             # Parse as text
-            svg_text = data.decode('utf-8', errors='ignore')
-            
+            svg_text = data.decode("utf-8", errors="ignore")
+
             # Check if it's actually SVG
-            if not ('<svg' in svg_text.lower() or '<?xml' in svg_text.lower()):
+            if not ("<svg" in svg_text.lower() or "<?xml" in svg_text.lower()):
                 return results
-            
+
             # Find all text elements with their properties
             hidden_texts = []
-            
+
             # Parse with ElementTree
             try:
                 # Remove namespace to make parsing easier
-                svg_clean = re.sub(r'\sxmlns[^=]*="[^"]*"', '', svg_text)
-                svg_clean = re.sub(r'\s+xmlns:[^=]+="[^"]*"', '', svg_clean)
-                
-                root = ET.fromstring(svg_clean.encode('utf-8'))
-                
+                svg_clean = re.sub(r'\sxmlns[^=]*="[^"]*"', "", svg_text)
+                svg_clean = re.sub(r'\s+xmlns:[^=]+="[^"]*"', "", svg_clean)
+
+                root = ET.fromstring(svg_clean.encode("utf-8"))
+
                 # Find all text and tspan elements
                 for elem in root.iter():
                     tag = elem.tag.lower() if isinstance(elem.tag, str) else str(elem.tag).lower()
-                    
-                    if 'text' in tag or 'tspan' in tag:
-                        text = elem.text or ''
-                        style = elem.get('style', '')
-                        font_size_attr = elem.get('font-size', '')
-                        
+
+                    if "text" in tag or "tspan" in tag:
+                        text = elem.text or ""
+                        style = elem.get("style", "")
+                        font_size_attr = elem.get("font-size", "")
+
                         # Extract font size from style or attribute
                         font_size = None
-                        
+
                         # Check style attribute
-                        font_match = re.search(r'font-size:\s*([\d.]+)', style)
+                        font_match = re.search(r"font-size:\s*([\d.]+)", style)
                         if font_match:
                             font_size = float(font_match.group(1))
                         elif font_size_attr:
-                            font_size_match = re.search(r'([\d.]+)', font_size_attr)
+                            font_size_match = re.search(r"([\d.]+)", font_size_attr)
                             if font_size_match:
                                 font_size = float(font_size_match.group(1))
-                        
+
                         # Detect suspicious text
                         is_tiny = font_size is not None and font_size < 0.1
-                        is_white = 'fill:#ffffff' in style or 'fill:white' in style.lower()
-                        has_flag = self.extractor.detect_flag_patterns(text.encode('utf-8', errors='ignore'))
-                        
+                        is_white = "fill:#ffffff" in style or "fill:white" in style.lower()
+                        has_flag = self.extractor.detect_flag_patterns(
+                            text.encode("utf-8", errors="ignore")
+                        )
+
                         if text and (is_tiny or (is_white and has_flag)):
-                            hidden_texts.append({
-                                'text': text,
-                                'font_size': font_size,
-                                'style': style,
-                                'is_tiny': is_tiny,
-                                'is_white': is_white,
-                                'has_flag': has_flag
-                            })
-            
+                            hidden_texts.append(
+                                {
+                                    "text": text,
+                                    "font_size": font_size,
+                                    "style": style,
+                                    "is_tiny": is_tiny,
+                                    "is_white": is_white,
+                                    "has_flag": has_flag,
+                                }
+                            )
+
             except ET.ParseError:
                 # Fallback to regex if XML parsing fails
                 pass
-            
+
             # Regex fallback for finding tiny text
-            tiny_text_pattern = r'font-size:\s*0\.\d+px[^>]*>([^<]+)'
+            tiny_text_pattern = r"font-size:\s*0\.\d+px[^>]*>([^<]+)"
             for match in re.finditer(tiny_text_pattern, svg_text):
                 text_content = match.group(1).strip()
                 if text_content:
-                    hidden_texts.append({
-                        'text': text_content,
-                        'font_size': 0.0,
-                        'style': 'tiny',
-                        'is_tiny': True,
-                        'is_white': False,
-                        'has_flag': self.extractor.detect_flag_patterns(text_content.encode('utf-8', errors='ignore'))
-                    })
-            
+                    hidden_texts.append(
+                        {
+                            "text": text_content,
+                            "font_size": 0.0,
+                            "style": "tiny",
+                            "is_tiny": True,
+                            "is_white": False,
+                            "has_flag": self.extractor.detect_flag_patterns(
+                                text_content.encode("utf-8", errors="ignore")
+                            ),
+                        }
+                    )
+
             # Process found hidden texts
             if hidden_texts:
                 # Combine all text
-                all_text = ' '.join([ht['text'] for ht in hidden_texts])
-                
+                all_text = " ".join([ht["text"] for ht in hidden_texts])
+
                 # Clean up - remove extra spaces between single characters (common in SVG stego)
-                cleaned_text = re.sub(r'(?<=[a-zA-Z0-9_{}])\s+(?=[a-zA-Z0-9_{}])', '', all_text)
-                
+                cleaned_text = re.sub(r"(?<=[a-zA-Z0-9_{}])\s+(?=[a-zA-Z0-9_{}])", "", all_text)
+
                 # Check for flags
-                flags = self.extractor.detect_flag_patterns(cleaned_text.encode('utf-8', errors='ignore'))
-                
+                flags = self.extractor.detect_flag_patterns(
+                    cleaned_text.encode("utf-8", errors="ignore")
+                )
+
                 if flags:
                     confidence = 1.0
                     desc = f"Hidden SVG text (font-size < 0.1px): {flags[:100]}"
@@ -1500,108 +1549,117 @@ class SVGStegoDetector:
                     confidence = 0.8
                     desc = f"Hidden SVG text (font-size < 0.1px): {cleaned_text[:100]}"
                     display_text = cleaned_text
-                
-                results.append(StegoResult(
-                    method="svg,hidden_text",
-                    channel="text",
-                    bit_plane=0,
-                    order="xml",
-                    data=display_text.encode('utf-8'),
-                    data_type="text",
-                    description=desc,
-                    confidence=confidence,
-                    offset=0,
-                    size=len(display_text)
-                ))
-            
+
+                results.append(
+                    StegoResult(
+                        method="svg,hidden_text",
+                        channel="text",
+                        bit_plane=0,
+                        order="xml",
+                        data=display_text.encode("utf-8"),
+                        data_type="text",
+                        description=desc,
+                        confidence=confidence,
+                        offset=0,
+                        size=len(display_text),
+                    )
+                )
+
             # Also check for suspicious comments
-            comments = re.findall(r'<!--\s*(.+?)\s*-->', svg_text, re.DOTALL)
+            comments = re.findall(r"<!--\s*(.+?)\s*-->", svg_text, re.DOTALL)
             for comment in comments:
                 comment_clean = comment.strip()
                 if len(comment_clean) > 20:  # Ignore short comments
-                    flags = self.extractor.detect_flag_patterns(comment_clean.encode('utf-8', errors='ignore'))
-                    if flags or any(keyword in comment_clean.lower() for keyword in ['flag', 'secret', 'hidden', 'password']):
-                        results.append(StegoResult(
-                            method="svg,comment",
-                            channel="xml",
-                            bit_plane=0,
-                            order="xml",
-                            data=comment_clean.encode('utf-8'),
-                            data_type="comment",
-                            description=f"Suspicious SVG comment: {comment_clean[:100]}",
-                            confidence=0.7 if flags else 0.5,
-                            offset=0,
-                            size=len(comment_clean)
-                        ))
-        
+                    flags = self.extractor.detect_flag_patterns(
+                        comment_clean.encode("utf-8", errors="ignore")
+                    )
+                    if flags or any(
+                        keyword in comment_clean.lower()
+                        for keyword in ["flag", "secret", "hidden", "password"]
+                    ):
+                        results.append(
+                            StegoResult(
+                                method="svg,comment",
+                                channel="xml",
+                                bit_plane=0,
+                                order="xml",
+                                data=comment_clean.encode("utf-8"),
+                                data_type="comment",
+                                description=f"Suspicious SVG comment: {comment_clean[:100]}",
+                                confidence=0.7 if flags else 0.5,
+                                offset=0,
+                                size=len(comment_clean),
+                            )
+                        )
+
         except Exception as e:
             logger.debug(f"SVG stego detection error: {e}")
-        
+
         return results
 
 
 def detect_steganography(data, format_hint: Optional[str] = None) -> list[StegoResult]:
     """
     Detect steganography in various file formats.
-    
+
     Supports:
     - PNG/BMP: LSB analysis
     - PDF: Metadata analysis
     - JPEG/PNG/PDF/GIF: Trailing data after EOI/IEND/EOF markers
-    
+
     Args:
         data: File data (bytes or file path)
         format_hint: Optional format hint ('png', 'bmp', 'pdf', 'jpeg', 'gif')
-        
+
     Returns:
         List of steganography results
     """
     # If data is a string, treat it as a file path
     if isinstance(data, str):
-        with open(data, 'rb') as f:
+        with open(data, "rb") as f:
             data = f.read()
-    
+
     results = []
-    
+
     # Auto-detect format if not provided
     if format_hint is None:
-        if data.startswith(b'\x89PNG'):
-            format_hint = 'png'
-        elif data.startswith(b'BM'):
-            format_hint = 'bmp'
-        elif data.startswith(b'%PDF'):
-            format_hint = 'pdf'
-        elif data.startswith(b'\xff\xd8\xff'):
-            format_hint = 'jpeg'
-        elif data.startswith(b'GIF8'):
-            format_hint = 'gif'
-        elif data.startswith(b'<?xml') or data.startswith(b'<svg'):
-            format_hint = 'svg'
-    
+        if data.startswith(b"\x89PNG"):
+            format_hint = "png"
+        elif data.startswith(b"BM"):
+            format_hint = "bmp"
+        elif data.startswith(b"%PDF"):
+            format_hint = "pdf"
+        elif data.startswith(b"\xff\xd8\xff"):
+            format_hint = "jpeg"
+        elif data.startswith(b"GIF8"):
+            format_hint = "gif"
+        elif data.startswith(b"<?xml") or data.startswith(b"<svg"):
+            format_hint = "svg"
+
     # LSB analysis for images
-    if format_hint == 'png' or data.startswith(b'\x89PNG'):
+    if format_hint == "png" or data.startswith(b"\x89PNG"):
         detector = PNGStegoDetector()
         results.extend(detector.detect(data))
-    
-    if format_hint == 'bmp' or data.startswith(b'BM'):
+
+    if format_hint == "bmp" or data.startswith(b"BM"):
         detector = BMPStegoDetector()
         results.extend(detector.detect(data))
-    
+
     # Metadata analysis for PDFs
-    if format_hint == 'pdf' or data.startswith(b'%PDF'):
+    if format_hint == "pdf" or data.startswith(b"%PDF"):
         detector = PDFMetadataDetector()
         results.extend(detector.detect(data))
-    
+
     # SVG hidden text detection
-    if format_hint == 'svg' or data.startswith(b'<?xml') or data.startswith(b'<svg'):
+    if format_hint == "svg" or data.startswith(b"<?xml") or data.startswith(b"<svg"):
         detector = SVGStegoDetector()
         results.extend(detector.detect(data))
-    
+
     # Trailing data detection for all formats
     trailing_detector = TrailingDataDetector()
     results.extend(trailing_detector.detect(data, format_hint))
-    
+
     # Sort by confidence
     results.sort(key=lambda x: x.confidence, reverse=True)
-    
+
     return results

--- a/filo/yarascanner.py
+++ b/filo/yarascanner.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 from dataclasses import dataclass, field
 
 logger = logging.getLogger(__name__)
@@ -15,8 +15,8 @@ class YARAMatch:
     rule: str
     namespace: str
     tags: list[str]
-    meta: dict
-    strings: list[dict]
+    meta: dict[str, Any]
+    strings: list[dict[str, Any]]
     data: bytes = b""
 
 
@@ -28,12 +28,12 @@ class YARAScanResult:
 
 
 class YARAScanner:
-    def __init__(self):
+    def __init__(self) -> None:
         self._yara = None
         self._rules = None
         self._init_yara()
 
-    def _init_yara(self):
+    def _init_yara(self) -> None:
         try:
             import yara
 
@@ -48,6 +48,7 @@ class YARAScanner:
     def compile_rules(self, source: str) -> None:
         if not self.available:
             raise YARAError("yara-python not installed. Install with: pip install yara-python")
+        assert self._yara is not None
         self._rules = self._yara.compile(source=source)
 
     def load_rule_file(self, path: Path, namespace: Optional[str] = None) -> None:
@@ -57,8 +58,10 @@ class YARAScanner:
             raise YARAError(f"Rule file not found: {path}")
         if namespace:
             sources = {namespace: str(path)}
+            assert self._yara is not None
             self._rules = self._yara.compile(filepaths=sources)
         else:
+            assert self._yara is not None
             self._rules = self._yara.compile(filepath=str(path))
 
     def load_rule_files(self, paths: list[Path]) -> None:
@@ -72,6 +75,7 @@ class YARAScanner:
                 continue
             sources[ns] = str(path)
         if sources:
+            assert self._yara is not None
             self._rules = self._yara.compile(filepaths=sources)
 
     def scan_file(self, path: Path, timeout: int = 60) -> YARAScanResult:
@@ -96,7 +100,7 @@ class YARAScanner:
         except Exception as e:
             return YARAScanResult(error=str(e))
 
-    def _process_matches(self, raw_matches) -> YARAScanResult:
+    def _process_matches(self, raw_matches: Any) -> YARAScanResult:
         matches = []
         for m in raw_matches:
             string_matches = []

--- a/filo/yarascanner.py
+++ b/filo/yarascanner.py
@@ -35,7 +35,7 @@ class YARAScanner:
 
     def _init_yara(self) -> None:
         try:
-            import yara
+            import yara  # type: ignore
 
             self._yara = yara
         except ImportError:

--- a/filo/yarascanner.py
+++ b/filo/yarascanner.py
@@ -102,19 +102,23 @@ class YARAScanner:
             string_matches = []
             for s in getattr(m, "strings", []):
                 for inst in getattr(s, "instances", []):
-                    string_matches.append({
-                        "identifier": s.identifier,
-                        "offset": inst.offset,
-                        "data": inst.matched_data,
-                        "length": inst.matched_length,
-                    })
-            matches.append(YARAMatch(
-                rule=m.rule,
-                namespace=getattr(m, "namespace", "default"),
-                tags=list(getattr(m, "tags", [])),
-                meta=dict(getattr(m, "meta", {})),
-                strings=string_matches,
-            ))
+                    string_matches.append(
+                        {
+                            "identifier": s.identifier,
+                            "offset": inst.offset,
+                            "data": inst.matched_data,
+                            "length": inst.matched_length,
+                        }
+                    )
+            matches.append(
+                YARAMatch(
+                    rule=m.rule,
+                    namespace=getattr(m, "namespace", "default"),
+                    tags=list(getattr(m, "tags", [])),
+                    meta=dict(getattr(m, "meta", {})),
+                    strings=string_matches,
+                )
+            )
         return YARAScanResult(
             matches=matches,
             rule_count=len(matches),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dev = [
     "black>=23.0.0",
     "mypy>=1.5.0",
     "ruff>=0.1.0",
+    "types-PyYAML>=6.0.0",
 ]
 
 [project.scripts]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,17 +18,20 @@ def temp_dir():
 def sample_png_data():
     """Sample PNG file data."""
     # PNG signature + minimal IHDR chunk
-    return bytes.fromhex(
-        "89504E470D0A1A0A"  # PNG signature
-        "0000000D49484452"  # IHDR chunk
-        "00000010"  # Width: 16
-        "00000010"  # Height: 16
-        "08"  # Bit depth: 8
-        "06"  # Color type: RGBA
-        "00"  # Compression: deflate
-        "00"  # Filter: adaptive
-        "00"  # Interlace: none
-    ) + b"\x00" * 100
+    return (
+        bytes.fromhex(
+            "89504E470D0A1A0A"  # PNG signature
+            "0000000D49484452"  # IHDR chunk
+            "00000010"  # Width: 16
+            "00000010"  # Height: 16
+            "08"  # Bit depth: 8
+            "06"  # Color type: RGBA
+            "00"  # Compression: deflate
+            "00"  # Filter: adaptive
+            "00"  # Interlace: none
+        )
+        + b"\x00" * 100
+    )
 
 
 @pytest.fixture
@@ -40,7 +43,7 @@ def sample_jpeg_data():
 @pytest.fixture
 def sample_pdf_data():
     """Sample PDF file data."""
-    return b"%PDF-1.7\r\n%\xE2\xE3\xCF\xD3\r\n1 0 obj\n<< /Type /Catalog >>\nendobj\n"
+    return b"%PDF-1.7\r\n%\xe2\xe3\xcf\xd3\r\n1 0 obj\n<< /Type /Catalog >>\nendobj\n"
 
 
 @pytest.fixture

--- a/tests/test_advanced_repair.py
+++ b/tests/test_advanced_repair.py
@@ -16,75 +16,75 @@ def repair_engine():
 
 class TestPNGRepair:
     """Tests for PNG repair strategies."""
-    
+
     def test_repair_png_chunks_valid(self, repair_engine):
         """Test PNG chunk repair with valid file."""
         # Create valid PNG with IHDR and IEND
         png = b"\x89PNG\r\n\x1a\n"
-        
+
         # IHDR chunk
         ihdr_data = struct.pack(">II", 100, 100)  # 100x100
         ihdr_data += b"\x08\x02\x00\x00\x00"
-        ihdr_crc = zlib.crc32(b"IHDR" + ihdr_data) & 0xffffffff
+        ihdr_crc = zlib.crc32(b"IHDR" + ihdr_data) & 0xFFFFFFFF
         png += struct.pack(">I", 13)  # Length
         png += b"IHDR" + ihdr_data
         png += struct.pack(">I", ihdr_crc)
-        
+
         # IEND chunk
-        iend_crc = zlib.crc32(b"IEND") & 0xffffffff
+        iend_crc = zlib.crc32(b"IEND") & 0xFFFFFFFF
         png += struct.pack(">I", 0)  # Length
         png += b"IEND"
         png += struct.pack(">I", iend_crc)
-        
+
         repaired, report = repair_engine._repair_png_chunks(png)
-        
+
         assert report.success is False  # No repairs needed
         assert "No repairs needed" in report.warnings
-    
+
     def test_repair_png_chunks_bad_crc(self, repair_engine):
         """Test PNG chunk repair with corrupted CRC."""
         # Create PNG with bad CRC
         png = b"\x89PNG\r\n\x1a\n"
-        
+
         # IHDR chunk with wrong CRC
         ihdr_data = struct.pack(">II", 100, 100)
         ihdr_data += b"\x08\x02\x00\x00\x00"
         png += struct.pack(">I", 13)
         png += b"IHDR" + ihdr_data
         png += struct.pack(">I", 0xDEADBEEF)  # Wrong CRC
-        
+
         # IEND chunk
-        iend_crc = zlib.crc32(b"IEND") & 0xffffffff
+        iend_crc = zlib.crc32(b"IEND") & 0xFFFFFFFF
         png += struct.pack(">I", 0)
         png += b"IEND"
         png += struct.pack(">I", iend_crc)
-        
+
         repaired, report = repair_engine._repair_png_chunks(png)
-        
+
         assert report.success is True
         assert report.chunks_repaired == 1
         assert "Fixed CRC for IHDR chunk" in report.changes_made
         assert repaired != png
-    
+
     def test_reconstruct_png_ihdr(self, repair_engine):
         """Test PNG IHDR reconstruction."""
         # PNG without IHDR
         png = b"\x89PNG\r\n\x1a\n"
         png += b"\x00\x00\x00\x00IDAT"  # Some IDAT data
-        
+
         repaired, report = repair_engine._reconstruct_png_ihdr(png)
-        
+
         assert report.success is True
         assert "Reconstructed IHDR chunk" in report.changes_made[0]
         assert repaired.startswith(b"\x89PNG\r\n\x1a\n")
         assert b"IHDR" in repaired
-    
+
     def test_reconstruct_png_ihdr_no_signature(self, repair_engine):
         """Test PNG IHDR reconstruction when signature is missing."""
         png = b"\x00\x00\x00\x00IDAT"  # No PNG signature
-        
+
         repaired, report = repair_engine._reconstruct_png_ihdr(png)
-        
+
         assert report.success is True
         assert repaired.startswith(b"\x89PNG\r\n\x1a\n")
         assert b"IHDR" in repaired
@@ -92,146 +92,146 @@ class TestPNGRepair:
 
 class TestJPEGRepair:
     """Tests for JPEG repair strategies."""
-    
+
     def test_repair_jpeg_markers_valid(self, repair_engine):
         """Test JPEG marker repair with valid file."""
         jpeg = b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00"
         jpeg += b"\xff\xd9"  # EOI marker
-        
+
         repaired, report = repair_engine._repair_jpeg_markers(jpeg)
-        
+
         assert report.success is False
         assert "No repairs needed" in report.warnings
-    
+
     def test_repair_jpeg_markers_no_soi(self, repair_engine):
         """Test JPEG marker repair without SOI."""
         jpeg = b"\x00\x00\x00\x00\xff\xd9"  # No SOI
-        
+
         repaired, report = repair_engine._repair_jpeg_markers(jpeg)
-        
+
         assert report.success is True
         assert "Added JPEG SOI and JFIF markers" in report.changes_made
         assert repaired.startswith(b"\xff\xd8")
-    
+
     def test_repair_jpeg_markers_no_eoi(self, repair_engine):
         """Test JPEG marker repair without EOI."""
         jpeg = b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00"
-        
+
         repaired, report = repair_engine._repair_jpeg_markers(jpeg)
-        
+
         assert report.success is True
         assert "Added JPEG EOI marker" in report.changes_made
         assert repaired.endswith(b"\xff\xd9")
-    
+
     def test_add_jpeg_eoi(self, repair_engine):
         """Test adding JPEG EOI marker."""
         jpeg = b"\xff\xd8\x00\x00\x00\x00"
-        
+
         repaired, report = repair_engine._add_jpeg_eoi(jpeg)
-        
+
         assert report.success is True
         assert repaired == jpeg + b"\xff\xd9"
         assert report.confidence == 0.95
-    
+
     def test_add_jpeg_eoi_already_present(self, repair_engine):
         """Test adding EOI when already present."""
         jpeg = b"\xff\xd8\x00\x00\xff\xd9"
-        
+
         repaired, report = repair_engine._add_jpeg_eoi(jpeg)
-        
+
         assert report.success is False
         assert "EOI marker already present" in report.warnings
 
 
 class TestZIPRepair:
     """Tests for ZIP repair strategies."""
-    
+
     def test_repair_zip_directory_valid(self, repair_engine):
         """Test ZIP directory repair with valid file."""
         zip_data = b"PK\x03\x04" + b"\x00" * 26  # Local file header
         zip_data += b"PK\x05\x06" + b"\x00" * 18  # EOCD
-        
+
         repaired, report = repair_engine._repair_zip_directory(zip_data)
-        
+
         assert report.success is False
         assert "Central directory appears intact" in report.warnings
-    
+
     def test_repair_zip_directory_missing_eocd(self, repair_engine):
         """Test ZIP directory repair without EOCD."""
         zip_data = b"PK\x03\x04" + b"\x00" * 26
-        
+
         repaired, report = repair_engine._repair_zip_directory(zip_data)
-        
+
         assert report.success is True
         assert "Reconstructed End of Central Directory" in report.changes_made
         assert b"PK\x05\x06" in repaired
-    
+
     def test_reconstruct_zip_headers(self, repair_engine):
         """Test ZIP header reconstruction."""
         zip_data = b"\x00\x00\x00\x00"  # No ZIP signature
-        
+
         repaired, report = repair_engine._reconstruct_zip_headers(zip_data)
-        
+
         assert report.success is True
         assert repaired.startswith(b"PK\x03\x04")
         assert "Added ZIP local file header" in report.changes_made
-    
+
     def test_reconstruct_zip_headers_already_present(self, repair_engine):
         """Test ZIP header reconstruction when already present."""
         zip_data = b"PK\x03\x04\x00\x00"
-        
+
         repaired, report = repair_engine._reconstruct_zip_headers(zip_data)
-        
+
         assert report.success is False
         assert "ZIP header already present" in report.warnings
 
 
 class TestPDFRepair:
     """Tests for PDF repair strategies."""
-    
+
     def test_repair_pdf_xref_valid(self, repair_engine):
         """Test PDF xref repair with valid file."""
         pdf = b"%PDF-1.4\nxref\n0 1\ntrailer\n%%EOF"
-        
+
         repaired, report = repair_engine._repair_pdf_xref(pdf)
-        
+
         assert report.success is False
         assert "xref table appears present" in report.warnings
-    
+
     def test_repair_pdf_xref_missing(self, repair_engine):
         """Test PDF xref repair without xref table."""
         pdf = b"%PDF-1.4\n1 0 obj\n<< /Type /Catalog >>\nendobj\n"
-        
+
         repaired, report = repair_engine._repair_pdf_xref(pdf)
-        
+
         assert report.success is True
         assert "Added minimal cross-reference table" in report.changes_made
         assert b"xref" in repaired
         assert b"%%EOF" in repaired
-    
+
     def test_add_pdf_eof(self, repair_engine):
         """Test adding PDF EOF marker."""
         pdf = b"%PDF-1.4\nxref\ntrailer"
-        
+
         repaired, report = repair_engine._add_pdf_eof(pdf)
-        
+
         assert report.success is True
         assert repaired.endswith(b"%%EOF")
         assert report.confidence == 0.9
-    
+
     def test_add_pdf_eof_already_present(self, repair_engine):
         """Test adding EOF when already present."""
         pdf = b"%PDF-1.4\n%%EOF"
-        
+
         repaired, report = repair_engine._add_pdf_eof(pdf)
-        
+
         assert report.success is False
         assert "EOF marker already present" in report.warnings
 
 
 class TestAdvancedRepairIntegration:
     """Integration tests for advanced repair strategies."""
-    
+
     def test_repair_corrupted_png(self, repair_engine):
         """Test repairing a corrupted PNG through main repair method."""
         # Create PNG with bad CRC
@@ -239,37 +239,37 @@ class TestAdvancedRepairIntegration:
         ihdr_data = struct.pack(">II", 100, 100) + b"\x08\x02\x00\x00\x00"
         png += struct.pack(">I", 13) + b"IHDR" + ihdr_data
         png += struct.pack(">I", 0xBADBAD)  # Bad CRC
-        
+
         repaired, report = repair_engine.repair(png, "png")
-        
+
         assert report.success is True
         assert repaired != png
-    
+
     def test_repair_truncated_jpeg(self, repair_engine):
         """Test repairing a truncated JPEG."""
         jpeg = b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00"
         # Missing EOI
-        
+
         repaired, report = repair_engine.repair(jpeg, "jpeg")
-        
+
         assert report.success is True
         assert repaired.endswith(b"\xff\xd9")
-    
+
     def test_repair_broken_zip(self, repair_engine):
         """Test repairing a broken ZIP file."""
         zip_data = b"PK\x03\x04" + b"\x00" * 26
         # Missing central directory
-        
+
         repaired, report = repair_engine.repair(zip_data, "zip")
-        
+
         assert report.success is True
         assert b"PK\x05\x06" in repaired
-    
+
     def test_repair_incomplete_pdf(self, repair_engine):
         """Test repairing an incomplete PDF."""
         pdf = b"%PDF-1.4\n1 0 obj\n<</Type/Catalog>>\nendobj\n"
-        
+
         repaired, report = repair_engine.repair(pdf, "pdf")
-        
+
         assert report.success is True
         assert b"%%EOF" in repaired

--- a/tests/test_advanced_repair.py
+++ b/tests/test_advanced_repair.py
@@ -2,12 +2,10 @@
 
 import struct
 import zlib
-from pathlib import Path
 
 import pytest
 
 from filo.repair import RepairEngine
-from filo.formats import FormatDatabase
 
 
 @pytest.fixture

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -2,9 +2,8 @@
 Tests for Analyzer
 """
 
-import pytest
 
-from filo.analyzer import Analyzer, SignatureAnalyzer, StatisticalAnalyzer
+from filo.analyzer import Analyzer, StatisticalAnalyzer
 
 
 def test_analyzer_initialization():

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -2,7 +2,6 @@
 Tests for Analyzer
 """
 
-
 from filo.analyzer import Analyzer, StatisticalAnalyzer
 
 
@@ -15,13 +14,13 @@ def test_analyzer_initialization():
 def test_analyze_png():
     """Test PNG file detection."""
     analyzer = Analyzer()
-    
+
     # PNG signature
     png_data = bytes.fromhex("89504E470D0A1A0A0000000D49484452")
     png_data += b"\x00" * 100  # Add some data
-    
+
     result = analyzer.analyze(png_data)
-    
+
     assert result.primary_format == "png"
     assert result.confidence > 0.5
     assert result.file_size == len(png_data)
@@ -31,13 +30,13 @@ def test_analyze_png():
 def test_analyze_jpeg():
     """Test JPEG file detection."""
     analyzer = Analyzer()
-    
+
     # JPEG JFIF signature with proper header structure
     # FFD8FFE0 (SOI + APP0) + size + JFIF marker + version + some data
     jpeg_data = bytes.fromhex("FFD8FFE000104A4649460001010000010001000000") + b"\x00" * 100
-    
+
     result = analyzer.analyze(jpeg_data)
-    
+
     assert result.primary_format == "jpeg"
     assert result.confidence > 0.4  # Lowered threshold for partial signature match
 
@@ -45,12 +44,12 @@ def test_analyze_jpeg():
 def test_analyze_pdf():
     """Test PDF file detection."""
     analyzer = Analyzer()
-    
+
     # PDF header
     pdf_data = b"%PDF-1.7\r\n" + b"\x00" * 100
-    
+
     result = analyzer.analyze(pdf_data)
-    
+
     assert result.primary_format == "pdf"
     assert result.confidence > 0.5
 
@@ -59,12 +58,12 @@ def test_analyze_unknown():
     """Test unknown file detection."""
     # Test without ML to check signature-only behavior
     analyzer = Analyzer(use_ml=False)
-    
+
     # Random data
     unknown_data = b"\x00\x11\x22\x33\x44\x55" * 20
-    
+
     result = analyzer.analyze(unknown_data)
-    
+
     # Should be unknown with low confidence when ML is disabled
     assert result.primary_format == "unknown"
     assert result.confidence == 0.0
@@ -74,10 +73,11 @@ def test_statistical_entropy():
     """Test entropy calculation."""
     # Random data should have high entropy
     import random
+
     random_data = bytes([random.randint(0, 255) for _ in range(1000)])
     entropy_random = StatisticalAnalyzer.calculate_entropy(random_data)
     assert entropy_random > 7.0  # Close to 8.0
-    
+
     # Uniform data should have low entropy
     uniform_data = b"\x00" * 1000
     entropy_uniform = StatisticalAnalyzer.calculate_entropy(uniform_data)
@@ -87,10 +87,10 @@ def test_statistical_entropy():
 def test_evidence_chain():
     """Test that evidence chain is populated."""
     analyzer = Analyzer()
-    
+
     png_data = bytes.fromhex("89504E470D0A1A0A0000000D49484452") + b"\x00" * 100
     result = analyzer.analyze(png_data)
-    
+
     assert len(result.evidence_chain) > 0
     assert result.evidence_chain[0]["module"] == "signature_analysis"
 
@@ -98,16 +98,16 @@ def test_evidence_chain():
 def test_analyze_corrupted_jpeg():
     """Test detection of JPEG with corrupted header but JFIF marker present."""
     analyzer = Analyzer()
-    
+
     # Corrupted JPEG: missing SOI marker but has JFIF marker and quantization table
     # Simulates a file like \x78\xff\xe0\x00\x10JFIF...
     corrupted_jpeg = bytes.fromhex(
         "5c78ffe000104a46494600010101000100010000"
         "ffdb004300080606070605080707070909080a0c140d0c0b0b0c"
     )
-    
+
     result = analyzer.analyze(corrupted_jpeg)
-    
+
     # Should detect as JPEG with moderate confidence using fallback signatures
     assert result.primary_format == "jpeg"
     assert result.confidence > 0.25
@@ -118,35 +118,35 @@ def test_analyze_office_formats():
     """Test detection of Office Open XML formats (DOCX, PPTX, XLSX)."""
     import zipfile
     import io
-    
+
     analyzer = Analyzer()
-    
+
     # Test DOCX
     docx_buffer = io.BytesIO()
-    with zipfile.ZipFile(docx_buffer, 'w') as zf:
-        zf.writestr('[Content_Types].xml', '<?xml version="1.0"?><Types></Types>')
-        zf.writestr('word/document.xml', '<?xml version="1.0"?><document></document>')
-    
+    with zipfile.ZipFile(docx_buffer, "w") as zf:
+        zf.writestr("[Content_Types].xml", '<?xml version="1.0"?><Types></Types>')
+        zf.writestr("word/document.xml", '<?xml version="1.0"?><document></document>')
+
     result = analyzer.analyze(docx_buffer.getvalue())
     assert result.primary_format == "docx"
     assert result.confidence > 0.9
-    
+
     # Test PPTX
     pptx_buffer = io.BytesIO()
-    with zipfile.ZipFile(pptx_buffer, 'w') as zf:
-        zf.writestr('[Content_Types].xml', '<?xml version="1.0"?><Types></Types>')
-        zf.writestr('ppt/presentation.xml', '<?xml version="1.0"?><presentation></presentation>')
-    
+    with zipfile.ZipFile(pptx_buffer, "w") as zf:
+        zf.writestr("[Content_Types].xml", '<?xml version="1.0"?><Types></Types>')
+        zf.writestr("ppt/presentation.xml", '<?xml version="1.0"?><presentation></presentation>')
+
     result = analyzer.analyze(pptx_buffer.getvalue())
     assert result.primary_format == "pptx"
     assert result.confidence > 0.9
-    
+
     # Test XLSX
     xlsx_buffer = io.BytesIO()
-    with zipfile.ZipFile(xlsx_buffer, 'w') as zf:
-        zf.writestr('[Content_Types].xml', '<?xml version="1.0"?><Types></Types>')
-        zf.writestr('xl/workbook.xml', '<?xml version="1.0"?><workbook></workbook>')
-    
+    with zipfile.ZipFile(xlsx_buffer, "w") as zf:
+        zf.writestr("[Content_Types].xml", '<?xml version="1.0"?><Types></Types>')
+        zf.writestr("xl/workbook.xml", '<?xml version="1.0"?><workbook></workbook>')
+
     result = analyzer.analyze(xlsx_buffer.getvalue())
     assert result.primary_format == "xlsx"
     assert result.confidence > 0.9
@@ -156,48 +156,49 @@ def test_analyze_opendocument_formats():
     """Test detection of OpenDocument formats (ODT, ODP, ODS)."""
     import zipfile
     import io
-    
+
     analyzer = Analyzer()
-    
+
     # Test ODT
     odt_buffer = io.BytesIO()
-    with zipfile.ZipFile(odt_buffer, 'w') as zf:
-        zf.writestr('mimetype', 'application/vnd.oasis.opendocument.text')
-        zf.writestr('content.xml', '<?xml version="1.0"?><document></document>')
-    
+    with zipfile.ZipFile(odt_buffer, "w") as zf:
+        zf.writestr("mimetype", "application/vnd.oasis.opendocument.text")
+        zf.writestr("content.xml", '<?xml version="1.0"?><document></document>')
+
     result = analyzer.analyze(odt_buffer.getvalue())
     assert result.primary_format == "odt"
     assert result.confidence > 0.9
-    
+
     # Test ODP
     odp_buffer = io.BytesIO()
-    with zipfile.ZipFile(odp_buffer, 'w') as zf:
-        zf.writestr('mimetype', 'application/vnd.oasis.opendocument.presentation')
-        zf.writestr('content.xml', '<?xml version="1.0"?><presentation></presentation>')
-    
+    with zipfile.ZipFile(odp_buffer, "w") as zf:
+        zf.writestr("mimetype", "application/vnd.oasis.opendocument.presentation")
+        zf.writestr("content.xml", '<?xml version="1.0"?><presentation></presentation>')
+
     result = analyzer.analyze(odp_buffer.getvalue())
     assert result.primary_format == "odp"
     assert result.confidence > 0.9
-    
+
     # Test ODS
     ods_buffer = io.BytesIO()
-    with zipfile.ZipFile(ods_buffer, 'w') as zf:
-        zf.writestr('mimetype', 'application/vnd.oasis.opendocument.spreadsheet')
-        zf.writestr('content.xml', '<?xml version="1.0"?><spreadsheet></spreadsheet>')
-    
+    with zipfile.ZipFile(ods_buffer, "w") as zf:
+        zf.writestr("mimetype", "application/vnd.oasis.opendocument.spreadsheet")
+        zf.writestr("content.xml", '<?xml version="1.0"?><spreadsheet></spreadsheet>')
+
     result = analyzer.analyze(ods_buffer.getvalue())
     assert result.primary_format == "ods"
     assert result.confidence > 0.9
 
 
-
 class TestEntropyViz:
     def test_chunk_entropy_empty(self):
         from filo.analyzer import StatisticalAnalyzer
+
         assert StatisticalAnalyzer.chunk_entropy(b"") == []
 
     def test_chunk_entropy_uniform(self):
         from filo.analyzer import StatisticalAnalyzer
+
         data = b"\x00" * 1024
         entropies = StatisticalAnalyzer.chunk_entropy(data)
         assert len(entropies) == 4
@@ -206,6 +207,7 @@ class TestEntropyViz:
 
     def test_chunk_entropy_random(self):
         from filo.analyzer import StatisticalAnalyzer
+
         data = bytes(range(256)) * 4
         entropies = StatisticalAnalyzer.chunk_entropy(data)
         assert len(entropies) == 4
@@ -214,6 +216,7 @@ class TestEntropyViz:
 
     def test_chunk_entropy_mixed(self):
         from filo.analyzer import StatisticalAnalyzer
+
         nulls = b"\x00" * 512
         random_data = bytes(range(256)) * 2
         data = nulls + random_data
@@ -226,6 +229,7 @@ class TestEntropyViz:
 
     def test_format_entropy_bar(self):
         from filo.analyzer import StatisticalAnalyzer
+
         entropies = [0.0, 2.0, 5.0, 8.0]
         bar = StatisticalAnalyzer.format_entropy_bar(entropies)
         assert bar is not None
@@ -233,4 +237,5 @@ class TestEntropyViz:
 
     def test_format_entropy_bar_empty(self):
         from filo.analyzer import StatisticalAnalyzer
+
         assert StatisticalAnalyzer.format_entropy_bar([]) == ""

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -5,400 +5,397 @@ from filo.architecture import ArchitectureDetector
 
 class TestELFArchitecture:
     """Test ELF architecture detection."""
-    
+
     def test_elf_x86_64(self):
         """Test x86-64 ELF detection."""
         # ELF 64-bit x86-64 little-endian header
         data = bytes.fromhex(
             "7F454C46"  # ELF magic
-            "02"        # 64-bit
-            "01"        # Little-endian
-            "01"        # Version
-            + "00" * 9    # Padding
-            + "0200"      # e_type (executable)
-            + "3E00"      # e_machine (0x3E = x86-64)
+            "02"  # 64-bit
+            "01"  # Little-endian
+            "01"  # Version
+            + "00" * 9  # Padding
+            + "0200"  # e_type (executable)
+            + "3E00"  # e_machine (0x3E = x86-64)
         )
-        
+
         detector = ArchitectureDetector()
         result = detector.detect_elf_architecture(data)
-        
+
         assert result is not None
         assert result["architecture"] == "AMD x86-64"
         assert result["bits"] == "64-bit"
         assert result["endian"] == "Little-endian"
         assert result["machine_code"] == 0x3E
         assert result["format"] == "ELF"
-    
+
     def test_elf_x86_32(self):
         """Test x86 32-bit ELF detection."""
         data = bytes.fromhex(
             "7F454C46"  # ELF magic
-            "01"        # 32-bit
-            "01"        # Little-endian
-            "01"        # Version
-            + "00" * 9    # Padding
-            + "0200"      # e_type
-            + "0300"      # e_machine (0x03 = x86)
+            "01"  # 32-bit
+            "01"  # Little-endian
+            "01"  # Version
+            + "00" * 9  # Padding
+            + "0200"  # e_type
+            + "0300"  # e_machine (0x03 = x86)
         )
-        
+
         detector = ArchitectureDetector()
         result = detector.detect_elf_architecture(data)
-        
+
         assert result is not None
         assert result["architecture"] == "x86"
         assert result["bits"] == "32-bit"
         assert result["machine_code"] == 0x03
-    
+
     def test_elf_arm64(self):
         """Test ARM64/Aarch64 ELF detection."""
         data = bytes.fromhex(
             "7F454C46"  # ELF magic
-            "02"        # 64-bit
-            "01"        # Little-endian
-            "01"        # Version
-            + "00" * 9    # Padding
-            + "0200"      # e_type
-            + "B700"      # e_machine (0xB7 = ARM64)
+            "02"  # 64-bit
+            "01"  # Little-endian
+            "01"  # Version
+            + "00" * 9  # Padding
+            + "0200"  # e_type
+            + "B700"  # e_machine (0xB7 = ARM64)
         )
-        
+
         detector = ArchitectureDetector()
         result = detector.detect_elf_architecture(data)
-        
+
         assert result is not None
         assert result["architecture"] == "ARM 64-bits (ARMv8/Aarch64)"
         assert result["bits"] == "64-bit"
         assert result["machine_code"] == 0xB7
-    
+
     def test_elf_arm32(self):
         """Test ARM 32-bit ELF detection."""
         data = bytes.fromhex(
             "7F454C46"  # ELF magic
-            "01"        # 32-bit
-            "01"        # Little-endian
-            "01"        # Version
-            + "00" * 9    # Padding
-            + "0200"      # e_type
-            + "2800"      # e_machine (0x28 = ARM)
+            "01"  # 32-bit
+            "01"  # Little-endian
+            "01"  # Version
+            + "00" * 9  # Padding
+            + "0200"  # e_type
+            + "2800"  # e_machine (0x28 = ARM)
         )
-        
+
         detector = ArchitectureDetector()
         result = detector.detect_elf_architecture(data)
-        
+
         assert result is not None
         assert result["architecture"] == "ARM (up to ARMv7/Aarch32)"
         assert result["bits"] == "32-bit"
         assert result["machine_code"] == 0x28
-    
+
     def test_elf_riscv(self):
         """Test RISC-V ELF detection."""
         data = bytes.fromhex(
             "7F454C46"  # ELF magic
-            "02"        # 64-bit
-            "01"        # Little-endian
-            "01"        # Version
-            + "00" * 9    # Padding
-            + "0200"      # e_type
-            + "F300"      # e_machine (0xF3 = RISC-V)
+            "02"  # 64-bit
+            "01"  # Little-endian
+            "01"  # Version
+            + "00" * 9  # Padding
+            + "0200"  # e_type
+            + "F300"  # e_machine (0xF3 = RISC-V)
         )
-        
+
         detector = ArchitectureDetector()
         result = detector.detect_elf_architecture(data)
-        
+
         assert result is not None
         assert result["architecture"] == "RISC-V"
         assert result["bits"] == "64-bit"
         assert result["machine_code"] == 0xF3
-    
+
     def test_elf_mips(self):
         """Test MIPS ELF detection."""
         data = bytes.fromhex(
             "7F454C46"  # ELF magic
-            "01"        # 32-bit
-            "02"        # Big-endian
-            "01"        # Version
-            + "00" * 9    # Padding
-            + "0002"      # e_type (big-endian)
-            + "0008"      # e_machine (0x08 = MIPS, big-endian)
+            "01"  # 32-bit
+            "02"  # Big-endian
+            "01"  # Version
+            + "00" * 9  # Padding
+            + "0002"  # e_type (big-endian)
+            + "0008"  # e_machine (0x08 = MIPS, big-endian)
         )
-        
+
         detector = ArchitectureDetector()
         result = detector.detect_elf_architecture(data)
-        
+
         assert result is not None
         assert result["architecture"] == "MIPS"
         assert result["bits"] == "32-bit"
         assert result["endian"] == "Big-endian"
         assert result["machine_code"] == 0x08
-    
+
     def test_elf_xtensa(self):
         """Test Tensilica Xtensa ELF detection (CTF challenge)."""
         data = bytes.fromhex(
             "7F454C46"  # ELF magic
-            "01"        # 32-bit
-            "01"        # Little-endian
-            "01"        # Version
-            + "00" * 9    # Padding
-            + "0200"      # e_type
-            + "5E00"      # e_machine (0x5E = Xtensa)
+            "01"  # 32-bit
+            "01"  # Little-endian
+            "01"  # Version
+            + "00" * 9  # Padding
+            + "0200"  # e_type
+            + "5E00"  # e_machine (0x5E = Xtensa)
         )
-        
+
         detector = ArchitectureDetector()
         result = detector.detect_elf_architecture(data)
-        
+
         assert result is not None
         assert result["architecture"] == "Tensilica Xtensa Architecture"
         assert result["bits"] == "32-bit"
         assert result["endian"] == "Little-endian"
         assert result["machine_code"] == 0x5E
-    
+
     def test_elf_powerpc(self):
         """Test PowerPC ELF detection."""
         data = bytes.fromhex(
             "7F454C46"  # ELF magic
-            "01"        # 32-bit
-            "02"        # Big-endian
-            "01"        # Version
-            + "00" * 9    # Padding
-            + "0002"      # e_type (big-endian)
-            + "0014"      # e_machine (0x14 = PowerPC, big-endian)
+            "01"  # 32-bit
+            "02"  # Big-endian
+            "01"  # Version
+            + "00" * 9  # Padding
+            + "0002"  # e_type (big-endian)
+            + "0014"  # e_machine (0x14 = PowerPC, big-endian)
         )
-        
+
         detector = ArchitectureDetector()
         result = detector.detect_elf_architecture(data)
-        
+
         assert result is not None
         assert result["architecture"] == "PowerPC"
         assert result["bits"] == "32-bit"
         assert result["endian"] == "Big-endian"
         assert result["machine_code"] == 0x14
-    
+
     def test_elf_sparc(self):
         """Test SPARC ELF detection."""
         data = bytes.fromhex(
             "7F454C46"  # ELF magic
-            "01"        # 32-bit
-            "02"        # Big-endian
-            "01"        # Version
-            + "00" * 9    # Padding
-            + "0002"      # e_type (big-endian)
-            + "0002"      # e_machine (0x02 = SPARC, big-endian)
+            "01"  # 32-bit
+            "02"  # Big-endian
+            "01"  # Version
+            + "00" * 9  # Padding
+            + "0002"  # e_type (big-endian)
+            + "0002"  # e_machine (0x02 = SPARC, big-endian)
         )
-        
+
         detector = ArchitectureDetector()
         result = detector.detect_elf_architecture(data)
-        
+
         assert result is not None
         assert result["architecture"] == "SPARC"
         assert result["bits"] == "32-bit"
         assert result["endian"] == "Big-endian"
         assert result["machine_code"] == 0x02
-    
+
     def test_elf_unknown_architecture(self):
         """Test unknown architecture code handling."""
         data = bytes.fromhex(
             "7F454C46"  # ELF magic
-            "01"        # 32-bit
-            "01"        # Little-endian
-            "01"        # Version
-            + "00" * 9    # Padding
-            + "0200"      # e_type
-            + "FF99"      # e_machine (unknown: 0x99FF)
+            "01"  # 32-bit
+            "01"  # Little-endian
+            "01"  # Version
+            + "00" * 9  # Padding
+            + "0200"  # e_type
+            + "FF99"  # e_machine (unknown: 0x99FF)
         )
-        
+
         detector = ArchitectureDetector()
         result = detector.detect_elf_architecture(data)
-        
+
         assert result is not None
         assert "Unknown" in result["architecture"]
         assert "0x99FF" in result["architecture"]
-    
+
     def test_not_elf(self):
         """Test non-ELF file returns None."""
         data = b"Not an ELF file"
-        
+
         detector = ArchitectureDetector()
         result = detector.detect_elf_architecture(data)
-        
+
         assert result is None
-    
+
     def test_elf_too_short(self):
         """Test truncated ELF returns None."""
         data = bytes.fromhex("7F454C46010100")  # Only 7 bytes
-        
+
         detector = ArchitectureDetector()
         result = detector.detect_elf_architecture(data)
-        
+
         assert result is None
 
 
 class TestPEArchitecture:
     """Test PE/COFF architecture detection."""
-    
+
     def test_pe_x86(self):
         """Test x86 PE detection."""
         # Create minimal DOS header + PE header
         data = bytearray(128)
-        data[0:2] = b'MZ'  # DOS signature
-        data[0x3C:0x40] = (0x40).to_bytes(4, 'little')  # PE offset at 0x40
-        data[0x40:0x44] = b'PE\x00\x00'  # PE signature
-        data[0x44:0x46] = (0x014C).to_bytes(2, 'little')  # Machine: I386
-        
+        data[0:2] = b"MZ"  # DOS signature
+        data[0x3C:0x40] = (0x40).to_bytes(4, "little")  # PE offset at 0x40
+        data[0x40:0x44] = b"PE\x00\x00"  # PE signature
+        data[0x44:0x46] = (0x014C).to_bytes(2, "little")  # Machine: I386
+
         detector = ArchitectureDetector()
         result = detector.detect_pe_architecture(bytes(data))
-        
+
         assert result is not None
         assert result["architecture"] == "x86 (I386)"
         assert result["bits"] == "32-bit"
         assert result["endian"] == "Little-endian"
         assert result["machine_code"] == 0x014C
         assert result["format"] == "PE"
-    
+
     def test_pe_x64(self):
         """Test x64 PE detection."""
         data = bytearray(128)
-        data[0:2] = b'MZ'
-        data[0x3C:0x40] = (0x40).to_bytes(4, 'little')
-        data[0x40:0x44] = b'PE\x00\x00'
-        data[0x44:0x46] = (0x8664).to_bytes(2, 'little')  # Machine: AMD64
-        
+        data[0:2] = b"MZ"
+        data[0x3C:0x40] = (0x40).to_bytes(4, "little")
+        data[0x40:0x44] = b"PE\x00\x00"
+        data[0x44:0x46] = (0x8664).to_bytes(2, "little")  # Machine: AMD64
+
         detector = ArchitectureDetector()
         result = detector.detect_pe_architecture(bytes(data))
-        
+
         assert result is not None
         assert result["architecture"] == "x64 (AMD64/Intel 64)"
         assert result["bits"] == "64-bit"
         assert result["machine_code"] == 0x8664
-    
+
     def test_pe_arm64(self):
         """Test ARM64 PE detection."""
         data = bytearray(128)
-        data[0:2] = b'MZ'
-        data[0x3C:0x40] = (0x40).to_bytes(4, 'little')
-        data[0x40:0x44] = b'PE\x00\x00'
-        data[0x44:0x46] = (0xAA64).to_bytes(2, 'little')  # Machine: ARM64
-        
+        data[0:2] = b"MZ"
+        data[0x3C:0x40] = (0x40).to_bytes(4, "little")
+        data[0x40:0x44] = b"PE\x00\x00"
+        data[0x44:0x46] = (0xAA64).to_bytes(2, "little")  # Machine: ARM64
+
         detector = ArchitectureDetector()
         result = detector.detect_pe_architecture(bytes(data))
-        
+
         assert result is not None
         assert result["architecture"] == "ARM64 little endian (Aarch64)"
         assert result["bits"] == "64-bit"
         assert result["machine_code"] == 0xAA64
-    
+
     def test_not_pe(self):
         """Test non-PE file returns None."""
         data = b"Not a PE file"
-        
+
         detector = ArchitectureDetector()
         result = detector.detect_pe_architecture(data)
-        
+
         assert result is None
 
 
 class TestMachOArchitecture:
     """Test Mach-O architecture detection."""
-    
+
     def test_macho_x86_64(self):
         """Test x86-64 Mach-O detection."""
         data = bytearray(32)
-        data[0:4] = (0xFEEDFACF).to_bytes(4, 'little')  # 64-bit magic
-        data[4:8] = (0x01000007).to_bytes(4, 'little')  # CPU type: x86_64
-        
+        data[0:4] = (0xFEEDFACF).to_bytes(4, "little")  # 64-bit magic
+        data[4:8] = (0x01000007).to_bytes(4, "little")  # CPU type: x86_64
+
         detector = ArchitectureDetector()
         result = detector.detect_macho_architecture(bytes(data))
-        
+
         assert result is not None
         assert result["architecture"] == "x86_64"
         assert result["bits"] == "64-bit"
         assert result["endian"] == "Little-endian"
         assert result["format"] == "Mach-O"
-    
+
     def test_macho_arm64(self):
         """Test ARM64 Mach-O detection."""
         data = bytearray(32)
-        data[0:4] = (0xFEEDFACF).to_bytes(4, 'little')  # 64-bit magic
-        data[4:8] = (0x0100000C).to_bytes(4, 'little')  # CPU type: ARM64
-        
+        data[0:4] = (0xFEEDFACF).to_bytes(4, "little")  # 64-bit magic
+        data[4:8] = (0x0100000C).to_bytes(4, "little")  # CPU type: ARM64
+
         detector = ArchitectureDetector()
         result = detector.detect_macho_architecture(bytes(data))
-        
+
         assert result is not None
         assert result["architecture"] == "ARM64 (Aarch64)"
         assert result["bits"] == "64-bit"
-    
+
     def test_macho_i386(self):
         """Test i386 Mach-O detection."""
         data = bytearray(32)
-        data[0:4] = (0xFEEDFACE).to_bytes(4, 'little')  # 32-bit magic
-        data[4:8] = (7).to_bytes(4, 'little')  # CPU type: x86
-        
+        data[0:4] = (0xFEEDFACE).to_bytes(4, "little")  # 32-bit magic
+        data[4:8] = (7).to_bytes(4, "little")  # CPU type: x86
+
         detector = ArchitectureDetector()
         result = detector.detect_macho_architecture(bytes(data))
-        
+
         assert result is not None
         assert result["architecture"] == "x86 (I386)"
         assert result["bits"] == "32-bit"
-    
+
     def test_not_macho(self):
         """Test non-Mach-O file returns None."""
         data = b"Not a Mach-O file"
-        
+
         detector = ArchitectureDetector()
         result = detector.detect_macho_architecture(data)
-        
+
         assert result is None
 
 
 class TestAutoDetect:
     """Test automatic format detection."""
-    
+
     def test_auto_detect_elf(self):
         """Test auto-detect identifies ELF."""
-        data = bytes.fromhex(
-            "7F454C46020101000000000000000000"
-            "02003E00"
-        )
-        
+        data = bytes.fromhex("7F454C46020101000000000000000000" "02003E00")
+
         detector = ArchitectureDetector()
         result = detector.detect(data)
-        
+
         assert result is not None
         assert result["format"] == "ELF"
         assert result["architecture"] == "AMD x86-64"
-    
+
     def test_auto_detect_pe(self):
         """Test auto-detect identifies PE."""
         data = bytearray(128)
-        data[0:2] = b'MZ'
-        data[0x3C:0x40] = (0x40).to_bytes(4, 'little')
-        data[0x40:0x44] = b'PE\x00\x00'
-        data[0x44:0x46] = (0x8664).to_bytes(2, 'little')
-        
+        data[0:2] = b"MZ"
+        data[0x3C:0x40] = (0x40).to_bytes(4, "little")
+        data[0x40:0x44] = b"PE\x00\x00"
+        data[0x44:0x46] = (0x8664).to_bytes(2, "little")
+
         detector = ArchitectureDetector()
         result = detector.detect(bytes(data))
-        
+
         assert result is not None
         assert result["format"] == "PE"
         assert result["architecture"] == "x64 (AMD64/Intel 64)"
-    
+
     def test_auto_detect_macho(self):
         """Test auto-detect identifies Mach-O."""
         data = bytearray(32)
-        data[0:4] = (0xFEEDFACF).to_bytes(4, 'little')
-        data[4:8] = (0x01000007).to_bytes(4, 'little')
-        
+        data[0:4] = (0xFEEDFACF).to_bytes(4, "little")
+        data[4:8] = (0x01000007).to_bytes(4, "little")
+
         detector = ArchitectureDetector()
         result = detector.detect(bytes(data))
-        
+
         assert result is not None
         assert result["format"] == "Mach-O"
         assert result["architecture"] == "x86_64"
-    
+
     def test_auto_detect_unknown(self):
         """Test auto-detect returns None for unknown format."""
         data = b"Unknown binary format"
-        
+
         detector = ArchitectureDetector()
         result = detector.detect(data)
-        
+
         assert result is None

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -1,6 +1,5 @@
 """Tests for CPU architecture detection."""
 
-import pytest
 from filo.architecture import ArchitectureDetector
 
 

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1,6 +1,5 @@
 """Tests for batch processing functionality."""
 
-
 import pytest
 
 from filo.batch import BatchProcessor, BatchConfig, analyze_directory
@@ -11,25 +10,25 @@ def test_files(temp_dir):
     """Create test files for batch processing."""
     # Create some test files
     files = []
-    
+
     # PNG file
     png_data = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
     png_file = temp_dir / "test.png"
     png_file.write_bytes(png_data)
     files.append(png_file)
-    
+
     # JPEG file
     jpeg_data = b"\xff\xd8\xff\xe0" + b"\x00" * 100
     jpeg_file = temp_dir / "test.jpg"
     jpeg_file.write_bytes(jpeg_data)
     files.append(jpeg_file)
-    
+
     # PDF file
     pdf_data = b"%PDF-1.7\n" + b"\x00" * 100
     pdf_file = temp_dir / "test.pdf"
     pdf_file.write_bytes(pdf_data)
     files.append(pdf_file)
-    
+
     # Subdirectory with file
     subdir = temp_dir / "subdir"
     subdir.mkdir()
@@ -37,14 +36,14 @@ def test_files(temp_dir):
     zip_file = subdir / "test.zip"
     zip_file.write_bytes(zip_data)
     files.append(zip_file)
-    
+
     return temp_dir, files
 
 
 def test_batch_processor_initialization():
     """Test batch processor initialization."""
     processor = BatchProcessor()
-    
+
     assert processor.config.max_workers == 4
     assert processor.config.recursive is True
 
@@ -52,12 +51,12 @@ def test_batch_processor_initialization():
 def test_batch_process_directory(test_files):
     """Test processing a directory."""
     temp_dir, files = test_files
-    
+
     config = BatchConfig(max_workers=2, recursive=True)
     processor = BatchProcessor(config)
-    
+
     result = processor.process_directory(temp_dir)
-    
+
     assert result.total_files == 4
     assert result.analyzed_files == 4
     assert result.failed_files == 0
@@ -69,12 +68,12 @@ def test_batch_process_directory(test_files):
 def test_batch_non_recursive(test_files):
     """Test non-recursive batch processing."""
     temp_dir, files = test_files
-    
+
     config = BatchConfig(recursive=False)
     processor = BatchProcessor(config)
-    
+
     result = processor.process_directory(temp_dir)
-    
+
     # Should only get files in root directory (3 files, not the one in subdir)
     assert result.total_files == 3
     assert result.analyzed_files == 3
@@ -83,13 +82,13 @@ def test_batch_non_recursive(test_files):
 def test_batch_file_size_filter(test_files):
     """Test file size filtering."""
     temp_dir, files = test_files
-    
+
     # Set very small max size
     config = BatchConfig(max_file_size=50)
     processor = BatchProcessor(config)
-    
+
     result = processor.process_directory(temp_dir)
-    
+
     # All files should be skipped (they're all >50 bytes)
     assert result.analyzed_files == 0
 
@@ -97,12 +96,12 @@ def test_batch_file_size_filter(test_files):
 def test_batch_exclude_patterns(test_files):
     """Test exclude patterns."""
     temp_dir, files = test_files
-    
+
     config = BatchConfig(exclude_patterns=["*.png", "*.jpg"])
     processor = BatchProcessor(config)
-    
+
     result = processor.process_directory(temp_dir)
-    
+
     # Should only analyze pdf and zip
     assert result.analyzed_files == 2
 
@@ -110,12 +109,12 @@ def test_batch_exclude_patterns(test_files):
 def test_batch_include_patterns(test_files):
     """Test include patterns."""
     temp_dir, files = test_files
-    
+
     config = BatchConfig(include_patterns=["*.png"])
     processor = BatchProcessor(config)
-    
+
     result = processor.process_directory(temp_dir)
-    
+
     # Should only analyze png
     assert result.analyzed_files == 1
 
@@ -123,9 +122,9 @@ def test_batch_include_patterns(test_files):
 def test_analyze_directory_convenience(test_files):
     """Test convenience function."""
     temp_dir, files = test_files
-    
+
     result = analyze_directory(temp_dir, max_workers=2)
-    
+
     assert result.total_files == 4
     assert result.analyzed_files == 4
 
@@ -133,17 +132,17 @@ def test_analyze_directory_convenience(test_files):
 def test_progress_callback(test_files):
     """Test progress callback."""
     temp_dir, files = test_files
-    
+
     progress_updates = []
-    
+
     def callback(completed, total):
         progress_updates.append((completed, total))
-    
+
     config = BatchConfig(progress_callback=callback)
     processor = BatchProcessor(config)
-    
+
     processor.process_directory(temp_dir)
-    
+
     # Should have progress updates
     assert len(progress_updates) == 4
     assert progress_updates[-1] == (4, 4)

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1,7 +1,5 @@
 """Tests for batch processing functionality."""
 
-import tempfile
-from pathlib import Path
 
 import pytest
 
@@ -144,7 +142,7 @@ def test_progress_callback(test_files):
     config = BatchConfig(progress_callback=callback)
     processor = BatchProcessor(config)
     
-    result = processor.process_directory(temp_dir)
+    processor.process_directory(temp_dir)
     
     # Should have progress updates
     assert len(progress_updates) == 4

--- a/tests/test_carver.py
+++ b/tests/test_carver.py
@@ -1,5 +1,4 @@
 import pytest
-from pathlib import Path
 from filo.carver import CarverEngine, CarvedFile, StreamCarver
 
 

--- a/tests/test_carver.py
+++ b/tests/test_carver.py
@@ -9,18 +9,18 @@ def carver():
 
 def test_carve_single_png():
     carver = CarverEngine()
-    
+
     png_header = bytes.fromhex("89504E470D0A1A0A")
     png_data = png_header + b"\x00" * 1000 + b"IEND\xae\x42\x60\x82"
-    
+
     junk = b"\xff" * 500
     combined = junk + png_data + junk
-    
+
     carved = carver.carve_data(combined, min_size=100)
-    
+
     assert len(carved) >= 1
     assert any(c.format == "png" for c in carved)
-    
+
     png_carved = [c for c in carved if c.format == "png"][0]
     assert png_carved.offset == 500
     assert png_carved.confidence > 0.5
@@ -28,41 +28,41 @@ def test_carve_single_png():
 
 def test_carve_multiple_files():
     carver = CarverEngine()
-    
+
     png = bytes.fromhex("89504E470D0A1A0A") + b"\x00" * 500 + b"IEND\xae\x42\x60\x82"
     jpeg = bytes.fromhex("FFD8FFE0") + b"\x00" * 300 + b"\xff\xd9"
     zip_data = bytes.fromhex("504B0304") + b"\x00" * 400
-    
+
     combined = b"\xff" * 100 + png + b"\x00" * 50 + jpeg + b"\x00" * 50 + zip_data
-    
+
     carved = carver.carve_data(combined, min_size=100)
-    
+
     assert len(carved) >= 1
-    
+
     formats = [c.format for c in carved]
     assert "png" in formats or "jpeg" in formats or "zip" in formats
 
 
 def test_carve_min_size_filter():
     carver = CarverEngine()
-    
+
     small_png = bytes.fromhex("89504E470D0A1A0A") + b"\x00" * 50
     large_png = bytes.fromhex("89504E470D0A1A0A") + b"\x00" * 2000 + b"IEND\xae\x42\x60\x82"
-    
+
     combined = small_png + b"\xff" * 100 + large_png
-    
+
     carved = carver.carve_data(combined, min_size=1000)
-    
+
     assert all(c.size >= 1000 for c in carved)
 
 
 def test_carve_with_overlapping_signatures():
     carver = CarverEngine()
-    
+
     data = bytes.fromhex("89504E470D0A1A0A") + b"\x00" * 1000 + b"IEND\xae\x42\x60\x82"
-    
+
     carved = carver.carve_data(data, min_size=100)
-    
+
     assert len(carved) >= 1
     assert carved[0].format == "png"
 
@@ -73,67 +73,67 @@ def test_carved_file_save(tmp_path):
         size=500,
         format="png",
         confidence=0.95,
-        data=b"\x89PNG\r\n\x1a\n" + b"\x00" * 492
+        data=b"\x89PNG\r\n\x1a\n" + b"\x00" * 492,
     )
-    
+
     output_file = tmp_path / "test.png"
     carved.save(output_file)
-    
+
     assert output_file.exists()
     assert output_file.read_bytes() == carved.data
 
 
 def test_carve_file(tmp_path):
     test_file = tmp_path / "test.bin"
-    
+
     png = bytes.fromhex("89504E470D0A1A0A") + b"\x00" * 1000 + b"IEND\xae\x42\x60\x82"
     test_file.write_bytes(b"\xff" * 200 + png + b"\xff" * 200)
-    
+
     carver = CarverEngine()
     carved = carver.carve_file(test_file, min_size=100)
-    
+
     assert len(carved) >= 1
     assert any(c.format == "png" for c in carved)
 
 
 def test_stream_carver():
     stream = StreamCarver(buffer_size=2048)
-    
+
     png = bytes.fromhex("89504E470D0A1A0A") + b"\x00" * 1000 + b"IEND\xae\x42\x60\x82"
-    
+
     chunk1 = b"\xff" * 100 + png[:500]
     chunk2 = png[500:] + b"\xff" * 100
-    
+
     result1 = stream.feed(chunk1)
     result2 = stream.feed(chunk2)
     final = stream.finalize()
-    
+
     all_carved = result1 + result2 + final
-    
+
     assert len(all_carved) >= 1
     assert any(c.format == "png" for c in all_carved)
 
 
 def test_estimate_file_size_png():
     carver = CarverEngine()
-    
+
     png_data = bytes.fromhex("89504E470D0A1A0A") + b"\x00" * 500 + b"IEND\xae\x42\x60\x82"
-    
+
     result = carver.analyzer.analyze(png_data)
     size = carver._estimate_file_size(png_data, result)
-    
+
     assert size > 0
     assert size <= len(png_data)
 
 
 def test_carve_jpeg_with_footer():
     carver = CarverEngine()
-    
+
     jpeg = bytes.fromhex("FFD8FFE0") + b"\x00" * 800 + b"\xff\xd9"
     combined = b"\xff" * 100 + jpeg + b"\x00" * 100
-    
+
     carved = carver.carve_data(combined, min_size=100)
-    
+
     jpeg_files = [c for c in carved if c.format == "jpeg"]
     if jpeg_files:
         assert jpeg_files[0].size >= 800
@@ -153,10 +153,10 @@ def test_carve_no_valid_files():
 
 def test_carved_file_metadata():
     carver = CarverEngine()
-    
+
     png = bytes.fromhex("89504E470D0A1A0A") + b"\x00" * 1000 + b"IEND\xae\x42\x60\x82"
     carved = carver.carve_data(png, min_size=100)
-    
+
     if carved:
         assert carved[0].metadata is not None
         assert "evidence" in carved[0].metadata
@@ -164,9 +164,9 @@ def test_carved_file_metadata():
 
 def test_signature_index_creation():
     carver = CarverEngine()
-    
+
     assert len(carver.signatures) > 0
-    
+
     png_sig = bytes.fromhex("89504E470D0A1A0A")
     assert png_sig in carver.signatures
     assert "png" in carver.signatures[png_sig]

--- a/tests/test_confidence_breakdown.py
+++ b/tests/test_confidence_breakdown.py
@@ -2,7 +2,6 @@
 
 import pytest
 from filo.analyzer import Analyzer
-from filo.models import ConfidenceContribution
 
 
 def test_confidence_contributions_in_signature_analysis():

--- a/tests/test_confidence_breakdown.py
+++ b/tests/test_confidence_breakdown.py
@@ -7,23 +7,26 @@ from filo.analyzer import Analyzer
 def test_confidence_contributions_in_signature_analysis():
     """Test that signature matches include contribution breakdown."""
     analyzer = Analyzer(use_ml=False)
-    
+
     # Create a PNG file (signature at offset 0 and 8)
     png_data = bytes.fromhex("89504E470D0A1A0A0000000D494844520000001000000010080200000090916836")
-    
+
     result = analyzer.analyze(png_data)
-    
+
     # Check that evidence chain includes contributions
     assert len(result.evidence_chain) > 0
-    
+
     # Find signature analysis evidence for PNG
-    sig_evidence = [e for e in result.evidence_chain 
-                    if e["format"] == "png" and e["module"] == "signature_analysis"]
-    
+    sig_evidence = [
+        e
+        for e in result.evidence_chain
+        if e["format"] == "png" and e["module"] == "signature_analysis"
+    ]
+
     assert len(sig_evidence) > 0
     assert "contributions" in sig_evidence[0]
     assert len(sig_evidence[0]["contributions"]) > 0
-    
+
     # Verify contribution structure
     for contrib in sig_evidence[0]["contributions"]:
         assert "source" in contrib
@@ -37,25 +40,28 @@ def test_confidence_contributions_in_container_analysis():
     """Test that ZIP container analysis includes contribution breakdown."""
     import zipfile
     import io
-    
+
     analyzer = Analyzer(use_ml=False)
-    
+
     # Create a minimal DOCX structure
     zip_buffer = io.BytesIO()
-    with zipfile.ZipFile(zip_buffer, 'w', zipfile.ZIP_DEFLATED) as zf:
-        zf.writestr('[Content_Types].xml', '<?xml version="1.0"?><Types></Types>')
-        zf.writestr('word/document.xml', '<?xml version="1.0"?><document></document>')
-    
+    with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("[Content_Types].xml", '<?xml version="1.0"?><Types></Types>')
+        zf.writestr("word/document.xml", '<?xml version="1.0"?><document></document>')
+
     result = analyzer.analyze(zip_buffer.getvalue())
-    
+
     # Find container analysis evidence for DOCX
-    container_evidence = [e for e in result.evidence_chain 
-                          if e["format"] == "docx" and e["module"] == "zip_container_analysis"]
-    
+    container_evidence = [
+        e
+        for e in result.evidence_chain
+        if e["format"] == "docx" and e["module"] == "zip_container_analysis"
+    ]
+
     assert len(container_evidence) > 0
     assert "contributions" in container_evidence[0]
     assert len(container_evidence[0]["contributions"]) > 0
-    
+
     # Verify contributions mention the key DOCX files
     contrib_descriptions = [c["description"] for c in container_evidence[0]["contributions"]]
     assert any("word/document.xml" in desc for desc in contrib_descriptions)
@@ -65,24 +71,23 @@ def test_confidence_contributions_in_container_analysis():
 def test_confidence_penalties_in_structural_analysis():
     """Test that structural analysis includes penalties for missing fields."""
     analyzer = Analyzer(use_ml=False)
-    
+
     # Create a very short PNG file (missing expected structure)
     png_data = bytes.fromhex("89504E47")  # Only magic bytes, missing IHDR
-    
+
     result = analyzer.analyze(png_data)
-    
+
     # Find structural analysis evidence
-    struct_evidence = [e for e in result.evidence_chain 
-                       if e["module"] == "structural_analysis"]
-    
+    struct_evidence = [e for e in result.evidence_chain if e["module"] == "structural_analysis"]
+
     # If structural analysis ran, check for penalties
     if struct_evidence:
         assert "contributions" in struct_evidence[0]
         contributions = struct_evidence[0]["contributions"]
-        
+
         # Check if any contribution is marked as penalty
         penalties = [c for c in contributions if c.get("is_penalty", False)]
-        
+
         # Verify penalty structure if present
         for penalty in penalties:
             assert penalty["value"] < 0
@@ -92,18 +97,18 @@ def test_confidence_penalties_in_structural_analysis():
 def test_contribution_value_ranges():
     """Test that contribution values are within expected ranges."""
     analyzer = Analyzer(use_ml=False)
-    
+
     # Create a complete PNG file
     png_data = bytes.fromhex("89504E470D0A1A0A0000000D494844520000001000000010080200000090916836")
-    
+
     result = analyzer.analyze(png_data)
-    
+
     # Collect all contributions
     all_contributions = []
     for evidence in result.evidence_chain:
         if "contributions" in evidence:
             all_contributions.extend(evidence["contributions"])
-    
+
     # Verify each contribution
     for contrib in all_contributions:
         # Contributions should be reasonable (not absurdly high or low)
@@ -119,58 +124,57 @@ def test_explain_flag_output_format(capsys):
     """Test that --explain flag produces correct output format."""
     import subprocess
     import tempfile
-    
+
     # Create a test PNG file
-    with tempfile.NamedTemporaryFile(suffix='.png', delete=False) as f:
+    with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
         f.write(bytes.fromhex("89504E470D0A1A0A0000000D494844520000001000000010080200000090916836"))
         temp_path = f.name
-    
+
     try:
         # Run filo with --explain flag
         result = subprocess.run(
-            ['filo', 'analyze', temp_path, '--explain'],
-            capture_output=True,
-            text=True
+            ["filo", "analyze", temp_path, "--explain"], capture_output=True, text=True
         )
-        
+
         output = result.stdout
-        
+
         # Verify key elements are present
         assert "Confidence Breakdown:" in output
         assert "Primary:" in output
         assert "PNG" in output or "png" in output
         assert "%" in output  # Percentage values
-        
+
         # Verify contribution format (+ or - prefix)
         assert "+" in output or "-" in output
-        
+
     finally:
         import os
+
         os.unlink(temp_path)
 
 
 def test_aggregated_confidence_calculation():
     """Test that displayed contributions reflect the detection strength."""
     analyzer = Analyzer(use_ml=False)
-    
+
     # Create a DOCX file
     import zipfile
     import io
-    
+
     zip_buffer = io.BytesIO()
-    with zipfile.ZipFile(zip_buffer, 'w', zipfile.ZIP_DEFLATED) as zf:
-        zf.writestr('[Content_Types].xml', '<?xml version="1.0"?><Types></Types>')
-        zf.writestr('word/document.xml', '<?xml version="1.0"?><document></document>')
-    
+    with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("[Content_Types].xml", '<?xml version="1.0"?><Types></Types>')
+        zf.writestr("word/document.xml", '<?xml version="1.0"?><document></document>')
+
     result = analyzer.analyze(zip_buffer.getvalue())
-    
+
     # Collect all contributions for the primary format
     total_contribution = 0.0
     for evidence in result.evidence_chain:
         if evidence["format"] == result.primary_format and "contributions" in evidence:
             module_weight = evidence.get("weight", 1.0)
             module = evidence["module"]
-            
+
             # Apply the same weighting as analyzer
             for contrib in evidence["contributions"]:
                 if module == "signature_analysis":
@@ -181,13 +185,13 @@ def test_aggregated_confidence_calculation():
                     weighted = contrib["value"] * module_weight * 0.8
                 else:
                     weighted = contrib["value"]
-                
+
                 total_contribution += weighted
-    
+
     # The total can exceed 1.0 (final confidence is clamped)
     # But it should be positive and represent detection strength
     assert total_contribution > 0
-    
+
     # For strong detections, contributions should sum to a meaningful value
     if result.confidence >= 0.8:
         assert total_contribution >= 0.5  # At least some positive evidence
@@ -196,22 +200,22 @@ def test_aggregated_confidence_calculation():
 def test_contribution_source_types():
     """Test that contributions use expected source types."""
     analyzer = Analyzer(use_ml=False)
-    
+
     # Create a PNG file
     png_data = bytes.fromhex("89504E470D0A1A0A0000000D494844520000001000000010080200000090916836")
-    
+
     result = analyzer.analyze(png_data)
-    
+
     # Collect all source types
     sources = set()
     for evidence in result.evidence_chain:
         if "contributions" in evidence:
             for contrib in evidence["contributions"]:
                 sources.add(contrib["source"])
-    
+
     # Valid source types
     valid_sources = {"signature", "structure", "container", "ml"}
-    
+
     # All sources should be from the valid set
     assert sources.issubset(valid_sources)
 

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -13,19 +13,19 @@ from filo.container import ContainerDetector, analyze_archive
 def zip_data():
     """Create sample ZIP archive."""
     buffer = io.BytesIO()
-    
-    with zipfile.ZipFile(buffer, 'w') as zf:
+
+    with zipfile.ZipFile(buffer, "w") as zf:
         # Add a PNG file
         png_data = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
         zf.writestr("image.png", png_data)
-        
+
         # Add a text file
         zf.writestr("readme.txt", b"Hello, World!")
-        
+
         # Add subdirectory
         jpeg_data = b"\xff\xd8\xff\xe0" + b"\x00" * 100
         zf.writestr("subdir/photo.jpg", jpeg_data)
-    
+
     return buffer.getvalue()
 
 
@@ -33,59 +33,59 @@ def zip_data():
 def tar_data():
     """Create sample TAR archive."""
     buffer = io.BytesIO()
-    
-    with tarfile.open(fileobj=buffer, mode='w') as tf:
+
+    with tarfile.open(fileobj=buffer, mode="w") as tf:
         # Add PNG file
         png_data = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
         info = tarfile.TarInfo(name="image.png")
         info.size = len(png_data)
         tf.addfile(info, io.BytesIO(png_data))
-        
+
         # Add PDF file
         pdf_data = b"%PDF-1.7\n" + b"\x00" * 100
         info = tarfile.TarInfo(name="document.pdf")
         info.size = len(pdf_data)
         tf.addfile(info, io.BytesIO(pdf_data))
-    
+
     return buffer.getvalue()
 
 
 def test_detect_zip(zip_data):
     """Test ZIP detection."""
     detector = ContainerDetector()
-    
+
     container_type = detector.is_container(zip_data)
-    
+
     assert container_type == "zip"
 
 
 def test_detect_tar(tar_data):
     """Test TAR detection."""
     detector = ContainerDetector()
-    
+
     container_type = detector.is_container(tar_data)
-    
+
     assert container_type == "tar"
 
 
 def test_detect_non_container():
     """Test non-container detection."""
     detector = ContainerDetector()
-    
+
     # Plain PNG data
     png_data = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
-    
+
     container_type = detector.is_container(png_data)
-    
+
     assert container_type is None
 
 
 def test_analyze_zip_container(zip_data):
     """Test ZIP container analysis."""
     detector = ContainerDetector()
-    
+
     result = detector.analyze_container(zip_data, recursive=False)
-    
+
     assert result is not None
     assert result.container_format == "zip"
     assert result.total_entries == 3
@@ -95,9 +95,9 @@ def test_analyze_zip_container(zip_data):
 def test_analyze_tar_container(tar_data):
     """Test TAR container analysis."""
     detector = ContainerDetector()
-    
+
     result = detector.analyze_container(tar_data, recursive=False)
-    
+
     assert result is not None
     assert result.container_format == "tar"
     assert result.total_entries == 2
@@ -107,12 +107,12 @@ def test_analyze_tar_container(tar_data):
 def test_container_entry_formats(zip_data):
     """Test that container entries are analyzed."""
     detector = ContainerDetector()
-    
+
     result = detector.analyze_container(zip_data)
-    
+
     # Find the PNG entry
     png_entry = next((e for e in result.entries if "image.png" in e.path), None)
-    
+
     assert png_entry is not None
     assert png_entry.result is not None
     assert png_entry.result.primary_format == "png"
@@ -122,20 +122,20 @@ def test_nested_containers():
     """Test nested container detection."""
     # Create ZIP containing a ZIP
     inner_buffer = io.BytesIO()
-    with zipfile.ZipFile(inner_buffer, 'w') as inner_zf:
+    with zipfile.ZipFile(inner_buffer, "w") as inner_zf:
         inner_zf.writestr("test.txt", b"Hello")
-    
+
     inner_data = inner_buffer.getvalue()
-    
+
     outer_buffer = io.BytesIO()
-    with zipfile.ZipFile(outer_buffer, 'w') as outer_zf:
+    with zipfile.ZipFile(outer_buffer, "w") as outer_zf:
         outer_zf.writestr("inner.zip", inner_data)
-    
+
     outer_data = outer_buffer.getvalue()
-    
+
     detector = ContainerDetector(max_depth=2)
     result = detector.analyze_container(outer_data, recursive=True)
-    
+
     assert result is not None
     assert result.container_format == "zip"
     # Should have warning about nested container
@@ -145,7 +145,7 @@ def test_nested_containers():
 def test_analyze_archive_convenience(zip_data):
     """Test convenience function."""
     result = analyze_archive(zip_data)
-    
+
     assert result is not None
     assert result.container_format == "zip"
 
@@ -154,10 +154,10 @@ def test_corrupted_zip():
     """Test handling of corrupted ZIP."""
     # Incomplete ZIP data
     corrupted = b"PK\x03\x04" + b"\x00" * 10
-    
+
     detector = ContainerDetector()
     result = detector.analyze_container(corrupted)
-    
+
     # Should still detect as ZIP but have warnings
     assert result is not None
     assert result.container_format == "zip"

--- a/tests/test_contradictions.py
+++ b/tests/test_contradictions.py
@@ -5,7 +5,6 @@ import zipfile
 import io
 import zlib
 from filo.analyzer import Analyzer
-from filo.contradictions import ContradictionDetector
 
 
 def test_png_with_invalid_compression():
@@ -169,7 +168,6 @@ def test_no_contradictions_in_valid_file():
     png_data = bytes.fromhex("89504E470D0A1A0A0000000D494844520000001000000010080200000090916836")
     
     # Add valid IDAT with proper zlib compression
-    import zlib
     raw_data = b'\x00' * 64  # Simple scanline data
     compressed = zlib.compress(raw_data)
     

--- a/tests/test_contradictions.py
+++ b/tests/test_contradictions.py
@@ -12,46 +12,49 @@ def test_png_with_invalid_compression():
     # Create PNG with valid signature but corrupted IDAT
     png_sig = bytes.fromhex("89504E470D0A1A0A")
     ihdr = bytes.fromhex("0000000D49484452" + "0000001000000010080200000090916836")
-    
+
     # Create IDAT chunk with invalid zlib data
     idat_len = bytes.fromhex("00000010")  # 16 bytes
-    idat_type = b'IDAT'
-    idat_data = b'\x00' * 16  # Invalid zlib stream
+    idat_type = b"IDAT"
+    idat_data = b"\x00" * 16  # Invalid zlib stream
     idat_crc = bytes.fromhex("00000000")
-    
+
     corrupted_png = png_sig + ihdr + idat_len + idat_type + idat_data + idat_crc
-    
+
     analyzer = Analyzer(use_ml=False)
     result = analyzer.analyze(corrupted_png)
-    
+
     # Should detect PNG
     assert result.primary_format == "png"
-    
+
     # Should find compression contradiction
     assert len(result.contradictions) > 0
     compression_issues = [c for c in result.contradictions if c.category == "compression"]
     assert len(compression_issues) > 0
-    assert "zlib" in compression_issues[0].details.lower() or "compression" in compression_issues[0].details.lower()
+    assert (
+        "zlib" in compression_issues[0].details.lower()
+        or "compression" in compression_issues[0].details.lower()
+    )
 
 
 def test_ooxml_missing_rels():
     """Test detection of OOXML structure missing mandatory _rels/.rels."""
     # Create ZIP with Content_Types but no _rels
     zip_buffer = io.BytesIO()
-    with zipfile.ZipFile(zip_buffer, 'w', zipfile.ZIP_DEFLATED) as zf:
-        zf.writestr('[Content_Types].xml', '<?xml version="1.0"?><Types></Types>')
+    with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("[Content_Types].xml", '<?xml version="1.0"?><Types></Types>')
         # Missing _rels/.rels
-        zf.writestr('word/document.xml', '<?xml version="1.0"?><document></document>')
-    
+        zf.writestr("word/document.xml", '<?xml version="1.0"?><document></document>')
+
     analyzer = Analyzer(use_ml=False)
     result = analyzer.analyze(zip_buffer.getvalue())
-    
+
     # Should detect as DOCX (or OOXML)
-    assert result.primary_format in ['docx', 'ooxml']
-    
+    assert result.primary_format in ["docx", "ooxml"]
+
     # Should find missing _rels contradiction
     assert len(result.contradictions) > 0
-    missing_rels = [c for c in result.contradictions if 'rels' in c.details.lower()]
+    missing_rels = [c for c in result.contradictions if "rels" in c.details.lower()]
     assert len(missing_rels) > 0
     assert missing_rels[0].category == "missing"
 
@@ -60,14 +63,14 @@ def test_ooxml_missing_core_document():
     """Test detection of OOXML with Content_Types but no actual document."""
     # Create ZIP with OOXML markers but no document content
     zip_buffer = io.BytesIO()
-    with zipfile.ZipFile(zip_buffer, 'w', zipfile.ZIP_DEFLATED) as zf:
-        zf.writestr('[Content_Types].xml', '<?xml version="1.0"?><Types></Types>')
-        zf.writestr('_rels/.rels', '<?xml version="1.0"?><Relationships></Relationships>')
+    with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("[Content_Types].xml", '<?xml version="1.0"?><Types></Types>')
+        zf.writestr("_rels/.rels", '<?xml version="1.0"?><Relationships></Relationships>')
         # No document.xml, presentation.xml, or workbook.xml
-    
+
     analyzer = Analyzer(use_ml=False)
     result = analyzer.analyze(zip_buffer.getvalue())
-    
+
     # Should find structure contradiction
     structure_issues = [c for c in result.contradictions if c.category == "structure"]
     if structure_issues:
@@ -78,19 +81,19 @@ def test_embedded_elf_in_zip():
     """Test detection of ELF executable embedded in ZIP file."""
     # Create ZIP with embedded ELF magic bytes
     zip_buffer = io.BytesIO()
-    with zipfile.ZipFile(zip_buffer, 'w', zipfile.ZIP_DEFLATED) as zf:
-        zf.writestr('normal.txt', 'Normal file content')
-        zf.writestr('README.md', 'Documentation')
+    with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("normal.txt", "Normal file content")
+        zf.writestr("README.md", "Documentation")
         # Embed ELF magic in a file (past first 512 bytes)
-        malicious_content = b'A' * 600 + b'\x7fELF' + b'\x00' * 100
-        zf.writestr('data.bin', malicious_content)
-    
+        malicious_content = b"A" * 600 + b"\x7fELF" + b"\x00" * 100
+        zf.writestr("data.bin", malicious_content)
+
     analyzer = Analyzer(use_ml=False)
     result = analyzer.analyze(zip_buffer.getvalue())
-    
+
     # Should detect ZIP
     assert result.primary_format == "zip"
-    
+
     # Should find embedded ELF
     embedded = [c for c in result.contradictions if c.category == "embedded"]
     assert len(embedded) > 0
@@ -102,38 +105,42 @@ def test_embedded_pe_in_docx():
     """Test detection of PE executable embedded in DOCX."""
     # Create DOCX with embedded PE signature
     zip_buffer = io.BytesIO()
-    with zipfile.ZipFile(zip_buffer, 'w', zipfile.ZIP_DEFLATED) as zf:
-        zf.writestr('[Content_Types].xml', '<?xml version="1.0"?><Types></Types>')
-        zf.writestr('_rels/.rels', '<?xml version="1.0"?><Relationships></Relationships>')
-        zf.writestr('word/document.xml', '<?xml version="1.0"?><document></document>')
+    with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("[Content_Types].xml", '<?xml version="1.0"?><Types></Types>')
+        zf.writestr("_rels/.rels", '<?xml version="1.0"?><Relationships></Relationships>')
+        zf.writestr("word/document.xml", '<?xml version="1.0"?><document></document>')
         # Embed PE/DOS magic bytes
-        malicious_content = b'X' * 700 + b'MZ' + b'\x00' * 200
-        zf.writestr('word/media/image1.jpg', malicious_content)
-    
+        malicious_content = b"X" * 700 + b"MZ" + b"\x00" * 200
+        zf.writestr("word/media/image1.jpg", malicious_content)
+
     analyzer = Analyzer(use_ml=False)
     result = analyzer.analyze(zip_buffer.getvalue())
-    
+
     # Should detect DOCX
     assert result.primary_format == "docx"
-    
+
     # Should find embedded executable
     embedded = [c for c in result.contradictions if c.category == "embedded"]
     assert len(embedded) > 0
-    assert "executable" in embedded[0].issue.lower() or "PE" in embedded[0].issue or "DOS" in embedded[0].issue
+    assert (
+        "executable" in embedded[0].issue.lower()
+        or "PE" in embedded[0].issue
+        or "DOS" in embedded[0].issue
+    )
 
 
 def test_pdf_missing_eof():
     """Test detection of PDF missing %%EOF marker."""
     # Create truncated PDF
-    pdf_data = b'%PDF-1.4\n1 0 obj\n<< /Type /Catalog >>\nendobj\n'
+    pdf_data = b"%PDF-1.4\n1 0 obj\n<< /Type /Catalog >>\nendobj\n"
     # Missing %%EOF
-    
+
     analyzer = Analyzer(use_ml=False)
     result = analyzer.analyze(pdf_data)
-    
+
     # Should detect PDF
     assert result.primary_format == "pdf"
-    
+
     # Should find missing EOF
     structure_issues = [c for c in result.contradictions if c.category == "structure"]
     assert len(structure_issues) > 0
@@ -143,19 +150,21 @@ def test_pdf_missing_eof():
 def test_jpeg_missing_sos():
     """Test detection of JPEG missing Start of Scan marker."""
     # Create JPEG with SOI and SOF but no SOS
-    jpeg_data = b'\xff\xd8'  # SOI
-    jpeg_data += b'\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00'  # APP0/JFIF
-    jpeg_data += b'\xff\xc0\x00\x11\x08\x00\x10\x00\x10\x03\x01\x22\x00\x02\x11\x01\x03\x11\x01'  # SOF0
+    jpeg_data = b"\xff\xd8"  # SOI
+    jpeg_data += b"\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00"  # APP0/JFIF
+    jpeg_data += (
+        b"\xff\xc0\x00\x11\x08\x00\x10\x00\x10\x03\x01\x22\x00\x02\x11\x01\x03\x11\x01"  # SOF0
+    )
     # Missing SOS (Start of Scan)
     # Add some data but no proper scan
-    jpeg_data += b'\xff\xd9'  # EOI
-    
+    jpeg_data += b"\xff\xd9"  # EOI
+
     analyzer = Analyzer(use_ml=False)
     result = analyzer.analyze(jpeg_data)
-    
+
     # Should detect JPEG
     assert result.primary_format == "jpeg"
-    
+
     # Should find structural issue
     structure_issues = [c for c in result.contradictions if c.category == "structure"]
     if structure_issues:
@@ -166,28 +175,29 @@ def test_no_contradictions_in_valid_file():
     """Test that valid files don't trigger false positives."""
     # Create valid PNG
     png_data = bytes.fromhex("89504E470D0A1A0A0000000D494844520000001000000010080200000090916836")
-    
+
     # Add valid IDAT with proper zlib compression
-    raw_data = b'\x00' * 64  # Simple scanline data
+    raw_data = b"\x00" * 64  # Simple scanline data
     compressed = zlib.compress(raw_data)
-    
-    idat_len = len(compressed).to_bytes(4, 'big')
-    idat_type = b'IDAT'
+
+    idat_len = len(compressed).to_bytes(4, "big")
+    idat_type = b"IDAT"
     idat_data = compressed
-    
+
     # Calculate CRC
     import binascii
+
     crc_data = idat_type + idat_data
-    crc = binascii.crc32(crc_data).to_bytes(4, 'big')
-    
+    crc = binascii.crc32(crc_data).to_bytes(4, "big")
+
     valid_png = png_data + idat_len + idat_type + idat_data + crc
-    
+
     # Add IEND
-    valid_png += b'\x00\x00\x00\x00IEND\xae\x42\x60\x82'
-    
+    valid_png += b"\x00\x00\x00\x00IEND\xae\x42\x60\x82"
+
     analyzer = Analyzer(use_ml=False)
     result = analyzer.analyze(valid_png)
-    
+
     # Should detect PNG with no contradictions
     assert result.primary_format == "png"
     assert len(result.contradictions) == 0
@@ -197,15 +207,15 @@ def test_embedded_shell_script():
     """Test detection of embedded shell script."""
     # Create ZIP with embedded shell script
     zip_buffer = io.BytesIO()
-    with zipfile.ZipFile(zip_buffer, 'w', zipfile.ZIP_DEFLATED) as zf:
-        zf.writestr('normal.txt', 'Normal content')
+    with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("normal.txt", "Normal content")
         # Embed shell script past header
-        script_content = b'X' * 600 + b'#!/bin/bash' + b'\nrm -rf /\n'
-        zf.writestr('data.txt', script_content)
-    
+        script_content = b"X" * 600 + b"#!/bin/bash" + b"\nrm -rf /\n"
+        zf.writestr("data.txt", script_content)
+
     analyzer = Analyzer(use_ml=False)
     result = analyzer.analyze(zip_buffer.getvalue())
-    
+
     # Should find embedded script
     embedded = [c for c in result.contradictions if c.category == "embedded"]
     assert len(embedded) > 0
@@ -216,12 +226,12 @@ def test_contradiction_severity_levels():
     """Test that contradictions have appropriate severity levels."""
     # Create file with critical embedded executable
     zip_buffer = io.BytesIO()
-    with zipfile.ZipFile(zip_buffer, 'w', zipfile.ZIP_DEFLATED) as zf:
-        zf.writestr('file.txt', b'A' * 600 + b'\x7fELF' + b'\x00' * 100)
-    
+    with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("file.txt", b"A" * 600 + b"\x7fELF" + b"\x00" * 100)
+
     analyzer = Analyzer(use_ml=False)
     result = analyzer.analyze(zip_buffer.getvalue())
-    
+
     # Embedded executables should be critical
     embedded = [c for c in result.contradictions if c.category == "embedded"]
     if embedded:
@@ -232,19 +242,19 @@ def test_multiple_contradictions():
     """Test detection of multiple contradictions in same file."""
     # Create DOCX with missing _rels AND embedded executable
     zip_buffer = io.BytesIO()
-    with zipfile.ZipFile(zip_buffer, 'w', zipfile.ZIP_DEFLATED) as zf:
-        zf.writestr('[Content_Types].xml', '<?xml version="1.0"?><Types></Types>')
+    with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("[Content_Types].xml", '<?xml version="1.0"?><Types></Types>')
         # Missing _rels/.rels (contradiction 1)
-        zf.writestr('word/document.xml', '<?xml version="1.0"?><document></document>')
+        zf.writestr("word/document.xml", '<?xml version="1.0"?><document></document>')
         # Embedded ELF (contradiction 2)
-        zf.writestr('word/media/file.dat', b'X' * 600 + b'\x7fELF' + b'\x00' * 100)
-    
+        zf.writestr("word/media/file.dat", b"X" * 600 + b"\x7fELF" + b"\x00" * 100)
+
     analyzer = Analyzer(use_ml=False)
     result = analyzer.analyze(zip_buffer.getvalue())
-    
+
     # Should find multiple contradictions
     assert len(result.contradictions) >= 2
-    
+
     # Should have different categories
     categories = {c.category for c in result.contradictions}
     assert len(categories) >= 2

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -2,8 +2,7 @@
 Tests for cryptographic detection functionality
 """
 
-import pytest
-from filo.crypto import CryptoDetector, CryptoAnalysis
+from filo.crypto import CryptoDetector
 
 
 class TestEntropyInterpretation:

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -7,27 +7,27 @@ from filo.crypto import CryptoDetector
 
 class TestEntropyInterpretation:
     """Test entropy interpretation"""
-    
+
     def test_very_low_entropy(self):
         result = CryptoDetector.interpret_entropy(0.5)
         assert "very low" in result.lower()
         assert "repetitive" in result.lower()
-    
+
     def test_low_entropy(self):
         result = CryptoDetector.interpret_entropy(3.0)
         assert "low" in result.lower()
         assert "text" in result.lower()
-    
+
     def test_medium_entropy(self):
         result = CryptoDetector.interpret_entropy(5.5)
         assert "medium" in result.lower()
         assert "compressed" in result.lower() or "encryption" in result.lower()
-    
+
     def test_high_entropy(self):
         result = CryptoDetector.interpret_entropy(7.5)
         assert "high" in result.lower()
         assert "encrypt" in result.lower()
-    
+
     def test_very_high_entropy(self):
         result = CryptoDetector.interpret_entropy(7.95)
         assert "very high" in result.lower()
@@ -36,70 +36,70 @@ class TestEntropyInterpretation:
 
 class TestBlockAlignment:
     """Test block cipher alignment detection"""
-    
+
     def test_aes_aligned(self):
         data = b"A" * 48  # 3 AES blocks
         result = CryptoDetector.analyze_block_alignment(data)
-        
+
         assert result["aes_aligned"] is True
         assert result["aes_block_count"] == 3
         assert result["pkcs7_padding_possible"] is True
-    
+
     def test_des_aligned(self):
         data = b"A" * 24  # 3 DES blocks
         result = CryptoDetector.analyze_block_alignment(data)
-        
+
         assert result["des_aligned"] is True
         assert result["des_block_count"] == 3
-    
+
     def test_not_aligned(self):
         data = b"A" * 50  # Not aligned to any block size
         result = CryptoDetector.analyze_block_alignment(data)
-        
+
         assert result["aes_aligned"] is False
         assert result["des_aligned"] is False
 
 
 class TestECBDetection:
     """Test ECB mode detection"""
-    
+
     def test_ecb_repeating_blocks(self):
         # Create data with repeating 16-byte blocks (ECB pattern)
         block = b"AAAAAAAAAAAAAAAA"  # 16 bytes
         data = block + block + b"B" * 16  # First two blocks identical
-        
+
         result = CryptoDetector.detect_ecb_mode(data, block_size=16)
         assert result is True
-    
+
     def test_no_ecb_unique_blocks(self):
         # Create data with unique blocks (not ECB)
         data = b"A" * 16 + b"B" * 16 + b"C" * 16
-        
+
         result = CryptoDetector.detect_ecb_mode(data, block_size=16)
         assert result is False
-    
+
     def test_ecb_too_small(self):
         # Not enough data for ECB detection
         data = b"AAAAAAAAAAAAAAAA"  # Only 1 block
-        
+
         result = CryptoDetector.detect_ecb_mode(data, block_size=16)
         assert result is False
-    
+
     def test_ecb_not_aligned(self):
         # Data not aligned to block size
         data = b"A" * 50
-        
+
         result = CryptoDetector.detect_ecb_mode(data, block_size=16)
         assert result is False
 
 
 class TestOpenSSLDetection:
     """Test OpenSSL format detection"""
-    
+
     def test_openssl_salted(self):
         data = b"Salted__" + b"\x00" * 40
         assert CryptoDetector.detect_openssl_format(data) is True
-    
+
     def test_not_openssl(self):
         data = b"NotSalted" + b"\x00" * 40
         assert CryptoDetector.detect_openssl_format(data) is False
@@ -107,15 +107,15 @@ class TestOpenSSLDetection:
 
 class TestPGPDetection:
     """Test PGP/GPG format detection"""
-    
+
     def test_pgp_ascii_armor(self):
         data = b"-----BEGIN PGP MESSAGE-----\n" + b"\x00" * 50
         assert CryptoDetector.detect_pgp_format(data) is True
-    
+
     def test_pgp_binary(self):
         data = b"\x85\x01" + b"\x00" * 50
         assert CryptoDetector.detect_pgp_format(data) is True
-    
+
     def test_not_pgp(self):
         data = b"NotPGP" + b"\x00" * 50
         assert CryptoDetector.detect_pgp_format(data) is False
@@ -123,19 +123,19 @@ class TestPGPDetection:
 
 class TestPKCS7Padding:
     """Test PKCS#7 padding detection"""
-    
+
     def test_valid_padding(self):
         # Valid PKCS#7: last 5 bytes are all 0x05
         data = b"A" * 27 + b"\x05" * 5  # 32 bytes total
         result = CryptoDetector.detect_pkcs7_padding(data)
         assert result == 5
-    
+
     def test_invalid_padding_value(self):
         # Invalid: padding value too large
         data = b"A" * 15 + b"\x20"  # 0x20 = 32, invalid
         result = CryptoDetector.detect_pkcs7_padding(data)
         assert result is None
-    
+
     def test_invalid_padding_inconsistent(self):
         # Invalid: inconsistent padding bytes
         data = b"A" * 28 + b"\x04\x04\x04\x05"
@@ -145,80 +145,82 @@ class TestPKCS7Padding:
 
 class TestCryptoAnalysis:
     """Test full crypto analysis"""
-    
+
     def test_high_entropy_encrypted(self):
         # Simulate encrypted data (high entropy, AES-aligned)
         data = bytes(range(256)) * 3  # 768 bytes, high entropy
         entropy = 7.8
-        
+
         result = CryptoDetector.analyze(data, entropy)
-        
+
         assert result.is_likely_encrypted is True
         assert result.confidence > 0.7
         assert "high" in result.entropy_interpretation.lower()
         assert "encrypt" in result.entropy_interpretation.lower()
         assert len(result.encryption_indicators) > 0
-    
+
     def test_medium_entropy_maybe_encrypted(self):
         # Simulate compressed data (medium entropy)
         data = b"A" * 48  # AES-aligned but low entropy
         entropy = 5.5
-        
+
         result = CryptoDetector.analyze(data, entropy)
-        
+
         assert "medium" in result.entropy_interpretation.lower()
-    
+
     def test_openssl_format(self):
         # OpenSSL encrypted file
         data = b"Salted__" + b"\x00" * 40
         entropy = 7.9
-        
+
         result = CryptoDetector.analyze(data, entropy)
-        
+
         assert result.is_likely_encrypted is True
         assert result.confidence >= 0.95
         assert any("OpenSSL" in ind for ind in result.encryption_indicators)
         assert any("AES" in hint for hint in result.cipher_hints)
-    
+
     def test_ecb_mode_detection(self):
         # ECB mode with repeating blocks
         block = b"AAAAAAAAAAAAAAAA"
         data = block * 3  # 48 bytes, aligned
         entropy = 3.0  # Low because it's repeating
-        
+
         result = CryptoDetector.analyze(data, entropy)
-        
+
         # Should detect block alignment
         assert result.block_alignment is not None
         assert result.block_alignment["aes_aligned"] is True
-        
+
         # Should detect ECB mode
         assert any("ECB" in ind for ind in result.encryption_indicators)
         assert any("ECB" in hint for hint in result.cipher_hints)
-    
+
     def test_low_entropy_plaintext(self):
         # Regular text file
         data = b"This is a normal text file. " * 10
         entropy = 3.5  # Actually in low range
-        
+
         result = CryptoDetector.analyze(data, entropy)
-        
+
         assert result.is_likely_encrypted is False
         assert "low" in result.entropy_interpretation.lower()
         assert "text" in result.entropy_interpretation.lower()
-    
+
     def test_ctf_challenge_file(self):
         # Simulate the CTF challenge: 48 bytes, medium-high entropy
-        data = bytes.fromhex("6afc705dd11147acddb3ae1027773c12c7d9729fbe12b71dd4f821f51629926fcf485b3460e638095596e5ed1215f665")
+        data = bytes.fromhex(
+            "6afc705dd11147acddb3ae1027773c12c7d9729fbe12b71dd4f821f51629926fcf485b3460e638095596e5ed1215f665"
+        )
         entropy = 5.49  # Actual entropy from the challenge
-        
+
         result = CryptoDetector.analyze(data, entropy)
-        
+
         # Should detect AES alignment
         assert result.block_alignment is not None
         assert result.block_alignment["aes_aligned"] is True
         assert result.block_alignment["aes_block_count"] == 3
-        
+
         # Should interpret as compressed/weak encryption
         assert "medium" in result.entropy_interpretation.lower()
         assert "AES" in " ".join(result.cipher_hints)

--- a/tests/test_embedded.py
+++ b/tests/test_embedded.py
@@ -58,22 +58,25 @@ class TestEmbeddedDetector:
     def test_pe_executable_embedded(self, detector):
         """Test detection of PE executable embedded in file."""
         # Padding + PE executable signature
-        prefix = b"\x00" * 256
-        
+        prefix = b"\x00" * 512
+
         # Minimal PE file structure
-        mz_header = b"MZ" + b"\x00" * 58  # DOS header
+        mz_header = b"MZ" + b"\x00" * 58
         mz_header += b"\x80\x00\x00\x00"  # PE offset at 0x80
         pe_padding = b"\x00" * (0x80 - len(mz_header))
         pe_sig = b"PE\x00\x00"
-        
-        data = prefix + mz_header + pe_padding + pe_sig + b"\x00" * 100
-        
+        coff_header = b"\x00" * 20
+        optional_header = b"\x00" * 56 + b"\x00\x08\x00\x00" + b"\x00" * 20
+
+        data = prefix + mz_header + pe_padding + pe_sig + coff_header + optional_header
+        data += b"\x00" * 2000
+
         embedded = detector.detect_embedded(data, skip_primary=True)
-        
+
         # Should find PE executable
         pe_obj = next((obj for obj in embedded if obj.format == "pe"), None)
         assert pe_obj is not None
-        assert pe_obj.offset == 256
+        assert pe_obj.offset == 512
         assert pe_obj.confidence >= 0.70
     
     def test_elf_executable_embedded(self, detector):
@@ -111,7 +114,7 @@ class TestEmbeddedDetector:
         
         # Add JPEG at offset 188 (158 + 10 + 20)
         data += b"\x00" * 100
-        data += bytes.fromhex("FFD8FFE0") + b"\x00" * 50
+        data += bytes.fromhex("FFD8FFE0") + b"\x00" * 200
         
         embedded = detector.detect_embedded(data, skip_primary=True)
         
@@ -299,18 +302,23 @@ class TestEmbeddedDetector:
     def test_polyglot_detection(self, detector):
         """Test detection of polyglot files (valid as multiple formats)."""
         # Create file that's valid ZIP but also has PE signature
-        # This is simplified - real polyglots are more complex
-        
+
         # Start with ZIP
         data = b"PK\x03\x04\x14\x00\x00\x00\x08\x00" + b"\x00" * 100
-        
-        # Embed PE signature
+
+        # Embed PE executable
         data += b"\x00" * 156
         data += b"MZ" + b"\x00" * 58
         data += b"\x80\x00\x00\x00"  # PE offset
-        
+        data += b"\x00" * (0x80 - 64)  # padding to PE signature
+        data += b"PE\x00\x00"          # PE signature
+        data += b"\x00" * 20           # COFF header
+        data += b"\x00" * 56
+        data += b"\x00\x08\x00\x00"   # SizeOfImage = 2048
+        data += b"\x00" * 500
+
         embedded = detector.detect_embedded(data, skip_primary=True, min_confidence=0.60)
-        
+
         # Should find at least the embedded PE or DLL (same MZ signature)
         formats_found = {obj.format for obj in embedded}
         assert "pe" in formats_found or "zip" in formats_found or "dll" in formats_found

--- a/tests/test_embedded.py
+++ b/tests/test_embedded.py
@@ -5,7 +5,6 @@ Author: Filo Forensics Team
 """
 
 import pytest
-from pathlib import Path
 
 from filo.embedded import EmbeddedDetector, EmbeddedObject
 from filo.formats import FormatDatabase
@@ -236,7 +235,7 @@ class TestEmbeddedDetector:
         
         full_data = pe_data + overlay
         
-        overlay_obj = detector.detect_overlay(full_data, "pe")
+        detector.detect_overlay(full_data, "pe")
         
         # PE overlay detection is complex - just verify no crash
         # (Overlay detection needs proper PE parsing which is simplified here)

--- a/tests/test_embedded.py
+++ b/tests/test_embedded.py
@@ -12,49 +12,49 @@ from filo.formats import FormatDatabase
 
 class TestEmbeddedDetector:
     """Test suite for embedded object detection."""
-    
+
     @pytest.fixture
     def detector(self):
         """Create detector instance."""
         return EmbeddedDetector()
-    
+
     @pytest.fixture
     def formats_db(self):
         """Create formats database."""
         return FormatDatabase()
-    
+
     def test_detector_initialization(self, detector):
         """Test detector initializes correctly."""
         assert detector is not None
         assert detector.formats_db is not None
-    
+
     def test_no_embedded_in_simple_file(self, detector):
         """Test that simple files have no embedded objects."""
         # Simple PNG file (just signature)
         png_data = bytes.fromhex("89504E470D0A1A0A")
-        
+
         embedded = detector.detect_embedded(png_data, skip_primary=True)
         assert len(embedded) == 0
-    
+
     def test_zip_inside_binary(self, detector):
         """Test detection of ZIP archive embedded in binary data."""
         # Random data + ZIP signature + more data
         prefix = b"\x00" * 100
         zip_sig = b"PK\x03\x04"
         zip_header = zip_sig + b"\x14\x00\x00\x00\x08\x00" + b"\x00" * 20
-        suffix = b"\xFF" * 50
-        
+        suffix = b"\xff" * 50
+
         data = prefix + zip_header + suffix
-        
+
         embedded = detector.detect_embedded(data, skip_primary=True)
-        
+
         # Should find the ZIP
         assert len(embedded) > 0
         zip_obj = next((obj for obj in embedded if obj.format == "zip"), None)
         assert zip_obj is not None
         assert zip_obj.offset == 100
         assert zip_obj.confidence >= 0.70
-    
+
     def test_pe_executable_embedded(self, detector):
         """Test detection of PE executable embedded in file."""
         # Padding + PE executable signature
@@ -78,105 +78,105 @@ class TestEmbeddedDetector:
         assert pe_obj is not None
         assert pe_obj.offset == 512
         assert pe_obj.confidence >= 0.70
-    
+
     def test_elf_executable_embedded(self, detector):
         """Test detection of ELF executable embedded in file."""
-        prefix = b"\xFF" * 512
-        
+        prefix = b"\xff" * 512
+
         # ELF header
         elf_header = b"\x7fELF"  # Magic
-        elf_header += b"\x02"    # 64-bit
-        elf_header += b"\x01"    # Little endian
-        elf_header += b"\x01"    # Current version
+        elf_header += b"\x02"  # 64-bit
+        elf_header += b"\x01"  # Little endian
+        elf_header += b"\x01"  # Current version
         elf_header += b"\x00" * 9  # Padding
         elf_header += b"\x00" * 32  # Rest of header
-        
+
         data = prefix + elf_header + b"\x00" * 100
-        
+
         embedded = detector.detect_embedded(data, skip_primary=True)
-        
+
         # Should find ELF
         elf_obj = next((obj for obj in embedded if obj.format == "elf"), None)
         assert elf_obj is not None
         assert elf_obj.offset == 512
         assert elf_obj.confidence >= 0.70
-    
+
     def test_multiple_embedded_objects(self, detector):
         """Test detection of multiple embedded objects."""
         # Create file with multiple embedded objects
         data = b"\x00" * 100
-        
+
         # Add PNG at offset 100
         data += bytes.fromhex("89504E470D0A1A0A") + b"\x00" * 50
-        
+
         # Add ZIP at offset 158 (100 + 8 + 50)
         data += b"PK\x03\x04\x14\x00\x00\x00\x08\x00" + b"\x00" * 20
-        
+
         # Add JPEG at offset 188 (158 + 10 + 20)
         data += b"\x00" * 100
         data += bytes.fromhex("FFD8FFE0") + b"\x00" * 200
-        
+
         embedded = detector.detect_embedded(data, skip_primary=True)
-        
+
         # Should find all three
         assert len(embedded) >= 3
-        
+
         formats_found = {obj.format for obj in embedded}
         assert "png" in formats_found
         assert "zip" in formats_found
         assert "jpeg" in formats_found
-    
+
     def test_confidence_scoring(self, detector):
         """Test that confidence scoring works correctly."""
         # Well-aligned ZIP (512-byte aligned)
         aligned_data = b"\x00" * 512
         aligned_data += b"PK\x03\x04\x14\x00\x00\x00\x08\x00" + b"\x00" * 20
-        
+
         # Misaligned ZIP
         misaligned_data = b"\x00" * 123
         misaligned_data += b"PK\x03\x04\x14\x00\x00\x00\x08\x00" + b"\x00" * 20
-        
+
         aligned_objs = detector.detect_embedded(aligned_data, skip_primary=True)
         misaligned_objs = detector.detect_embedded(misaligned_data, skip_primary=True)
-        
+
         # Aligned should have higher confidence
         if aligned_objs and misaligned_objs:
             aligned_zip = next((obj for obj in aligned_objs if obj.format == "zip"), None)
             misaligned_zip = next((obj for obj in misaligned_objs if obj.format == "zip"), None)
-            
+
             if aligned_zip and misaligned_zip:
                 assert aligned_zip.confidence >= misaligned_zip.confidence
-    
+
     def test_min_confidence_threshold(self, detector):
         """Test minimum confidence filtering."""
         # Create data with weak signature match
         data = b"\x00" * 100 + b"PK\x03\x04" + b"\x00" * 50
-        
+
         # High threshold - should find ZIP
         high_threshold = detector.detect_embedded(data, min_confidence=0.60, skip_primary=True)
-        
+
         # Very high threshold - might filter it out
         very_high = detector.detect_embedded(data, min_confidence=0.95, skip_primary=True)
-        
+
         # High threshold should have more results than very high
         assert len(high_threshold) >= len(very_high)
-    
+
     def test_skip_primary_flag(self, detector):
         """Test skip_primary flag behavior."""
         # File starts with ZIP signature
         data = b"PK\x03\x04\x14\x00\x00\x00\x08\x00" + b"\x00" * 100
         data += b"PK\x03\x04\x14\x00\x00\x00\x08\x00" + b"\x00" * 50  # Another ZIP
-        
+
         # With skip_primary=True, should not find offset 0
         with_skip = detector.detect_embedded(data, skip_primary=True)
         offset_0_found = any(obj.offset == 0 for obj in with_skip)
         assert not offset_0_found
-        
+
         # With skip_primary=False, should find offset 0
         without_skip = detector.detect_embedded(data, skip_primary=False)
         offset_0_found = any(obj.offset == 0 for obj in without_skip)
         assert offset_0_found
-    
+
     def test_deduplication(self, detector):
         """Test that overlapping detections are deduplicated."""
         # Create data where multiple signatures might match nearby
@@ -184,16 +184,16 @@ class TestEmbeddedDetector:
         # PNG signature
         data += bytes.fromhex("89504E470D0A1A0A")
         data += b"\x00" * 10
-        
+
         embedded = detector.detect_embedded(data, skip_primary=True)
-        
+
         # Should not have duplicate PNG detections at same offset
         offsets = [obj.offset for obj in embedded]
         # Check no offsets within 16 bytes of each other (dedup threshold)
         for i, off1 in enumerate(offsets):
-            for off2 in offsets[i+1:]:
+            for off2 in offsets[i + 1 :]:
                 assert abs(off1 - off2) > 16
-    
+
     def test_embedded_object_model(self):
         """Test EmbeddedObject data model."""
         obj = EmbeddedObject(
@@ -202,9 +202,9 @@ class TestEmbeddedDetector:
             confidence=0.95,
             size=2048,
             description="ZIP at offset 0x1000 (2048 bytes)",
-            data_snippet=b"PK\x03\x04"
+            data_snippet=b"PK\x03\x04",
         )
-        
+
         assert obj.offset == 0x1000
         assert obj.format == "zip"
         assert obj.confidence == 0.95
@@ -212,7 +212,7 @@ class TestEmbeddedDetector:
         assert obj.data_snippet == b"PK\x03\x04"
         assert "0x1000" in obj.description
         assert "ZIP" in obj.description
-    
+
     def test_overlay_detection_pe(self, detector):
         """Test overlay detection for PE files."""
         # Create minimal PE file
@@ -220,31 +220,31 @@ class TestEmbeddedDetector:
         mz_header += b"\x80\x00\x00\x00"  # PE offset
         pe_padding = b"\x00" * (0x80 - len(mz_header))
         pe_sig = b"PE\x00\x00"
-        
+
         # PE optional header with SizeOfImage
         coff_header = b"\x00" * 20
         optional_header = b"\x00" * 80
         # Set SizeOfImage to 512 (overlays after this)
         optional_header += b"\x00\x02\x00\x00"  # 512 in little endian
         optional_header += b"\x00" * 100
-        
+
         pe_data = mz_header + pe_padding + pe_sig + coff_header + optional_header
-        
+
         # Pad to 512 bytes
         pe_data += b"\x00" * (512 - len(pe_data))
-        
+
         # Add overlay (ZIP archive)
         overlay = b"PK\x03\x04\x14\x00\x00\x00\x08\x00" + b"\x00" * 600
-        
+
         full_data = pe_data + overlay
-        
+
         detector.detect_overlay(full_data, "pe")
-        
+
         # PE overlay detection is complex - just verify no crash
         # (Overlay detection needs proper PE parsing which is simplified here)
         # In production, this would work with real PE files
         assert True  # Test passes if no exception
-    
+
     def test_overlay_detection_zip(self, detector):
         """Test overlay detection for ZIP files."""
         # Create minimal ZIP file
@@ -261,30 +261,30 @@ class TestEmbeddedDetector:
         local_header += b"\x04\x00"  # Filename length (4)
         local_header += b"\x00\x00"  # Extra field length
         local_header += b"test"  # Filename
-        
+
         # Central directory
         central_dir = b"PK\x01\x02"
         central_dir += b"\x00" * 42
         central_dir += b"test"
-        
+
         # End of central directory
         eocd = b"PK\x05\x06"
         eocd += b"\x00" * 18
-        
+
         zip_data = local_header + central_dir + eocd
-        
+
         # Add overlay
         overlay = b"\x00" * 1000 + b"SECRET DATA" + b"\x00" * 500
-        
+
         full_data = zip_data + overlay
-        
+
         overlay_obj = detector.detect_overlay(full_data, "zip")
-        
+
         # Should detect overlay
         assert overlay_obj is not None
         assert overlay_obj.offset > len(zip_data) - 100  # Near end of ZIP
         assert overlay_obj.size >= 500  # At least part of overlay
-    
+
     def test_no_overlay_in_normal_file(self, detector):
         """Test that normal files don't trigger false overlay detection."""
         # Normal PNG with proper IEND
@@ -292,13 +292,13 @@ class TestEmbeddedDetector:
         png_data += b"\x00" * 100
         # IEND chunk
         png_data += b"\x00\x00\x00\x00IEND"
-        png_data += b"\xAE\x42\x60\x82"  # CRC
-        
+        png_data += b"\xae\x42\x60\x82"  # CRC
+
         overlay = detector.detect_overlay(png_data, "png")
-        
+
         # Should not detect overlay
         assert overlay is None
-    
+
     def test_polyglot_detection(self, detector):
         """Test detection of polyglot files (valid as multiple formats)."""
         # Create file that's valid ZIP but also has PE signature
@@ -311,10 +311,10 @@ class TestEmbeddedDetector:
         data += b"MZ" + b"\x00" * 58
         data += b"\x80\x00\x00\x00"  # PE offset
         data += b"\x00" * (0x80 - 64)  # padding to PE signature
-        data += b"PE\x00\x00"          # PE signature
-        data += b"\x00" * 20           # COFF header
+        data += b"PE\x00\x00"  # PE signature
+        data += b"\x00" * 20  # COFF header
         data += b"\x00" * 56
-        data += b"\x00\x08\x00\x00"   # SizeOfImage = 2048
+        data += b"\x00\x08\x00\x00"  # SizeOfImage = 2048
         data += b"\x00" * 500
 
         embedded = detector.detect_embedded(data, skip_primary=True, min_confidence=0.60)

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -21,9 +21,9 @@ def sample_result():
 def test_json_export_result(sample_result):
     """Test JSON export of single result."""
     exported = JSONExporter.export_result(sample_result, pretty=True)
-    
+
     data = json.loads(exported)
-    
+
     assert data["format"] == "png"
     assert "confidence" in data
     assert "file_size" in data
@@ -37,11 +37,11 @@ def test_json_export_batch(sample_result):
         (Path("test1.png"), sample_result),
         (Path("test2.png"), sample_result),
     ]
-    
+
     exported = JSONExporter.export_batch(results, pretty=True)
-    
+
     data = json.loads(exported)
-    
+
     assert data["total_files"] == 2
     assert len(data["files"]) == 2
     assert "timestamp" in data
@@ -56,13 +56,13 @@ def test_json_export_repair():
         repaired_size=110,
         changes_made=["Added header"],
         warnings=[],
-        confidence=0.9
+        confidence=0.9,
     )
-    
+
     exported = JSONExporter.export_repair(report, pretty=True)
-    
+
     data = json.loads(exported)
-    
+
     assert data["success"] is True
     assert data["strategy_used"] == "test_strategy"
     assert data["confidence"] == 0.9
@@ -71,9 +71,9 @@ def test_json_export_repair():
 def test_sarif_export_result(sample_result):
     """Test SARIF export of single result."""
     exported = SARIFExporter.export_result(sample_result, Path("test.png"), pretty=True)
-    
+
     data = json.loads(exported)
-    
+
     assert data["version"] == "2.1.0"
     assert "runs" in data
     assert len(data["runs"]) == 1
@@ -86,11 +86,11 @@ def test_sarif_export_batch(sample_result):
         (Path("test1.png"), sample_result),
         (Path("test2.png"), sample_result),
     ]
-    
+
     exported = SARIFExporter.export_batch(results, pretty=True)
-    
+
     data = json.loads(exported)
-    
+
     assert data["version"] == "2.1.0"
     assert "runs" in data
 
@@ -98,16 +98,16 @@ def test_sarif_export_batch(sample_result):
 def test_export_to_file(sample_result, temp_dir):
     """Test exporting to file."""
     output_path = temp_dir / "result.json"
-    
+
     exported = JSONExporter.export_result(sample_result)
     export_to_file(exported, output_path, overwrite=True)
-    
+
     assert output_path.exists()
-    
+
     # Verify content
     with open(output_path) as f:
         data = json.load(f)
-    
+
     assert data["format"] == "png"
 
 
@@ -115,7 +115,7 @@ def test_export_to_file_no_overwrite(temp_dir):
     """Test export with no overwrite."""
     output_path = temp_dir / "result.json"
     output_path.write_text("existing")
-    
+
     with pytest.raises(FileExistsError):
         export_to_file("new data", output_path, overwrite=False)
 
@@ -124,9 +124,9 @@ def test_sarif_with_warnings(sample_result):
     """Test SARIF export with warnings - currently AnalysisResult doesn't have warnings field."""
     exported = SARIFExporter.export_result(sample_result, Path("test.png"))
     data = json.loads(exported)
-    
+
     results = data["runs"][0]["results"]
-    
+
     # Should have main result
     assert len(results) >= 1
     assert results[0]["ruleId"] == "FILE-001"

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -7,7 +7,7 @@ import pytest
 
 from filo.export import JSONExporter, SARIFExporter, export_to_file
 from filo.analyzer import Analyzer
-from filo.repair import RepairEngine, RepairReport
+from filo.repair import RepairReport
 
 
 @pytest.fixture

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -2,8 +2,6 @@
 Tests for FormatDatabase
 """
 
-import pytest
-from pathlib import Path
 
 from filo.formats import FormatDatabase
 

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -2,7 +2,6 @@
 Tests for FormatDatabase
 """
 
-
 from filo.formats import FormatDatabase
 
 
@@ -16,7 +15,7 @@ def test_database_initialization():
 def test_get_format():
     """Test getting format specification."""
     db = FormatDatabase()
-    
+
     png_spec = db.get_format("png")
     assert png_spec is not None
     assert png_spec.format == "png"
@@ -27,7 +26,7 @@ def test_get_format():
 def test_list_formats():
     """Test listing all formats."""
     db = FormatDatabase()
-    
+
     formats = db.list_formats()
     assert isinstance(formats, list)
     assert len(formats) > 0
@@ -38,10 +37,10 @@ def test_list_formats():
 def test_get_formats_by_category():
     """Test filtering by category."""
     db = FormatDatabase()
-    
+
     image_formats = db.get_formats_by_category("raster_image")
     assert len(image_formats) > 0
-    
+
     format_names = [spec.format for spec in image_formats]
     assert "png" in format_names
     assert "jpeg" in format_names
@@ -50,11 +49,11 @@ def test_get_formats_by_category():
 def test_get_formats_by_extension():
     """Test filtering by extension."""
     db = FormatDatabase()
-    
+
     png_formats = db.get_formats_by_extension("png")
     assert len(png_formats) == 1
     assert png_formats[0].format == "png"
-    
+
     # Test with leading dot
     png_formats2 = db.get_formats_by_extension(".png")
     assert len(png_formats2) == 1
@@ -63,7 +62,7 @@ def test_get_formats_by_extension():
 def test_format_contains():
     """Test __contains__ method."""
     db = FormatDatabase()
-    
+
     assert "png" in db
     assert "jpeg" in db
     assert "nonexistent" not in db

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,7 +2,6 @@
 Integration tests
 """
 
-
 from filo import Analyzer, RepairEngine
 
 
@@ -11,14 +10,14 @@ def test_analyze_and_repair_workflow(temp_dir, corrupted_pdf_data):
     # Create corrupted file
     corrupted_file = temp_dir / "corrupted.pdf"
     corrupted_file.write_bytes(corrupted_pdf_data)
-    
+
     # Analyze
     analyzer = Analyzer()
     result = analyzer.analyze_file(corrupted_file)
-    
+
     # Should detect as PDF (or unknown due to missing header)
     print(f"Detected as: {result.primary_format} with {result.confidence:.2%} confidence")
-    
+
     # Repair
     engine = RepairEngine()
     repaired_data, report = engine.repair_file(
@@ -28,14 +27,14 @@ def test_analyze_and_repair_workflow(temp_dir, corrupted_pdf_data):
         output_path=temp_dir / "repaired.pdf",
         create_backup=False,
     )
-    
+
     assert report.success
     assert repaired_data.startswith(b"%PDF")
-    
+
     # Verify repaired file exists
     repaired_file = temp_dir / "repaired.pdf"
     assert repaired_file.exists()
-    
+
     # Analyze repaired file
     result2 = analyzer.analyze_file(repaired_file)
     assert result2.primary_format == "pdf"
@@ -45,15 +44,15 @@ def test_analyze_and_repair_workflow(temp_dir, corrupted_pdf_data):
 def test_multiple_format_detection(sample_png_data, sample_jpeg_data, sample_pdf_data):
     """Test detecting multiple different formats."""
     analyzer = Analyzer()
-    
+
     # PNG
     png_result = analyzer.analyze(sample_png_data)
     assert png_result.primary_format == "png"
-    
+
     # JPEG
     jpeg_result = analyzer.analyze(sample_jpeg_data)
     assert jpeg_result.primary_format == "jpeg"
-    
+
     # PDF
     pdf_result = analyzer.analyze(sample_pdf_data)
     assert pdf_result.primary_format == "pdf"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,8 +2,6 @@
 Integration tests
 """
 
-import pytest
-from pathlib import Path
 
 from filo import Analyzer, RepairEngine
 

--- a/tests/test_lineage.py
+++ b/tests/test_lineage.py
@@ -23,7 +23,7 @@ def sample_data():
     return {
         "original": b"This is the original file content",
         "repaired": b"This is the repaired file content",
-        "carved": b"This is a carved file"
+        "carved": b"This is a carved file",
     }
 
 
@@ -31,7 +31,7 @@ def test_lineage_tracker_initialization(tmp_path):
     """Test lineage tracker initialization."""
     db_path = tmp_path / "lineage.db"
     tracker = LineageTracker(db_path)
-    
+
     assert tracker.db_path == db_path
     assert db_path.exists()
 
@@ -43,9 +43,9 @@ def test_record_transformation(tracker, sample_data):
         result_data=sample_data["repaired"],
         operation=OperationType.REPAIR,
         format="png",
-        strategy="add_header"
+        strategy="add_header",
     )
-    
+
     assert lineage.original_hash == hashlib.sha256(sample_data["original"]).hexdigest()
     assert lineage.result_hash == hashlib.sha256(sample_data["repaired"]).hexdigest()
     assert lineage.operation == OperationType.REPAIR
@@ -57,17 +57,17 @@ def test_record_from_files(tracker, tmp_path, sample_data):
     """Test recording transformation from file paths."""
     original_file = tmp_path / "original.bin"
     result_file = tmp_path / "repaired.bin"
-    
+
     original_file.write_bytes(sample_data["original"])
     result_file.write_bytes(sample_data["repaired"])
-    
+
     lineage = tracker.record_from_files(
         original_path=original_file,
         result_path=result_file,
         operation=OperationType.REPAIR,
-        format="pdf"
+        format="pdf",
     )
-    
+
     assert lineage.original_path == str(original_file)
     assert lineage.result_path == str(result_file)
     assert lineage.metadata["format"] == "pdf"
@@ -79,19 +79,19 @@ def test_get_descendants(tracker, sample_data):
     lineage1 = tracker.record(
         original_data=sample_data["original"],
         result_data=sample_data["repaired"],
-        operation=OperationType.REPAIR
+        operation=OperationType.REPAIR,
     )
-    
+
     # Record repaired -> carved
     tracker.record(
         original_data=sample_data["repaired"],
         result_data=sample_data["carved"],
-        operation=OperationType.CARVE
+        operation=OperationType.CARVE,
     )
-    
+
     # Get descendants of original
     descendants = tracker.get_descendants(lineage1.original_hash)
-    
+
     assert len(descendants) == 1
     assert descendants[0].result_hash == lineage1.result_hash
     assert descendants[0].operation == OperationType.REPAIR
@@ -103,18 +103,18 @@ def test_get_ancestors(tracker, sample_data):
     lineage1 = tracker.record(
         original_data=sample_data["original"],
         result_data=sample_data["repaired"],
-        operation=OperationType.REPAIR
+        operation=OperationType.REPAIR,
     )
-    
+
     lineage2 = tracker.record(
         original_data=sample_data["repaired"],
         result_data=sample_data["carved"],
-        operation=OperationType.CARVE
+        operation=OperationType.CARVE,
     )
-    
+
     # Get ancestors of carved file
     ancestors = tracker.get_ancestors(lineage2.result_hash)
-    
+
     assert len(ancestors) == 1
     assert ancestors[0].original_hash == lineage1.result_hash
     assert ancestors[0].operation == OperationType.CARVE
@@ -126,24 +126,24 @@ def test_get_full_chain(tracker, sample_data):
     original_hash = hashlib.sha256(sample_data["original"]).hexdigest()
     repaired_hash = hashlib.sha256(sample_data["repaired"]).hexdigest()
     hashlib.sha256(sample_data["carved"]).hexdigest()
-    
+
     tracker.record(
         original_data=sample_data["original"],
         result_data=sample_data["repaired"],
         operation=OperationType.REPAIR,
-        format="png"
+        format="png",
     )
-    
+
     tracker.record(
         original_data=sample_data["repaired"],
         result_data=sample_data["carved"],
         operation=OperationType.CARVE,
-        offset=1024
+        offset=1024,
     )
-    
+
     # Query from middle of chain
     chain = tracker.get_full_chain(repaired_hash)
-    
+
     assert chain["root_hash"] == original_hash
     assert chain["query_hash"] == repaired_hash
     assert len(chain["ancestors"]) == 1
@@ -156,18 +156,18 @@ def test_get_by_operation(tracker, sample_data):
     tracker.record(
         original_data=sample_data["original"],
         result_data=sample_data["repaired"],
-        operation=OperationType.REPAIR
+        operation=OperationType.REPAIR,
     )
-    
+
     tracker.record(
         original_data=sample_data["original"],
         result_data=sample_data["carved"],
-        operation=OperationType.CARVE
+        operation=OperationType.CARVE,
     )
-    
+
     repairs = tracker.get_by_operation(OperationType.REPAIR)
     carves = tracker.get_by_operation(OperationType.CARVE)
-    
+
     assert len(repairs) == 1
     assert len(carves) == 1
     assert repairs[0].operation == OperationType.REPAIR
@@ -177,16 +177,16 @@ def test_get_by_operation(tracker, sample_data):
 def test_export_chain_json(tracker, sample_data):
     """Test JSON export of lineage chain."""
     original_hash = hashlib.sha256(sample_data["original"]).hexdigest()
-    
+
     tracker.record(
         original_data=sample_data["original"],
         result_data=sample_data["repaired"],
         operation=OperationType.REPAIR,
-        format="png"
+        format="png",
     )
-    
+
     json_export = tracker.export_chain_json(original_hash)
-    
+
     # Validate JSON structure
     data = json.loads(json_export)
     assert "lineage_export" in data
@@ -199,17 +199,17 @@ def test_export_chain_json(tracker, sample_data):
 def test_export_chain_report(tracker, sample_data):
     """Test text report export of lineage chain."""
     original_hash = hashlib.sha256(sample_data["original"]).hexdigest()
-    
+
     tracker.record(
         original_data=sample_data["original"],
         result_data=sample_data["repaired"],
         operation=OperationType.REPAIR,
         format="png",
-        strategy="add_header"
+        strategy="add_header",
     )
-    
+
     report = tracker.export_chain_report(original_hash)
-    
+
     # Verify report contains key information
     assert "FORENSIC CHAIN-OF-CUSTODY REPORT" in report
     assert original_hash in report
@@ -222,20 +222,20 @@ def test_lineage_stats(tracker, sample_data):
     # Initially empty
     stats = tracker.get_stats()
     assert stats["total_records"] == 0
-    
+
     # Add some records
     tracker.record(
         original_data=sample_data["original"],
         result_data=sample_data["repaired"],
-        operation=OperationType.REPAIR
+        operation=OperationType.REPAIR,
     )
-    
+
     tracker.record(
         original_data=sample_data["original"],
         result_data=sample_data["carved"],
-        operation=OperationType.CARVE
+        operation=OperationType.CARVE,
     )
-    
+
     stats = tracker.get_stats()
     assert stats["total_records"] == 2
     assert stats["by_operation"]["repair"] == 1
@@ -249,26 +249,26 @@ def test_no_duplicate_records(tracker, sample_data):
     # Record same transformation twice with same timestamp would be duplicate
     # But since timestamps are different, they are allowed (legitimate re-processing)
     # This test verifies UNIQUE constraint on (hash, hash, operation, timestamp)
-    
+
     import time
-    
+
     # Record same transformation
     tracker.record(
         original_data=sample_data["original"],
         result_data=sample_data["repaired"],
-        operation=OperationType.REPAIR
+        operation=OperationType.REPAIR,
     )
-    
+
     # Small delay to ensure different timestamp
     time.sleep(0.01)
-    
+
     # Record again - different timestamp, so it's allowed
     tracker.record(
         original_data=sample_data["original"],
         result_data=sample_data["repaired"],
-        operation=OperationType.REPAIR
+        operation=OperationType.REPAIR,
     )
-    
+
     stats = tracker.get_stats()
     # Two records because timestamps differ (legitimate re-processing)
     assert stats["total_records"] >= 1  # At least one record exists
@@ -279,24 +279,24 @@ def test_multiple_descendants(tracker, sample_data):
     original = sample_data["original"]
     repaired1 = sample_data["repaired"]
     repaired2 = b"Alternative repair"
-    
+
     original_hash = hashlib.sha256(original).hexdigest()
-    
+
     # Original has two different repairs
     tracker.record(
         original_data=original,
         result_data=repaired1,
         operation=OperationType.REPAIR,
-        strategy="method1"
+        strategy="method1",
     )
-    
+
     tracker.record(
         original_data=original,
         result_data=repaired2,
         operation=OperationType.REPAIR,
-        strategy="method2"
+        strategy="method2",
     )
-    
+
     descendants = tracker.get_descendants(original_hash)
     assert len(descendants) == 2
 
@@ -308,45 +308,42 @@ def test_complex_lineage_chain(tracker):
     repaired = b"Repaired file data"
     carved = b"Carved embedded file"
     exported = b"Exported JSON"
-    
+
     corrupt_hash = hashlib.sha256(corrupt).hexdigest()
     hashlib.sha256(repaired).hexdigest()
     carved_hash = hashlib.sha256(carved).hexdigest()
-    
+
     # Step 1: Repair
     tracker.record(
         original_data=corrupt,
         result_data=repaired,
         operation=OperationType.REPAIR,
         format="png",
-        strategy="add_header"
+        strategy="add_header",
     )
-    
+
     # Step 2: Carve embedded file
     tracker.record(
         original_data=repaired,
         result_data=carved,
         operation=OperationType.CARVE,
         format="jpeg",
-        offset=2048
+        offset=2048,
     )
-    
+
     # Step 3: Export
     tracker.record(
-        original_data=carved,
-        result_data=exported,
-        operation=OperationType.EXPORT,
-        format="json"
+        original_data=carved, result_data=exported, operation=OperationType.EXPORT, format="json"
     )
-    
+
     # Verify full chain from carved file
     chain = tracker.get_full_chain(carved_hash)
-    
+
     assert chain["root_hash"] == corrupt_hash
     assert len(chain["ancestors"]) == 2  # repair + carve (backward chain to root)
     assert len(chain["descendants"]) == 1  # export (forward chain)
     assert chain["chain_length"] == 4  # corrupt -> repaired -> carved -> exported
-    
+
     # Verify we can trace back to root
     assert chain["ancestors"][0]["operation"] == "repair"
     assert chain["ancestors"][1]["operation"] == "carve"
@@ -357,17 +354,17 @@ def test_file_lineage_to_dict(sample_data):
     """Test FileLineage to_dict conversion."""
     original_hash = hashlib.sha256(sample_data["original"]).hexdigest()
     result_hash = hashlib.sha256(sample_data["repaired"]).hexdigest()
-    
+
     lineage = FileLineage(
         original_hash=original_hash,
         result_hash=result_hash,
         operation=OperationType.REPAIR,
-        timestamp=datetime.utcnow().isoformat() + 'Z',
-        metadata={"format": "png"}
+        timestamp=datetime.utcnow().isoformat() + "Z",
+        metadata={"format": "png"},
     )
-    
+
     data = lineage.to_dict()
-    
+
     assert data["original_hash"] == original_hash
     assert data["result_hash"] == result_hash
     assert data["operation"] == "repair"
@@ -378,17 +375,17 @@ def test_file_lineage_from_dict(sample_data):
     """Test FileLineage from_dict conversion."""
     original_hash = hashlib.sha256(sample_data["original"]).hexdigest()
     result_hash = hashlib.sha256(sample_data["repaired"]).hexdigest()
-    
+
     data = {
         "original_hash": original_hash,
         "result_hash": result_hash,
         "operation": "repair",
-        "timestamp": datetime.utcnow().isoformat() + 'Z',
-        "metadata": {"format": "png"}
+        "timestamp": datetime.utcnow().isoformat() + "Z",
+        "metadata": {"format": "png"},
     }
-    
+
     lineage = FileLineage.from_dict(data)
-    
+
     assert lineage.original_hash == original_hash
     assert lineage.result_hash == result_hash
     assert lineage.operation == OperationType.REPAIR
@@ -401,14 +398,14 @@ def test_clear_all(tracker, sample_data):
     tracker.record(
         original_data=sample_data["original"],
         result_data=sample_data["repaired"],
-        operation=OperationType.REPAIR
+        operation=OperationType.REPAIR,
     )
-    
+
     stats_before = tracker.get_stats()
     assert stats_before["total_records"] == 1
-    
+
     # Clear all
     tracker.clear_all()
-    
+
     stats_after = tracker.get_stats()
     assert stats_after["total_records"] == 0

--- a/tests/test_lineage.py
+++ b/tests/test_lineage.py
@@ -5,7 +5,6 @@ Tests for hash lineage tracking and chain-of-custody.
 import hashlib
 import json
 import pytest
-from pathlib import Path
 from datetime import datetime
 
 from filo.lineage import LineageTracker, FileLineage, OperationType
@@ -84,7 +83,7 @@ def test_get_descendants(tracker, sample_data):
     )
     
     # Record repaired -> carved
-    lineage2 = tracker.record(
+    tracker.record(
         original_data=sample_data["repaired"],
         result_data=sample_data["carved"],
         operation=OperationType.CARVE
@@ -126,7 +125,7 @@ def test_get_full_chain(tracker, sample_data):
     # Create a chain: original -> repaired -> carved
     original_hash = hashlib.sha256(sample_data["original"]).hexdigest()
     repaired_hash = hashlib.sha256(sample_data["repaired"]).hexdigest()
-    carved_hash = hashlib.sha256(sample_data["carved"]).hexdigest()
+    hashlib.sha256(sample_data["carved"]).hexdigest()
     
     tracker.record(
         original_data=sample_data["original"],
@@ -311,7 +310,7 @@ def test_complex_lineage_chain(tracker):
     exported = b"Exported JSON"
     
     corrupt_hash = hashlib.sha256(corrupt).hexdigest()
-    repaired_hash = hashlib.sha256(repaired).hexdigest()
+    hashlib.sha256(repaired).hexdigest()
     carved_hash = hashlib.sha256(carved).hexdigest()
     
     # Step 1: Repair

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,131 +1,127 @@
 """Tests for metadata extraction module"""
 
 import struct
-from filo.metadata import (
-    extract_metadata,
-    JPEGMetadataExtractor,
-    PNGMetadataExtractor
-)
+from filo.metadata import extract_metadata, JPEGMetadataExtractor, PNGMetadataExtractor
 
 
 class TestJPEGMetadataExtractor:
     """Test JPEG metadata extraction"""
-    
+
     def test_jpeg_basic_structure(self):
         """Test basic JPEG structure extraction"""
         # Minimal JPEG: SOI + JFIF APP0 + SOF0 + SOS + EOI
         jpeg_data = bytes.fromhex(
-            'FFD8'  # SOI
-            'FFE0'  # APP0 marker
-            '0010'  # Length = 16
-            '4A46494600'  # 'JFIF\0'
-            '0101'  # Version 1.01
-            '00'  # Density units: none
-            '0001'  # X density = 1
-            '0001'  # Y density = 1
-            '0000'  # Thumbnail size = 0x0
-            'FFC0'  # SOF0 marker
-            '0011'  # Length = 17
-            '08'  # Bits per sample = 8
-            '0280'  # Height = 640
-            '0280'  # Width = 640
-            '03'  # Components = 3
-            '011100'  # Component 1
-            '021101'  # Component 2
-            '031101'  # Component 3
-            'FFD9'  # EOI
+            "FFD8"  # SOI
+            "FFE0"  # APP0 marker
+            "0010"  # Length = 16
+            "4A46494600"  # 'JFIF\0'
+            "0101"  # Version 1.01
+            "00"  # Density units: none
+            "0001"  # X density = 1
+            "0001"  # Y density = 1
+            "0000"  # Thumbnail size = 0x0
+            "FFC0"  # SOF0 marker
+            "0011"  # Length = 17
+            "08"  # Bits per sample = 8
+            "0280"  # Height = 640
+            "0280"  # Width = 640
+            "03"  # Components = 3
+            "011100"  # Component 1
+            "021101"  # Component 2
+            "031101"  # Component 3
+            "FFD9"  # EOI
         )
-        
+
         extractor = JPEGMetadataExtractor()
         result = extractor.extract(jpeg_data)
-        
+
         assert result.format == "JPEG"
         assert len(result.fields) > 0
-        
+
         # Check for basic fields
         field_keys = [f.key for f in result.fields]
         assert "FileType" in field_keys
         assert "ImageWidth" in field_keys
         assert "ImageHeight" in field_keys
-        
+
         # Check values
         width_field = next(f for f in result.fields if f.key == "ImageWidth")
         assert width_field.value == 640
-        
+
         height_field = next(f for f in result.fields if f.key == "ImageHeight")
         assert height_field.value == 640
-    
+
     def test_jpeg_comment_extraction(self):
         """Test JPEG comment marker extraction"""
         # JPEG with comment marker
         jpeg_data = bytes.fromhex(
-            'FFD8'  # SOI
-            'FFFE'  # COM marker
-            '000D'  # Length = 13 (includes length field itself, which is 2 bytes, plus 11 bytes of data)
-            '48656C6C6F20574F524C44'  # 'Hello WORLD' (11 bytes)
-            'FFD9'  # EOI
+            "FFD8"  # SOI
+            "FFFE"  # COM marker
+            "000D"  # Length = 13 (includes length field itself, which is 2 bytes, plus 11 bytes of data)
+            "48656C6C6F20574F524C44"  # 'Hello WORLD' (11 bytes)
+            "FFD9"  # EOI
         )
-        
+
         extractor = JPEGMetadataExtractor()
         result = extractor.extract(jpeg_data)
-        
+
         # Find comment field
         comment_fields = [f for f in result.fields if f.key == "Comment"]
         assert len(comment_fields) == 1
         assert comment_fields[0].value == "Hello WORLD"
         assert comment_fields[0].group == "JPEG"
-    
+
     def test_jpeg_suspicious_base64_comment(self):
         """Test detection of suspicious base64 in comment"""
         # JPEG with base64-encoded steghide password in comment
         # This mimics the picoCTF challenge
         comment_text = b"c3RlZ2hpZGU6Y0VGNmVuZHZjbVE="  # "steghide:cEF6endvcmQ=" in base64
-        
+
         jpeg_data = (
-            b'\xFF\xD8'  # SOI
-            b'\xFF\xFE'  # COM marker
-            + (len(comment_text) + 2).to_bytes(2, 'big')  # Length
+            b"\xff\xd8"  # SOI
+            b"\xff\xfe"  # COM marker
+            + (len(comment_text) + 2).to_bytes(2, "big")  # Length
             + comment_text
-            + b'\xFF\xD9'  # EOI
+            + b"\xff\xd9"  # EOI
         )
-        
+
         extractor = JPEGMetadataExtractor()
         result = extractor.extract(jpeg_data)
-        
+
         # Should detect suspicious content
         assert result.has_suspicious is True
         assert "Comment" in result.suspicious_fields
-        
+
         # Find comment field
         comment_field = next(f for f in result.fields if f.key == "Comment")
-        assert comment_field.value == comment_text.decode('utf-8')
-    
+        assert comment_field.value == comment_text.decode("utf-8")
+
     def test_jpeg_jfif_metadata(self):
         """Test JFIF metadata extraction"""
         jpeg_data = bytes.fromhex(
-            'FFD8'  # SOI
-            'FFE0'  # APP0 marker
-            '0010'  # Length = 16
-            '4A46494600'  # 'JFIF\0'
-            '0102'  # Version 1.02
-            '01'  # Density units: pixels/inch
-            '0048'  # X density = 72
-            '0048'  # Y density = 72
-            '0000'  # Thumbnail size = 0x0
-            'FFD9'  # EOI
+            "FFD8"  # SOI
+            "FFE0"  # APP0 marker
+            "0010"  # Length = 16
+            "4A46494600"  # 'JFIF\0'
+            "0102"  # Version 1.02
+            "01"  # Density units: pixels/inch
+            "0048"  # X density = 72
+            "0048"  # Y density = 72
+            "0000"  # Thumbnail size = 0x0
+            "FFD9"  # EOI
         )
-        
+
         extractor = JPEGMetadataExtractor()
         result = extractor.extract(jpeg_data)
-        
+
         # Find JFIF fields
         jfif_fields = [f for f in result.fields if f.group == "JFIF"]
         assert len(jfif_fields) > 0
-        
+
         # Check version
         version_field = next(f for f in jfif_fields if f.key == "JFIFVersion")
         assert version_field.value == "1.02"
-        
+
         # Check resolution
         xres_field = next(f for f in jfif_fields if f.key == "XResolution")
         assert xres_field.value == 72
@@ -133,111 +129,110 @@ class TestJPEGMetadataExtractor:
 
 class TestPNGMetadataExtractor:
     """Test PNG metadata extraction"""
-    
+
     def test_png_basic_structure(self):
         """Test PNG IHDR extraction"""
         png_data = bytes.fromhex(
-            '89504E470D0A1A0A'  # PNG signature
-            '0000000D'  # IHDR length = 13
-            '49484452'  # 'IHDR'
-            '00000280'  # Width = 640
-            '00000280'  # Height = 640
-            '08'  # Bit depth = 8
-            '06'  # Color type = 6 (RGBA)
-            '000000'  # Compression, filter, interlace
-            '00000000'  # CRC (dummy)
-            '00000000'  # IEND length = 0
-            '49454E44'  # 'IEND'
-            'AE426082'  # IEND CRC
+            "89504E470D0A1A0A"  # PNG signature
+            "0000000D"  # IHDR length = 13
+            "49484452"  # 'IHDR'
+            "00000280"  # Width = 640
+            "00000280"  # Height = 640
+            "08"  # Bit depth = 8
+            "06"  # Color type = 6 (RGBA)
+            "000000"  # Compression, filter, interlace
+            "00000000"  # CRC (dummy)
+            "00000000"  # IEND length = 0
+            "49454E44"  # 'IEND'
+            "AE426082"  # IEND CRC
         )
-        
+
         extractor = PNGMetadataExtractor()
         result = extractor.extract(png_data)
-        
+
         assert result.format == "PNG"
-        
+
         # Check for basic fields
         field_keys = [f.key for f in result.fields]
         assert "ImageWidth" in field_keys
         assert "ImageHeight" in field_keys
         assert "BitDepth" in field_keys
         assert "ColorType" in field_keys
-        
+
         # Check values
         width_field = next(f for f in result.fields if f.key == "ImageWidth")
         assert width_field.value == 640
-    
+
     def test_png_text_chunk(self):
         """Test PNG tEXt chunk extraction"""
         # Create PNG with tEXt chunk
-        text_data = b'Comment\x00Hidden message here'
-        
+        text_data = b"Comment\x00Hidden message here"
+
         png_data = (
-            b'\x89PNG\r\n\x1a\n'  # PNG signature
-            + len(text_data).to_bytes(4, 'big')  # Chunk length
-            + b'tEXt'  # Chunk type
+            b"\x89PNG\r\n\x1a\n"  # PNG signature
+            + len(text_data).to_bytes(4, "big")  # Chunk length
+            + b"tEXt"  # Chunk type
             + text_data
-            + b'\x00\x00\x00\x00'  # CRC (dummy)
-            + b'\x00\x00\x00\x00'  # IEND length
-            + b'IEND'
-            + b'\xAE\x42\x60\x82'  # IEND CRC
+            + b"\x00\x00\x00\x00"  # CRC (dummy)
+            + b"\x00\x00\x00\x00"  # IEND length
+            + b"IEND"
+            + b"\xae\x42\x60\x82"  # IEND CRC
         )
-        
+
         extractor = PNGMetadataExtractor()
         result = extractor.extract(png_data)
-        
+
         # Find text fields
         text_fields = [f for f in result.fields if f.group == "PNG_Text"]
         assert len(text_fields) == 1
         assert text_fields[0].key == "Comment"
         assert text_fields[0].value == "Hidden message here"
-    
+
     def test_png_suspicious_text(self):
         """Test detection of suspicious base64 in PNG text chunks"""
         # PNG with suspicious base64 in tEXt
-        text_data = b'Password\x00c3RlZ2hpZGU6Y0VGNmVuZHZjbVE='
-        
+        text_data = b"Password\x00c3RlZ2hpZGU6Y0VGNmVuZHZjbVE="
+
         png_data = (
-            b'\x89PNG\r\n\x1a\n'  # PNG signature
-            + len(text_data).to_bytes(4, 'big')
-            + b'tEXt'
+            b"\x89PNG\r\n\x1a\n"  # PNG signature
+            + len(text_data).to_bytes(4, "big")
+            + b"tEXt"
             + text_data
-            + b'\x00\x00\x00\x00'  # CRC
-            + b'\x00\x00\x00\x00'  # IEND length
-            + b'IEND'
-            + b'\xAE\x42\x60\x82'
+            + b"\x00\x00\x00\x00"  # CRC
+            + b"\x00\x00\x00\x00"  # IEND length
+            + b"IEND"
+            + b"\xae\x42\x60\x82"
         )
-        
+
         extractor = PNGMetadataExtractor()
         result = extractor.extract(png_data)
-        
+
         # Should detect suspicious content
         assert result.has_suspicious is True
         assert "Password" in result.suspicious_fields
-    
+
     def test_png_time_chunk(self):
         """Test PNG tIME chunk extraction"""
         import struct
-        
-        time_data = (
-            struct.pack('>H', 2024)  # Year = 2024
-            + bytes([1, 15, 14, 30, 45])  # Jan 15, 14:30:45
-        )
-        
+
+        time_data = struct.pack(">H", 2024) + bytes(  # Year = 2024
+            [1, 15, 14, 30, 45]
+        )  # Jan 15, 14:30:45
+
         png_data = (
-            b'\x89PNG\r\n\x1a\n'
-            + len(time_data).to_bytes(4, 'big')
-            + b'tIME'
+            b"\x89PNG\r\n\x1a\n"
+            + len(time_data).to_bytes(4, "big")
+            + b"tIME"
             + time_data
-            + b'\x00\x00\x00\x00'  # CRC
-            + b'\x00\x00\x00\x00'  # IEND length
-            + b'IEND'
-            + b'\xAE\x42\x60\x82'
+            + b"\x00\x00\x00\x00"  # CRC
+            + b"\x00\x00\x00\x00"  # IEND length
+            + b"IEND"
+            + b"\xae\x42\x60\x82"
         )
-        
+
         extractor = PNGMetadataExtractor()
         result = extractor.extract(png_data)
-        
+
         # Find time field
         time_fields = [f for f in result.fields if f.key == "ModificationTime"]
         assert len(time_fields) == 1
@@ -246,72 +241,72 @@ class TestPNGMetadataExtractor:
 
 class TestExtractMetadata:
     """Test the main extract_metadata function"""
-    
+
     def test_auto_detect_jpeg(self):
         """Test auto-detection of JPEG format"""
-        jpeg_data = bytes.fromhex('FFD8FFE000104A46494600FFD9')
-        
+        jpeg_data = bytes.fromhex("FFD8FFE000104A46494600FFD9")
+
         result = extract_metadata(jpeg_data)
         assert result.format == "JPEG"
-    
+
     def test_auto_detect_png(self):
         """Test auto-detection of PNG format"""
-        png_data = bytes.fromhex('89504E470D0A1A0A0000000049454E44AE426082')
-        
+        png_data = bytes.fromhex("89504E470D0A1A0A0000000049454E44AE426082")
+
         result = extract_metadata(png_data)
         assert result.format == "PNG"
-    
+
     def test_unsupported_format(self):
         """Test handling of unsupported formats"""
         # Random data
-        data = b'\x00\x01\x02\x03'
-        
+        data = b"\x00\x01\x02\x03"
+
         result = extract_metadata(data)
         assert result.format == "unknown"
         assert len(result.warnings) > 0
-    
+
     def test_format_hint_jpeg(self):
         """Test explicit format hint"""
-        jpeg_data = bytes.fromhex('FFD8FFD9')
-        
-        result = extract_metadata(jpeg_data, format_hint='jpeg')
+        jpeg_data = bytes.fromhex("FFD8FFD9")
+
+        result = extract_metadata(jpeg_data, format_hint="jpeg")
         assert result.format == "JPEG"
-    
+
     def test_format_hint_png(self):
         """Test explicit format hint for PNG"""
-        png_data = bytes.fromhex('89504E470D0A1A0A0000000049454E44AE426082')
-        
-        result = extract_metadata(png_data, format_hint='png')
+        png_data = bytes.fromhex("89504E470D0A1A0A0000000049454E44AE426082")
+
+        result = extract_metadata(png_data, format_hint="png")
         assert result.format == "PNG"
 
 
 class TestSuspiciousDetection:
     """Test suspicious content detection patterns"""
-    
+
     def test_base64_detection(self):
         """Test base64 pattern detection"""
         extractor = JPEGMetadataExtractor()
-        
+
         # Should detect
         assert extractor._is_suspicious("c3RlZ2hpZGU6Y0VGNmVuZHZjbVE=")
         assert extractor._is_suspicious("VGhpcyBpcyBhIGxvbmcgYmFzZTY0IHN0cmluZw==")
-        
+
         # Should not detect (too short)
         assert not extractor._is_suspicious("short")
         assert not extractor._is_suspicious("")
-    
+
     def test_steghide_detection(self):
         """Test steghide keyword detection"""
         extractor = JPEGMetadataExtractor()
-        
+
         assert extractor._is_suspicious("steghide:password")
         assert extractor._is_suspicious("STEGHIDE embedded data")
         assert not extractor._is_suspicious("regular comment")
-    
+
     def test_encoding_prefix_detection(self):
         """Test detection of encoding prefixes"""
         extractor = JPEGMetadataExtractor()
-        
+
         assert extractor._is_suspicious("data:image/png;base64,iVBORw0KGgo=")
         assert extractor._is_suspicious("base64:SGVsbG8=")
         assert extractor._is_suspicious("encrypted:aGlkZGVu")
@@ -320,82 +315,84 @@ class TestSuspiciousDetection:
 
 class TestComputedFields:
     """Test computed metadata fields"""
-    
+
     def test_jpeg_computed_fields(self):
         """Test ImageSize and Megapixels computation"""
         # Create JPEG with known dimensions
         jpeg_data = bytes.fromhex(
-            'FFD8'  # SOI
-            'FFE000104A46494600010100000100010000'  # JFIF
-            'FFC0'  # SOF0
-            '0011'  # Length
-            '08'  # Bits
-            '0BB8'  # Height = 3000
-            '0FA0'  # Width = 4000
-            '03012200021101031101'  # Components
-            'FFD9'  # EOI
+            "FFD8"  # SOI
+            "FFE000104A46494600010100000100010000"  # JFIF
+            "FFC0"  # SOF0
+            "0011"  # Length
+            "08"  # Bits
+            "0BB8"  # Height = 3000
+            "0FA0"  # Width = 4000
+            "03012200021101031101"  # Components
+            "FFD9"  # EOI
         )
-        
+
         extractor = JPEGMetadataExtractor()
         result = extractor.extract(jpeg_data)
-        
+
         # Find computed fields
         image_size = next((f for f in result.fields if f.key == "ImageSize"), None)
         megapixels = next((f for f in result.fields if f.key == "Megapixels"), None)
-        
+
         assert image_size is not None
         assert image_size.value == "4000x3000"
         assert image_size.group == "Computed"
-        
+
         assert megapixels is not None
         assert megapixels.value == "12.0"
 
 
 class TestICCProfile:
     """Test ICC profile extraction"""
-    
+
     def test_jpeg_icc_profile_extraction(self):
         """Test ICC profile metadata extraction"""
         import struct
-        
+
         # Create JPEG with minimal ICC profile
-        jpeg_data = bytearray(b'\xFF\xD8')  # SOI
-        
+        jpeg_data = bytearray(b"\xff\xd8")  # SOI
+
         # APP0 - JFIF
-        jfif = b'\xFF\xE0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00'
+        jfif = b"\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00"
         jpeg_data.extend(jfif)
-        
+
         # APP2 - ICC Profile
-        icc_header = b'ICC_PROFILE\x00\x01\x01'
+        icc_header = b"ICC_PROFILE\x00\x01\x01"
         icc_profile = bytearray(128)
-        struct.pack_into('>I', icc_profile, 0, 128)  # Profile size
-        icc_profile[4:8] = b'appl'  # CMM Type
-        icc_profile[8:11] = b'\x02\x20\x00'  # Version 2.2.0
-        icc_profile[12:16] = b'mntr'  # Display device
-        icc_profile[16:20] = b'RGB '  # RGB color space
-        icc_profile[20:24] = b'XYZ '  # XYZ PCS
-        
+        struct.pack_into(">I", icc_profile, 0, 128)  # Profile size
+        icc_profile[4:8] = b"appl"  # CMM Type
+        icc_profile[8:11] = b"\x02\x20\x00"  # Version 2.2.0
+        icc_profile[12:16] = b"mntr"  # Display device
+        icc_profile[16:20] = b"RGB "  # RGB color space
+        icc_profile[20:24] = b"XYZ "  # XYZ PCS
+
         app2_data = icc_header + icc_profile
-        jpeg_data.extend(b'\xFF\xE2')  # APP2 marker
-        jpeg_data.extend(struct.pack('>H', len(app2_data) + 2))
+        jpeg_data.extend(b"\xff\xe2")  # APP2 marker
+        jpeg_data.extend(struct.pack(">H", len(app2_data) + 2))
         jpeg_data.extend(app2_data)
-        
+
         # SOF0 and EOI
-        jpeg_data.extend(b'\xFF\xC0\x00\x11\x08\x00\x64\x00\x64\x03\x01\x11\x00\x02\x11\x01\x03\x11\x01')
-        jpeg_data.extend(b'\xFF\xD9')
-        
+        jpeg_data.extend(
+            b"\xff\xc0\x00\x11\x08\x00\x64\x00\x64\x03\x01\x11\x00\x02\x11\x01\x03\x11\x01"
+        )
+        jpeg_data.extend(b"\xff\xd9")
+
         extractor = JPEGMetadataExtractor()
         result = extractor.extract(bytes(jpeg_data))
-        
+
         # Check ICC fields
         icc_fields = [f for f in result.fields if f.group == "ICC_Profile"]
         assert len(icc_fields) > 0
-        
+
         # Check specific fields
         cmm_field = next((f for f in icc_fields if f.key == "ProfileCMMType"), None)
         assert cmm_field is not None
         assert cmm_field.value == "appl"
-        
+
         version_field = next((f for f in icc_fields if f.key == "ProfileVersion"), None)
         assert version_field is not None
         assert version_field.value == "2.2.0"
@@ -403,34 +400,34 @@ class TestICCProfile:
 
 class TestEncodingProcess:
     """Test encoding process detection"""
-    
+
     def test_baseline_dct(self):
         """Test Baseline DCT detection"""
         jpeg_data = bytes.fromhex(
-            'FFD8FFE000104A46494600010100000100010000'
-            'FFC00011080064006403011100021101031101'  # SOF0 = Baseline DCT
-            'FFD9'
+            "FFD8FFE000104A46494600010100000100010000"
+            "FFC00011080064006403011100021101031101"  # SOF0 = Baseline DCT
+            "FFD9"
         )
-        
+
         extractor = JPEGMetadataExtractor()
         result = extractor.extract(jpeg_data)
-        
+
         encoding = next((f for f in result.fields if f.key == "EncodingProcess"), None)
         assert encoding is not None
         assert "Baseline DCT" in encoding.value
         assert "Huffman" in encoding.value
-    
+
     def test_progressive_dct(self):
         """Test Progressive DCT detection"""
         jpeg_data = bytes.fromhex(
-            'FFD8FFE000104A46494600010100000100010000'
-            'FFC20011080064006403011100021101031101'  # SOF2 = Progressive DCT
-            'FFD9'
+            "FFD8FFE000104A46494600010100000100010000"
+            "FFC20011080064006403011100021101031101"  # SOF2 = Progressive DCT
+            "FFD9"
         )
-        
+
         extractor = JPEGMetadataExtractor()
         result = extractor.extract(jpeg_data)
-        
+
         encoding = next((f for f in result.fields if f.key == "EncodingProcess"), None)
         assert encoding is not None
         assert "Progressive DCT" in encoding.value
@@ -438,14 +435,14 @@ class TestEncodingProcess:
 
 class TestMIMEType:
     """Test MIME type extraction"""
-    
+
     def test_jpeg_mime_type(self):
         """Test JPEG MIME type"""
-        jpeg_data = bytes.fromhex('FFD8FFD9')  # Minimal JPEG
-        
+        jpeg_data = bytes.fromhex("FFD8FFD9")  # Minimal JPEG
+
         extractor = JPEGMetadataExtractor()
         result = extractor.extract(jpeg_data)
-        
+
         mime_field = next((f for f in result.fields if f.key == "MIMEType"), None)
         assert mime_field is not None
         assert mime_field.value == "image/jpeg"
@@ -454,13 +451,13 @@ class TestMIMEType:
 
 class TestFixtures:
     """Test with generated fixture files"""
-    
+
     def test_fixture_files_exist(self):
         """Ensure fixture files were generated"""
         from pathlib import Path
-        
+
         fixtures_dir = Path(__file__).parent / "fixtures" / "metadata"
-        
+
         assert (fixtures_dir / "minimal.jpg").exists()
         assert (fixtures_dir / "with_comment.jpg").exists()
         assert (fixtures_dir / "with_icc.jpg").exists()
@@ -471,42 +468,42 @@ class TestFixtures:
 
 class TestIPTCParsing:
     """Test IPTC metadata extraction"""
-    
+
     def test_iptc_copyright_notice(self):
         """Test IPTC copyright notice extraction"""
         # Create minimal JPEG with IPTC copyright
         data = bytearray()
-        data.extend(b'\xFF\xD8')  # SOI
-        
+        data.extend(b"\xff\xd8")  # SOI
+
         # APP13 marker (Photoshop)
         app13_data = bytearray()
-        app13_data.extend(b'Photoshop 3.0\x00')
-        app13_data.extend(b'8BIM')  # 8BIM signature
-        app13_data.extend(struct.pack('>H', 0x0404))  # IPTC resource ID
-        app13_data.extend(b'\x00')  # Name length (0)
-        app13_data.extend(b'\x00')  # Padding
-        
+        app13_data.extend(b"Photoshop 3.0\x00")
+        app13_data.extend(b"8BIM")  # 8BIM signature
+        app13_data.extend(struct.pack(">H", 0x0404))  # IPTC resource ID
+        app13_data.extend(b"\x00")  # Name length (0)
+        app13_data.extend(b"\x00")  # Padding
+
         # IPTC data
         iptc_data = bytearray()
-        copyright_text = b'PicoCTF'
+        copyright_text = b"PicoCTF"
         iptc_data.append(0x1C)  # Tag marker
         iptc_data.append(2)  # Record 2 (Application)
         iptc_data.append(116)  # Dataset 116 (CopyrightNotice)
-        iptc_data.extend(struct.pack('>H', len(copyright_text)))
+        iptc_data.extend(struct.pack(">H", len(copyright_text)))
         iptc_data.extend(copyright_text)
-        
-        app13_data.extend(struct.pack('>I', len(iptc_data)))
+
+        app13_data.extend(struct.pack(">I", len(iptc_data)))
         app13_data.extend(iptc_data)
-        
-        data.extend(b'\xFF\xED')  # APP13
-        data.extend(struct.pack('>H', len(app13_data) + 2))
+
+        data.extend(b"\xff\xed")  # APP13
+        data.extend(struct.pack(">H", len(app13_data) + 2))
         data.extend(app13_data)
-        
-        data.extend(b'\xFF\xD9')  # EOI
-        
+
+        data.extend(b"\xff\xd9")  # EOI
+
         extractor = JPEGMetadataExtractor()
         result = extractor.extract(bytes(data))
-        
+
         # Check copyright notice
         copyright_fields = [f for f in result.fields if f.key == "CopyrightNotice"]
         assert len(copyright_fields) == 1
@@ -516,14 +513,14 @@ class TestIPTCParsing:
 
 class TestXMPParsing:
     """Test XMP metadata extraction"""
-    
+
     def test_xmp_license_base64(self):
         """Test XMP license extraction with base64 (CTF scenario)"""
         # Create minimal JPEG with XMP containing base64 license
         data = bytearray()
-        data.extend(b'\xFF\xD8')  # SOI
-        
-        xmp_data = b'''<?xpacket begin='' id='W5M0MpCehiHzreSzNTczkc9d'?>
+        data.extend(b"\xff\xd8")  # SOI
+
+        xmp_data = b"""<?xpacket begin='' id='W5M0MpCehiHzreSzNTczkc9d'?>
 <x:xmpmeta xmlns:x='adobe:ns:meta/' x:xmptk='Image::ExifTool 10.80'>
 <rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'>
  <rdf:Description rdf:about=''
@@ -532,31 +529,31 @@ class TestXMPParsing:
  </rdf:Description>
 </rdf:RDF>
 </x:xmpmeta>
-<?xpacket end='w'?>'''
-        
-        data.extend(b'\xFF\xE1')  # APP1
-        data.extend(struct.pack('>H', len(xmp_data) + 2 + 29))
-        data.extend(b'http://ns.adobe.com/xap/1.0/\x00')
+<?xpacket end='w'?>"""
+
+        data.extend(b"\xff\xe1")  # APP1
+        data.extend(struct.pack(">H", len(xmp_data) + 2 + 29))
+        data.extend(b"http://ns.adobe.com/xap/1.0/\x00")
         data.extend(xmp_data)
-        
-        data.extend(b'\xFF\xD9')  # EOI
-        
+
+        data.extend(b"\xff\xd9")  # EOI
+
         extractor = JPEGMetadataExtractor()
         result = extractor.extract(bytes(data))
-        
+
         # Check XMP license
         license_fields = [f for f in result.fields if f.key == "License"]
         assert len(license_fields) == 1
         assert license_fields[0].value == "cGljb0NURnt0aGVfbTN0YWRhdGFfMXNfbW9kaWZpZWR9"
         assert license_fields[0].group == "XMP"
-        
+
         # Should be flagged as suspicious
         assert result.has_suspicious
         assert "License" in result.suspicious_fields
-    
+
     def test_xmp_rights(self):
         """Test XMP rights/creator extraction"""
-        xmp_data = b'''<?xpacket begin='' id='W5M0MpCehiHzreSzNTczkc9d'?>
+        xmp_data = b"""<?xpacket begin='' id='W5M0MpCehiHzreSzNTczkc9d'?>
 <x:xmpmeta xmlns:x='adobe:ns:meta/'>
 <rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'>
  <rdf:Description rdf:about=''
@@ -568,19 +565,19 @@ class TestXMPParsing:
   </dc:rights>
  </rdf:Description>
 </rdf:RDF>
-</x:xmpmeta>'''
-        
+</x:xmpmeta>"""
+
         data = bytearray()
-        data.extend(b'\xFF\xD8')  # SOI
-        data.extend(b'\xFF\xE1')  # APP1
-        data.extend(struct.pack('>H', len(xmp_data) + 2 + 29))
-        data.extend(b'http://ns.adobe.com/xap/1.0/\x00')
+        data.extend(b"\xff\xd8")  # SOI
+        data.extend(b"\xff\xe1")  # APP1
+        data.extend(struct.pack(">H", len(xmp_data) + 2 + 29))
+        data.extend(b"http://ns.adobe.com/xap/1.0/\x00")
         data.extend(xmp_data)
-        data.extend(b'\xFF\xD9')  # EOI
-        
+        data.extend(b"\xff\xd9")  # EOI
+
         extractor = JPEGMetadataExtractor()
         result = extractor.extract(bytes(data))
-        
+
         # Check rights field
         rights_fields = [f for f in result.fields if f.key == "Rights"]
         assert len(rights_fields) == 1

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,13 +1,10 @@
 """Tests for metadata extraction module"""
 
 import struct
-import pytest
 from filo.metadata import (
     extract_metadata,
     JPEGMetadataExtractor,
-    PNGMetadataExtractor,
-    MetadataResult,
-    MetadataField
+    PNGMetadataExtractor
 )
 
 

--- a/tests/test_ml.py
+++ b/tests/test_ml.py
@@ -1,5 +1,3 @@
-import pytest
-from pathlib import Path
 
 from filo.ml import MLDetector, LearningExample, PatternMatch
 

--- a/tests/test_ml.py
+++ b/tests/test_ml.py
@@ -1,11 +1,10 @@
-
 from filo.ml import MLDetector, LearningExample, PatternMatch
 
 
 def test_ml_detector_initialization(tmp_path):
     model_path = tmp_path / "test_model.pkl"
     detector = MLDetector(model_path)
-    
+
     assert detector.model_path == model_path
     assert len(detector.pattern_weights) == 0
 
@@ -13,45 +12,42 @@ def test_ml_detector_initialization(tmp_path):
 def test_learn_and_predict(tmp_path):
     model_path = tmp_path / "test_model.pkl"
     detector = MLDetector(model_path)
-    
+
     png_data = bytes.fromhex("89504E470D0A1A0A") + b"\x00" * 100
-    
+
     example = LearningExample(
         file_hash="test123",
         patterns=[
             PatternMatch(
-                offset=0,
-                pattern=bytes.fromhex("89504E470D0A1A0A"),
-                format="png",
-                weight=1.0
+                offset=0, pattern=bytes.fromhex("89504E470D0A1A0A"), format="png", weight=1.0
             )
         ],
         correct_format="png",
         file_size=108,
-        entropy=0.5
+        entropy=0.5,
     )
-    
+
     detector.learn(example)
-    
+
     predictions = detector.predict(png_data, 0.5, 108)
-    
+
     assert len(predictions) > 0
     assert predictions[0][0] == "png"
 
 
 def test_model_persistence(tmp_path):
     model_path = tmp_path / "test_model.pkl"
-    
+
     detector1 = MLDetector(model_path)
     example = LearningExample(
         file_hash="test",
         patterns=[PatternMatch(0, b"\x89PNG", "png")],
         correct_format="png",
         file_size=100,
-        entropy=0.5
+        entropy=0.5,
     )
     detector1.learn(example)
-    
+
     detector2 = MLDetector(model_path)
     assert len(detector2.pattern_weights) > 0
 
@@ -59,7 +55,7 @@ def test_model_persistence(tmp_path):
 def test_extract_patterns():
     detector = MLDetector()
     data = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
-    
+
     patterns = detector.extract_patterns(data)
     assert len(patterns) > 0
     assert isinstance(patterns[0], bytes)

--- a/tests/test_office.py
+++ b/tests/test_office.py
@@ -40,7 +40,9 @@ def make_ole2_header(sector_shift: int = 9) -> bytes:
     return bytes(header)
 
 
-def make_dir_entry(name: str, obj_type: int = 2, start_sector: int = 0xFFFFFFFF, stream_size: int = 0) -> bytes:
+def make_dir_entry(
+    name: str, obj_type: int = 2, start_sector: int = 0xFFFFFFFF, stream_size: int = 0
+) -> bytes:
     entry = bytearray(128)
     name_encoded = name.encode("utf-16-le") + b"\x00\x00"
     name_len = min(len(name_encoded), 64)

--- a/tests/test_polyglot.py
+++ b/tests/test_polyglot.py
@@ -1,6 +1,7 @@
 """
 Tests for polyglot detection - files valid as multiple formats simultaneously.
 """
+
 import struct
 import zlib
 from filo.polyglot import PolyglotDetector
@@ -8,315 +9,388 @@ from filo.polyglot import PolyglotDetector
 
 class TestFormatValidators:
     """Test individual format validators."""
-    
+
     def test_validate_png_valid(self):
         detector = PolyglotDetector()
-        
-        png_data = bytearray([
-            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
-        ])
-        
+
+        png_data = bytearray(
+            [
+                0x89,
+                0x50,
+                0x4E,
+                0x47,
+                0x0D,
+                0x0A,
+                0x1A,
+                0x0A,
+            ]
+        )
+
         ihdr = struct.pack(">IIBBBBB", 1, 1, 8, 2, 0, 0, 0)
         ihdr_crc = zlib.crc32(b"IHDR" + ihdr)
         png_data.extend(struct.pack(">I", len(ihdr)))
         png_data.extend(b"IHDR")
         png_data.extend(ihdr)
         png_data.extend(struct.pack(">I", ihdr_crc))
-        
+
         assert detector._validate_png(bytes(png_data))
-    
+
     def test_validate_png_invalid(self):
         detector = PolyglotDetector()
-        
+
         invalid_data = b"Not a PNG file"
         assert not detector._validate_png(invalid_data)
-    
+
     def test_validate_gif_valid(self):
         detector = PolyglotDetector()
-        
-        gif_data = b'GIF89a' + struct.pack('<HH', 100, 100) + b'\x00' * 5
+
+        gif_data = b"GIF89a" + struct.pack("<HH", 100, 100) + b"\x00" * 5
         assert detector._validate_gif(gif_data)
-    
+
     def test_validate_gif_invalid(self):
         detector = PolyglotDetector()
-        
-        invalid_data = b'GIF' + b'\x00' * 10
+
+        invalid_data = b"GIF" + b"\x00" * 10
         assert not detector._validate_gif(invalid_data)
-    
+
     def test_validate_jpeg_valid(self):
         detector = PolyglotDetector()
-        
-        jpeg_data = bytes([
-            0xFF, 0xD8,
-            0xFF, 0xE0, 0x00, 0x10,
-            0x4A, 0x46, 0x49, 0x46, 0x00,
-            0x01, 0x01, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00,
-            0xFF, 0xDA, 0x00, 0x08, 0x01, 0x01, 0x00, 0x00, 0x3F, 0x00,
-            0x00,
-            0xFF, 0xD9,
-        ])
-        
+
+        jpeg_data = bytes(
+            [
+                0xFF,
+                0xD8,
+                0xFF,
+                0xE0,
+                0x00,
+                0x10,
+                0x4A,
+                0x46,
+                0x49,
+                0x46,
+                0x00,
+                0x01,
+                0x01,
+                0x00,
+                0x00,
+                0x01,
+                0x00,
+                0x01,
+                0x00,
+                0x00,
+                0xFF,
+                0xDA,
+                0x00,
+                0x08,
+                0x01,
+                0x01,
+                0x00,
+                0x00,
+                0x3F,
+                0x00,
+                0x00,
+                0xFF,
+                0xD9,
+            ]
+        )
+
         assert detector._validate_jpeg(jpeg_data)
-    
+
     def test_validate_jpeg_invalid(self):
         detector = PolyglotDetector()
-        
-        invalid_data = b'\xFF\xD8' + b'\x00' * 10
+
+        invalid_data = b"\xff\xd8" + b"\x00" * 10
         assert not detector._validate_jpeg(invalid_data)
-    
+
     def test_validate_zip_valid(self):
         detector = PolyglotDetector()
-        
+
         zip_data = bytearray(b"PK\x03\x04")
-        zip_data.extend(b'\x00' * 26)
+        zip_data.extend(b"\x00" * 26)
         zip_data.extend(b"PK\x05\x06")
-        zip_data.extend(b'\x00' * 18)
-        
+        zip_data.extend(b"\x00" * 18)
+
         assert detector._validate_zip(bytes(zip_data))
-    
+
     def test_validate_zip_invalid(self):
         detector = PolyglotDetector()
-        
+
         invalid_data = b"Not a ZIP file"
         assert not detector._validate_zip(invalid_data)
-    
+
     def test_validate_pdf_valid(self):
         detector = PolyglotDetector()
-        
-        pdf_data = b'%PDF-1.4\n' + b'%' + b'\x00' * 100 + b'/Type' + b'\x00' * 100 + b'%%EOF\n'
+
+        pdf_data = b"%PDF-1.4\n" + b"%" + b"\x00" * 100 + b"/Type" + b"\x00" * 100 + b"%%EOF\n"
         assert detector._validate_pdf(pdf_data)
-    
+
     def test_validate_pdf_invalid(self):
         detector = PolyglotDetector()
-        
+
         invalid_data = b"Not a PDF"
         assert not detector._validate_pdf(invalid_data)
-    
+
     def test_validate_pe_valid(self):
         detector = PolyglotDetector()
-        
-        pe_data = bytearray(b'MZ')
-        pe_data.extend(b'\x00' * 58)
-        pe_data.extend(struct.pack('<I', 64))
-        pe_data.extend(b'PE\x00\x00')
-        
+
+        pe_data = bytearray(b"MZ")
+        pe_data.extend(b"\x00" * 58)
+        pe_data.extend(struct.pack("<I", 64))
+        pe_data.extend(b"PE\x00\x00")
+
         assert detector._validate_pe(bytes(pe_data))
-    
+
     def test_validate_pe_invalid(self):
         detector = PolyglotDetector()
-        
+
         invalid_data = b"Not a PE file"
         assert not detector._validate_pe(invalid_data)
 
 
 class TestPolyglotDetection:
     """Test polyglot file detection."""
-    
+
     def test_png_zip_polyglot(self):
         detector = PolyglotDetector()
-        
-        png_data = bytearray([
-            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
-        ])
-        
+
+        png_data = bytearray(
+            [
+                0x89,
+                0x50,
+                0x4E,
+                0x47,
+                0x0D,
+                0x0A,
+                0x1A,
+                0x0A,
+            ]
+        )
+
         ihdr = struct.pack(">IIBBBBB", 1, 1, 8, 2, 0, 0, 0)
         ihdr_crc = zlib.crc32(b"IHDR" + ihdr)
         png_data.extend(struct.pack(">I", len(ihdr)))
         png_data.extend(b"IHDR")
         png_data.extend(ihdr)
         png_data.extend(struct.pack(">I", ihdr_crc))
-        
+
         iend_crc = zlib.crc32(b"IEND")
         png_data.extend(struct.pack(">I", 0))
         png_data.extend(b"IEND")
         png_data.extend(struct.pack(">I", iend_crc))
-        
+
         _zip_offset = len(png_data)
         png_data.extend(b"PK\x03\x04")
-        png_data.extend(b'\x00' * 26)
+        png_data.extend(b"\x00" * 26)
         png_data.extend(b"PK\x05\x06")
-        png_data.extend(b'\x00' * 18)
-        
+        png_data.extend(b"\x00" * 18)
+
         polyglots = detector.detect_polyglots(bytes(png_data))
-        
+
         assert len(polyglots) > 0
-        assert any(p.pattern == 'png_zip' for p in polyglots)
-    
+        assert any(p.pattern == "png_zip" for p in polyglots)
+
     def test_gif_jar_polyglot(self):
         detector = PolyglotDetector()
-        
-        gif_data = bytearray(b'GIF89a')
-        gif_data.extend(struct.pack('<HH', 100, 100))
-        gif_data.extend(b'\x00' * 50)
-        
+
+        gif_data = bytearray(b"GIF89a")
+        gif_data.extend(struct.pack("<HH", 100, 100))
+        gif_data.extend(b"\x00" * 50)
+
         gif_data.extend(b"PK\x03\x04")
-        gif_data.extend(b'\x00' * 26)
-        gif_data.extend(b'META-INF/MANIFEST.MF')
-        gif_data.extend(b'\x00' * 50)
+        gif_data.extend(b"\x00" * 26)
+        gif_data.extend(b"META-INF/MANIFEST.MF")
+        gif_data.extend(b"\x00" * 50)
         gif_data.extend(b"PK\x05\x06")
-        gif_data.extend(b'\x00' * 18)
-        
+        gif_data.extend(b"\x00" * 18)
+
         polyglots = detector.detect_polyglots(bytes(gif_data))
-        
+
         assert len(polyglots) > 0
-        assert any(p.pattern == 'gifar' for p in polyglots)
-    
+        assert any(p.pattern == "gifar" for p in polyglots)
+
     def test_pdf_with_javascript(self):
         detector = PolyglotDetector()
-        
-        pdf_data = b'%PDF-1.4\n'
+
+        pdf_data = b"%PDF-1.4\n"
         pdf_data += b'/JavaScript /JS eval(unescape("payload")) /OpenAction\n'
-        pdf_data += b'/Type /Catalog\n'
-        pdf_data += b'\x00' * 100
-        pdf_data += b'%%EOF\n'
-        
+        pdf_data += b"/Type /Catalog\n"
+        pdf_data += b"\x00" * 100
+        pdf_data += b"%%EOF\n"
+
         polyglots = detector.detect_polyglots(pdf_data)
-        
+
         assert len(polyglots) > 0
-        pdf_js_found = any(p.pattern == 'pdf_js' for p in polyglots)
+        pdf_js_found = any(p.pattern == "pdf_js" for p in polyglots)
         assert pdf_js_found
-    
+
     def test_no_polyglot_simple_file(self):
         detector = PolyglotDetector()
-        
-        png_data = bytearray([
-            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
-        ])
-        
+
+        png_data = bytearray(
+            [
+                0x89,
+                0x50,
+                0x4E,
+                0x47,
+                0x0D,
+                0x0A,
+                0x1A,
+                0x0A,
+            ]
+        )
+
         ihdr = struct.pack(">IIBBBBB", 1, 1, 8, 2, 0, 0, 0)
         ihdr_crc = zlib.crc32(b"IHDR" + ihdr)
         png_data.extend(struct.pack(">I", len(ihdr)))
         png_data.extend(b"IHDR")
         png_data.extend(ihdr)
         png_data.extend(struct.pack(">I", ihdr_crc))
-        
+
         polyglots = detector.detect_polyglots(bytes(png_data))
-        
+
         assert len(polyglots) == 0
-    
+
     def test_risk_assessment(self):
         detector = PolyglotDetector()
-        
-        assert detector._assess_risk('gifar', ['gif', 'jar']) == 'high'
-        assert detector._assess_risk('pdf_js', ['pdf']) == 'high'
-        assert detector._assess_risk('png_zip', ['png', 'zip']) == 'medium'
-        assert detector._assess_risk('unknown', ['png', 'jpeg']) == 'low'
-    
+
+        assert detector._assess_risk("gifar", ["gif", "jar"]) == "high"
+        assert detector._assess_risk("pdf_js", ["pdf"]) == "high"
+        assert detector._assess_risk("png_zip", ["png", "zip"]) == "medium"
+        assert detector._assess_risk("unknown", ["png", "jpeg"]) == "low"
+
     def test_confidence_calculation(self):
         detector = PolyglotDetector()
-        
-        confidence = detector._calculate_polyglot_confidence(b'test', ['png', 'zip'])
+
+        confidence = detector._calculate_polyglot_confidence(b"test", ["png", "zip"])
         assert 0.70 <= confidence <= 1.0
-    
+
     def test_pattern_descriptions(self):
         detector = PolyglotDetector()
-        
-        assert 'GIFAR' in detector._get_pattern_description('gifar')
-        assert 'PNG + ZIP' in detector._get_pattern_description('png_zip')
-        assert 'JavaScript' in detector._get_pattern_description('pdf_js')
+
+        assert "GIFAR" in detector._get_pattern_description("gifar")
+        assert "PNG + ZIP" in detector._get_pattern_description("png_zip")
+        assert "JavaScript" in detector._get_pattern_description("pdf_js")
 
 
 class TestJavaScriptDetection:
     """Test JavaScript payload detection in PDFs."""
-    
+
     def test_pdf_with_js_indicators(self):
         detector = PolyglotDetector()
-        
-        pdf_data = b'%PDF-1.4\n/JavaScript /AA eval( unescape( String.fromCharCode\n%%EOF\n'
+
+        pdf_data = b"%PDF-1.4\n/JavaScript /AA eval( unescape( String.fromCharCode\n%%EOF\n"
         assert detector._has_js_payload(pdf_data)
-    
+
     def test_pdf_without_js(self):
         detector = PolyglotDetector()
-        
-        pdf_data = b'%PDF-1.4\n/Type /Catalog\n%%EOF\n'
+
+        pdf_data = b"%PDF-1.4\n/Type /Catalog\n%%EOF\n"
         assert not detector._has_js_payload(pdf_data)
-    
+
     def test_non_pdf_no_js(self):
         detector = PolyglotDetector()
-        
-        not_pdf = b'Not a PDF with /JavaScript'
+
+        not_pdf = b"Not a PDF with /JavaScript"
         assert not detector._has_js_payload(not_pdf)
 
 
 class TestMultipleFormats:
     """Test detection of multiple valid formats."""
-    
+
     def test_three_format_polyglot(self):
         detector = PolyglotDetector()
-        
-        data = bytearray(b'%PDF-1.4\n')
-        data.extend(b'/Type /Catalog\n')
-        data.extend(b'%%EOF\n')
-        data.extend(b'\x00' * 100)
+
+        data = bytearray(b"%PDF-1.4\n")
+        data.extend(b"/Type /Catalog\n")
+        data.extend(b"%%EOF\n")
+        data.extend(b"\x00" * 100)
         data.extend(b"PK\x03\x04")
-        data.extend(b'\x00' * 26)
+        data.extend(b"\x00" * 26)
         data.extend(b"PK\x05\x06")
-        data.extend(b'\x00' * 18)
-        
+        data.extend(b"\x00" * 18)
+
         valid_formats = detector._get_valid_formats(bytes(data))
-        
-        assert 'pdf' in valid_formats
-        assert 'zip' in valid_formats
-    
+
+        assert "pdf" in valid_formats
+        assert "zip" in valid_formats
+
     def test_find_other_combinations(self):
         detector = PolyglotDetector()
-        
-        valid_formats = {'png', 'jpeg', 'zip'}
+
+        valid_formats = {"png", "jpeg", "zip"}
         existing = []
-        
+
         other = detector._find_other_combinations(valid_formats, existing)
-        
+
         assert len(other) > 0
         assert all(p.confidence > 0.70 for p in other)
 
 
 class TestIntegration:
     """Integration tests with Analyzer."""
-    
+
     def test_analyzer_detects_polyglot(self):
         from filo import Analyzer
-        
-        png_zip_data = bytearray([
-            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
-        ])
-        
+
+        png_zip_data = bytearray(
+            [
+                0x89,
+                0x50,
+                0x4E,
+                0x47,
+                0x0D,
+                0x0A,
+                0x1A,
+                0x0A,
+            ]
+        )
+
         ihdr = struct.pack(">IIBBBBB", 1, 1, 8, 2, 0, 0, 0)
         ihdr_crc = zlib.crc32(b"IHDR" + ihdr)
         png_zip_data.extend(struct.pack(">I", len(ihdr)))
         png_zip_data.extend(b"IHDR")
         png_zip_data.extend(ihdr)
         png_zip_data.extend(struct.pack(">I", ihdr_crc))
-        
+
         iend_crc = zlib.crc32(b"IEND")
         png_zip_data.extend(struct.pack(">I", 0))
         png_zip_data.extend(b"IEND")
         png_zip_data.extend(struct.pack(">I", iend_crc))
-        
+
         png_zip_data.extend(b"PK\x03\x04")
-        png_zip_data.extend(b'\x00' * 26)
+        png_zip_data.extend(b"\x00" * 26)
         png_zip_data.extend(b"PK\x05\x06")
-        png_zip_data.extend(b'\x00' * 18)
-        
+        png_zip_data.extend(b"\x00" * 18)
+
         analyzer = Analyzer(detect_polyglots=True)
         result = analyzer.analyze(bytes(png_zip_data))
-        
+
         assert len(result.polyglots) > 0
-    
+
     def test_analyzer_no_polyglot_normal_file(self):
         from filo import Analyzer
-        
-        normal_data = bytearray([
-            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
-        ])
-        
+
+        normal_data = bytearray(
+            [
+                0x89,
+                0x50,
+                0x4E,
+                0x47,
+                0x0D,
+                0x0A,
+                0x1A,
+                0x0A,
+            ]
+        )
+
         ihdr = struct.pack(">IIBBBBB", 1, 1, 8, 2, 0, 0, 0)
         ihdr_crc = zlib.crc32(b"IHDR" + ihdr)
         normal_data.extend(struct.pack(">I", len(ihdr)))
         normal_data.extend(b"IHDR")
         normal_data.extend(ihdr)
         normal_data.extend(struct.pack(">I", ihdr_crc))
-        
+
         analyzer = Analyzer(detect_polyglots=True)
         result = analyzer.analyze(bytes(normal_data))
-        
+
         assert len(result.polyglots) == 0

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -8,7 +8,7 @@ from filo.profiler import Profiler, profile_session, profile_analysis
 def test_profiler_initialization():
     """Test profiler initialization."""
     profiler = Profiler(enabled=True)
-    
+
     assert profiler.enabled is True
     assert profiler.report.total_duration == 0.0
 
@@ -16,11 +16,11 @@ def test_profiler_initialization():
 def test_profiler_disabled():
     """Test disabled profiler."""
     profiler = Profiler(enabled=False)
-    
+
     profiler.start()
     time.sleep(0.1)
     report = profiler.stop()
-    
+
     # Should not track anything when disabled
     assert report.total_duration == 0.0
 
@@ -29,23 +29,23 @@ def test_profiler_basic_timing():
     """Test basic timing functionality."""
     profiler = Profiler(enabled=True)
     profiler.start()
-    
+
     time.sleep(0.1)
-    
+
     report = profiler.stop()
-    
+
     assert report.total_duration >= 0.1
 
 
 def test_time_operation_context_manager():
     """Test time_operation context manager."""
     profiler = Profiler(enabled=True)
-    
+
     with profiler.time_operation("test_op"):
         time.sleep(0.05)
-    
+
     report = profiler.report
-    
+
     assert "test_op" in report.timings
     assert report.timings["test_op"].duration >= 0.05
 
@@ -53,15 +53,15 @@ def test_time_operation_context_manager():
 def test_multiple_operations():
     """Test timing multiple operations."""
     profiler = Profiler(enabled=True)
-    
+
     with profiler.time_operation("op1"):
         time.sleep(0.05)
-    
+
     with profiler.time_operation("op2"):
         time.sleep(0.03)
-    
+
     report = profiler.report
-    
+
     assert len(report.timings) == 2
     assert "op1" in report.timings
     assert "op2" in report.timings
@@ -70,14 +70,14 @@ def test_multiple_operations():
 def test_repeated_operation():
     """Test timing same operation multiple times."""
     profiler = Profiler(enabled=True)
-    
+
     for _ in range(3):
         with profiler.time_operation("repeated"):
             time.sleep(0.01)
-    
+
     report = profiler.report
     timing = report.timings["repeated"]
-    
+
     assert timing.calls == 3
     assert timing.duration >= 0.03
     assert timing.avg_duration >= 0.01
@@ -86,14 +86,14 @@ def test_repeated_operation():
 def test_time_function_decorator():
     """Test function timing decorator."""
     profiler = Profiler(enabled=True)
-    
+
     @profiler.time_function("test_func")
     def slow_function():
         time.sleep(0.05)
         return 42
-    
+
     result = slow_function()
-    
+
     assert result == 42
     assert "test_func" in profiler.report.timings
     assert profiler.report.timings["test_func"].duration >= 0.05
@@ -104,9 +104,9 @@ def test_profile_session_context_manager():
     with profile_session() as profiler:
         with profiler.time_operation("work"):
             time.sleep(0.05)
-    
+
     report = profiler.report
-    
+
     assert report.total_duration >= 0.05
     assert "work" in report.timings
 
@@ -114,15 +114,15 @@ def test_profile_session_context_manager():
 def test_sorted_timings():
     """Test getting sorted timings."""
     profiler = Profiler(enabled=True)
-    
+
     with profiler.time_operation("slow"):
         time.sleep(0.1)
-    
+
     with profiler.time_operation("fast"):
         time.sleep(0.01)
-    
+
     sorted_timings = profiler.report.get_sorted_timings()
-    
+
     # Should be sorted by duration (descending)
     assert sorted_timings[0].name == "slow"
     assert sorted_timings[1].name == "fast"
@@ -132,14 +132,14 @@ def test_format_report():
     """Test report formatting."""
     profiler = Profiler(enabled=True)
     profiler.start()
-    
+
     with profiler.time_operation("test"):
         time.sleep(0.05)
-    
+
     profiler.stop()
-    
+
     formatted = profiler.report.format_report()
-    
+
     assert "PERFORMANCE PROFILE REPORT" in formatted
     assert "test" in formatted
     assert "Total Duration" in formatted
@@ -147,11 +147,12 @@ def test_format_report():
 
 def test_profile_analysis_decorator():
     """Test profile_analysis decorator."""
+
     @profile_analysis
     def analyze_data(data):
         time.sleep(0.01)
         return len(data)
-    
+
     result = analyze_data(b"test data")
-    
+
     assert result == 9

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -16,12 +16,12 @@ def test_repair_engine_initialization():
 def test_repair_pdf():
     """Test PDF header repair."""
     engine = RepairEngine()
-    
+
     # PDF without header
     data = b"1 0 obj\n<< /Type /Catalog >>\nendobj\n"
-    
+
     repaired, report = engine.repair(data, "pdf", strategy="add_pdf_header")
-    
+
     assert report.success
     assert repaired.startswith(b"%PDF-1.7")
     assert len(repaired) > len(data)
@@ -31,12 +31,12 @@ def test_repair_pdf():
 def test_repair_pdf_already_has_header():
     """Test PDF repair when header already exists."""
     engine = RepairEngine()
-    
+
     # PDF with header
     data = b"%PDF-1.7\r\n1 0 obj\n"
-    
+
     repaired, report = engine.repair(data, "pdf", strategy="add_pdf_header")
-    
+
     assert not report.success
     assert "already present" in report.warnings[0].lower()
     assert repaired == data
@@ -45,20 +45,25 @@ def test_repair_pdf_already_has_header():
 def test_repair_auto_strategy():
     """Test auto strategy selection."""
     engine = RepairEngine()
-    
+
     # Corrupted PDF
     data = b"corrupted pdf data here"
-    
+
     repaired, report = engine.repair(data, "pdf", strategy="auto")
-    
+
     # Should try strategies (advanced strategies tried first)
-    assert report.strategy_used in ["add_pdf_header", "generate_minimal_header", "add_pdf_eof", "repair_pdf_xref"]
+    assert report.strategy_used in [
+        "add_pdf_header",
+        "generate_minimal_header",
+        "add_pdf_eof",
+        "repair_pdf_xref",
+    ]
 
 
 def test_repair_unknown_format():
     """Test repair with unknown format."""
     engine = RepairEngine()
-    
+
     with pytest.raises(ValueError, match="Unknown format"):
         engine.repair(b"data", "nonexistent_format")
 
@@ -66,15 +71,15 @@ def test_repair_unknown_format():
 def test_repair_report_structure():
     """Test repair report contains expected fields."""
     engine = RepairEngine()
-    
+
     data = b"test data"
     repaired, report = engine.repair(data, "pdf", strategy="add_pdf_header")
-    
+
     assert hasattr(report, "success")
     assert hasattr(report, "strategy_used")
     assert hasattr(report, "original_size")
     assert hasattr(report, "repaired_size")
     assert hasattr(report, "changes_made")
     assert hasattr(report, "warnings")
-    
+
     assert report.original_size == len(data)


### PR DESCRIPTION
## Summary
- Fixes 3 tests broken by v0.2.7 changes (min_size checks, short sig penalty, raised min_confidence)
- `test_pe_executable_embedded` — Added proper PE header (COFF + optional header with SizeOfImage), aligned data to 512 bytes, increased trailing data
- `test_multiple_embedded_objects` — Extended JPEG trailing data to exceed 128-byte min_size
- `test_polyglot_detection` — Added PE\0\0 signature, COFF header, SizeOfImage, and trailing data

All 15 embedded detector tests now pass.